### PR TITLE
Allow target namespace for root applications to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,17 @@ Register one of these applications per account to be managed by the ArgoCD worke
 >   - `<config-repo>-revision>`: The revision of `<config-repo>` to source cluster/instance configuration from, e.g. `master`.
 >   - `<account-id>`: The ID of the account this root application manages. This also determines the root folder in `<config-repo>`:`<config-repo-revision` to source cluster/instance configuration from, e.g. `aws-dev`.
 >   - `<argocd-project>`: The ArgoCD project to register this application in, e.g. `mas`.
+>   - `<argoapp-namespace>`: The namespace on cluster running ArgoCD in which to create ArgoCD Application resources. E.g. `openshift-gitops` (internal clusters), `argocd-worker` (MCSP)
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: root.<account-id>
-  namespace: openshift-gitops
+  namespace: <argoapp-namespace>
 spec:
   destination:
-    namespace: openshift-gitops
+    namespace: <argoapp-namespace>
     server: 'https://kubernetes.default.svc'
   project: "<argocd-project>"
   source:
@@ -41,7 +42,8 @@ spec:
           },
           "source": {
             "targetRevision": "<source-repo-revision>"
-          }
+          },
+          "argoapp_namespace": "<argoapp-namespace>"
         }
   syncPolicy:
     syncOptions:

--- a/applications/010-redhat-cert-manager/templates/00-cert-manager_Namespace.yaml
+++ b/applications/010-redhat-cert-manager/templates/00-cert-manager_Namespace.yaml
@@ -6,4 +6,4 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "010"
   labels:
-    argocd.argoproj.io/managed-by: openshift-gitops
+    argocd.argoproj.io/managed-by: {{ .Values.argoapp_namespace }}

--- a/applications/020-ibm-dro/templates/00-dro_Namespace.yaml
+++ b/applications/020-ibm-dro/templates/00-dro_Namespace.yaml
@@ -11,4 +11,4 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "020"
   labels:
-    argocd.argoproj.io/managed-by: openshift-gitops
+    argocd.argoproj.io/managed-by: {{ .Values.argoapp_namespace }}

--- a/applications/020-ibm-dro/templates/08-postsync-update-sm_Job.yaml
+++ b/applications/020-ibm-dro/templates/08-postsync-update-sm_Job.yaml
@@ -125,11 +125,12 @@ spec:
               SM_AWS_ACCESS_KEY_ID=$(cat /etc/mas/creds/aws/aws_access_key_id)
               SM_AWS_SECRET_ACCESS_KEY=$(cat /etc/mas/creds/aws/aws_secret_access_key)
 
-              export DRO_URL=https://$(oc get route ibm-data-reporter -n ${DRO_NAMESPACE} -ojsonpath='{.spec.host}')
-              if [[ -z "${DRO_URL}" ]]; then
-                echo "Failed to fetch dro url from route"
+              export DRO_HOST="$(oc get route ibm-data-reporter -n ${DRO_NAMESPACE} -ojsonpath='{.spec.host}')"
+              if [[ -z "${DRO_HOST}" ]]; then
+                echo "Failed to fetch dro host from route"
                 exit 1
               fi
+              export DRO_URL="https://${DRO_HOST}"
 
               echo "Fetching token from ibm-data-reporter-operator-api-token Secret in ${DRO_NAMESPACE}"
               export DRO_API_TOKEN=$(oc get secret ibm-data-reporter-operator-api-token -n ${DRO_NAMESPACE} -o jsonpath='{.data.token}' | base64 -d ; echo)

--- a/applications/020-ibm-dro/templates/08-postsync-update-sm_Job.yaml
+++ b/applications/020-ibm-dro/templates/08-postsync-update-sm_Job.yaml
@@ -51,7 +51,12 @@ rules:
       - ""
     resources:
       - secrets
-
+  - verbs:
+      - get
+    apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
 
 
 ---

--- a/applications/040-cis-compliance/templates/01-cis-compliance_Namespace.yaml
+++ b/applications/040-cis-compliance/templates/01-cis-compliance_Namespace.yaml
@@ -6,4 +6,4 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "040"
   labels:
-    argocd.argoproj.io/managed-by: openshift-gitops
+    argocd.argoproj.io/managed-by: {{ .Values.argoapp_namespace }}

--- a/applications/050-nvidia-gpu-operator/templates/00-nfd_Namespace.yaml
+++ b/applications/050-nvidia-gpu-operator/templates/00-nfd_Namespace.yaml
@@ -6,4 +6,4 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "050"
   labels:
-    argocd.argoproj.io/managed-by: openshift-gitops
+    argocd.argoproj.io/managed-by: {{ .Values.argoapp_namespace }}

--- a/applications/050-nvidia-gpu-operator/templates/04-gpu_Namespace.yaml
+++ b/applications/050-nvidia-gpu-operator/templates/04-gpu_Namespace.yaml
@@ -6,4 +6,4 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "051"
   labels:
-    argocd.argoproj.io/managed-by: openshift-gitops
+    argocd.argoproj.io/managed-by: {{ .Values.argoapp_namespace }}

--- a/applications/060-ibm-db2u/templates/00-db2_Namespace.yaml
+++ b/applications/060-ibm-db2u/templates/00-db2_Namespace.yaml
@@ -6,4 +6,4 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "060"
   labels:
-    argocd.argoproj.io/managed-by: openshift-gitops
+    argocd.argoproj.io/managed-by: {{ .Values.argoapp_namespace }}

--- a/applications/060-ibm-db2u/templates/00-db2_NamespaceScope.yaml
+++ b/applications/060-ibm-db2u/templates/00-db2_NamespaceScope.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "061"
   labels:
-    argocd.argoproj.io/managed-by: openshift-gitops
+    argocd.argoproj.io/managed-by: {{ .Values.argoapp_namespace }}
 spec:
   csvInjector:
     enable: false

--- a/applications/100-ibm-sls/templates/01-ibm-sls_namespace.yaml
+++ b/applications/100-ibm-sls/templates/01-ibm-sls_namespace.yaml
@@ -6,4 +6,4 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "100"
   labels:
-    argocd.argoproj.io/managed-by: openshift-gitops
+    argocd.argoproj.io/managed-by: {{ .Values.argoapp_namespace }}

--- a/applications/130-ibm-db2u-jdbc-config-rotate-password/templates/00-db2u_jdbccfg-credentials.yaml
+++ b/applications/130-ibm-db2u-jdbc-config-rotate-password/templates/00-db2u_jdbccfg-credentials.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "150"
   labels:
-    argocd.argoproj.io/managed-by: openshift-gitops
+    argocd.argoproj.io/managed-by: {{ .Values.argoapp_namespace }}
 stringData:
   username: "{{ .Values.db2_jdbc_username }}"
   password: "{{ .Values.jdbc_instance_password }}"

--- a/applications/130-ibm-db2u-jdbc-config/templates/01-suite_jdbccfg.yaml
+++ b/applications/130-ibm-db2u-jdbc-config/templates/01-suite_jdbccfg.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "150"
   labels:
-    argocd.argoproj.io/managed-by: openshift-gitops
+    argocd.argoproj.io/managed-by: {{ .Values.argoapp_namespace }}
 stringData:
   username: "{{ .Values.db2_jdbc_username }}"
   password: "{{ .Values.jdbc_instance_password }}"

--- a/applications/130-ibm-mas-suite/templates/00-ibm-mas_namespace.yaml
+++ b/applications/130-ibm-mas-suite/templates/00-ibm-mas_namespace.yaml
@@ -6,4 +6,4 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "130"
   labels:
-    argocd.argoproj.io/managed-by: openshift-gitops
+    argocd.argoproj.io/managed-by: {{ .Values.argoapp_namespace }}

--- a/applications/500-ibm-mas-suite-app-install/templates/01-ibm-mas_namespace.yaml
+++ b/applications/500-ibm-mas-suite-app-install/templates/01-ibm-mas_namespace.yaml
@@ -7,5 +7,5 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "500"
   labels:
-    argocd.argoproj.io/managed-by: openshift-gitops
+    argocd.argoproj.io/managed-by: {{ .Values.argoapp_namespace }}
 {{- end }}

--- a/root-applications/ibm-mas-account-root/templates/000-cluster-appset.yaml
+++ b/root-applications/ibm-mas-account-root/templates/000-cluster-appset.yaml
@@ -5,7 +5,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
   name: cluster-appset.{{ .Values.account.id }}
-  namespace: openshift-gitops
+  namespace: {{ .Values.argoapp_namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: "000"
 spec:
@@ -82,9 +82,11 @@ spec:
                 value: "{{ .Values.generator.revision }}"
               - name: "source.targetRevision"
                 value: "{{ .Values.source.targetRevision }}"
+              - name: argoapp_namespace
+                value: "{{ .Values.argoapp_namespace }}"
       destination:
         server: 'https://kubernetes.default.svc'
-        namespace: 'openshift-gitops'
+        namespace: {{ .Values.argoapp_namespace }}
       syncPolicy:
         automated:
           prune: true

--- a/root-applications/ibm-mas-cluster-root/templates/000-ibm-operator-catalog-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/000-ibm-operator-catalog-app.yaml
@@ -5,7 +5,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: operator-catalog.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}
-  namespace: openshift-gitops
+  namespace: {{ .Values.argoapp_namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: "000"
     healthCheckTimeout: "1800"

--- a/root-applications/ibm-mas-cluster-root/templates/010-ibm-redhat-cert-manager-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/010-ibm-redhat-cert-manager-app.yaml
@@ -5,7 +5,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: redhat-cert-manager.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}
-  namespace: openshift-gitops
+  namespace: {{ .Values.argoapp_namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: "010"
     healthCheckTimeout: "1800"

--- a/root-applications/ibm-mas-cluster-root/templates/020-ibm-dro-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/020-ibm-dro-app.yaml
@@ -5,7 +5,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: dro.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}
-  namespace: openshift-gitops
+  namespace: {{ .Values.argoapp_namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: "020"
     healthCheckTimeout: "1800"

--- a/root-applications/ibm-mas-cluster-root/templates/040-cis-compliance-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/040-cis-compliance-app.yaml
@@ -5,7 +5,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: cis-compliance.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}
-  namespace: openshift-gitops
+  namespace: {{ .Values.argoapp_namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: "040"
     healthCheckTimeout: "1800"

--- a/root-applications/ibm-mas-cluster-root/templates/050-nvidia-gpu-operator-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/050-nvidia-gpu-operator-app.yaml
@@ -5,7 +5,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: nvidia-gpu.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}
-  namespace: openshift-gitops
+  namespace: {{ .Values.argoapp_namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: "050"
     healthCheckTimeout: "1800"

--- a/root-applications/ibm-mas-cluster-root/templates/060-ibm-db2u-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/060-ibm-db2u-app.yaml
@@ -5,7 +5,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: db2u.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}
-  namespace: openshift-gitops
+  namespace: {{ .Values.argoapp_namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: "060"
     healthCheckTimeout: "1800"

--- a/root-applications/ibm-mas-cluster-root/templates/099-instance-appset.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/099-instance-appset.yaml
@@ -5,7 +5,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
   name: instance-appset.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}
-  namespace: openshift-gitops
+  namespace: {{ .Values.argoapp_namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: "099"
 spec:
@@ -69,9 +69,11 @@ spec:
                 value: "{{ .Values.generator.revision }}"
               - name: "source.targetRevision"
                 value: "{{ .Values.source.targetRevision }}"
+              - name: argoapp_namespace
+                value: "{{ .Values.argoapp_namespace }}"
       destination:
         server: 'https://kubernetes.default.svc'
-        namespace: 'openshift-gitops'
+        namespace: {{ .Values.argoapp_namespace }}
       syncPolicy:
         automated:
           prune: true

--- a/root-applications/ibm-mas-instance-root/templates/100-ibm-sls-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/100-ibm-sls-app.yaml
@@ -5,7 +5,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: sls.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
-  namespace: openshift-gitops
+  namespace: {{ .Values.argoapp_namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: "100"
   finalizers:

--- a/root-applications/ibm-mas-instance-root/templates/120-db2-databases-appset.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-db2-databases-appset.yaml
@@ -53,7 +53,9 @@ spec:
                               dict "targetRevision" "`}}{{ .Values.source.targetRevision }}{{`"
                             )
                           )
-                          dict "argoapp_namespace" "`}}{{ .Values.argoapp_namespace}}{{`"
+                          (
+                            dict "argoapp_namespace" "`}}{{ .Values.argoapp_namespace}}{{`"
+                          )
                       )
                     }}
                   `}}

--- a/root-applications/ibm-mas-instance-root/templates/120-db2-databases-appset.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-db2-databases-appset.yaml
@@ -4,7 +4,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
   name: db2-db-appset.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
-  namespace: openshift-gitops
+  namespace: {{ .Values.argoapp_namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: "120"
 spec:
@@ -53,6 +53,7 @@ spec:
                               dict "targetRevision" "`}}{{ .Values.source.targetRevision }}{{`"
                             )
                           )
+                          dict "argoapp_namespace" "`}}{{ .Values.argoapp_namespace}}{{`"
                       )
                     }}
                   `}}

--- a/root-applications/ibm-mas-instance-root/templates/130-configs-appset.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/130-configs-appset.yaml
@@ -59,7 +59,9 @@ spec:
                               dict "targetRevision" "`}}{{ .Values.source.targetRevision }}{{`"
                             )
                           )
-                          dict "argoapp_namespace" "`}}{{ .Values.argoapp_namespace}}{{`"
+                          (
+                            dict "argoapp_namespace" "`}}{{ .Values.argoapp_namespace}}{{`"
+                          )
                       )
                     }}
                   `}}
@@ -90,7 +92,9 @@ spec:
                               dict "targetRevision" "`}}{{ .Values.source.targetRevision }}{{`"
                             )
                           )
-                          dict "argoapp_namespace" "`}}{{ .Values.argoapp_namespace}}{{`"
+                          (
+                            dict "argoapp_namespace" "`}}{{ .Values.argoapp_namespace}}{{`"
+                          )
                       )
                     }}
                   `}}

--- a/root-applications/ibm-mas-instance-root/templates/130-configs-appset.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/130-configs-appset.yaml
@@ -12,7 +12,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
   name: configs-appset.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
-  namespace: openshift-gitops
+  namespace: {{ .Values.argoapp_namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: "130"
 spec:
@@ -59,6 +59,7 @@ spec:
                               dict "targetRevision" "`}}{{ .Values.source.targetRevision }}{{`"
                             )
                           )
+                          dict "argoapp_namespace" "`}}{{ .Values.argoapp_namespace}}{{`"
                       )
                     }}
                   `}}
@@ -89,6 +90,7 @@ spec:
                               dict "targetRevision" "`}}{{ .Values.source.targetRevision }}{{`"
                             )
                           )
+                          dict "argoapp_namespace" "`}}{{ .Values.argoapp_namespace}}{{`"
                       )
                     }}
                   `}}

--- a/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-app.yaml
@@ -5,7 +5,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: suite.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
-  namespace: openshift-gitops
+  namespace: {{ .Values.argoapp_namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: "130"
   finalizers:

--- a/root-applications/ibm-mas-instance-root/templates/220-ibm-mas-workspace.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/220-ibm-mas-workspace.yaml
@@ -5,7 +5,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: workspace.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
-  namespace: openshift-gitops
+  namespace: {{ .Values.argoapp_namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: "200"
   finalizers:

--- a/root-applications/ibm-mas-instance-root/templates/500-masapp-appset.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/500-masapp-appset.yaml
@@ -73,7 +73,9 @@ spec:
                               dict "targetRevision" "`}}{{ .Values.source.targetRevision }}{{`"
                             )
                           )
-                          dict "argoapp_namespace" "`}}{{ .Values.argoapp_namespace}}{{`"
+                          (
+                            dict "argoapp_namespace" "`}}{{ .Values.argoapp_namespace}}{{`"
+                          )
                       )
                     }}
                   `}}
@@ -103,7 +105,9 @@ spec:
                               dict "targetRevision" "`}}{{ .Values.source.targetRevision }}{{`"
                             )
                           )
-                          dict "argoapp_namespace" "`}}{{ .Values.argoapp_namespace}}{{`"
+                          (
+                            dict "argoapp_namespace" "`}}{{ .Values.argoapp_namespace}}{{`"
+                          )
                       )
                     }}
                   `}}

--- a/root-applications/ibm-mas-instance-root/templates/500-masapp-appset.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/500-masapp-appset.yaml
@@ -5,7 +5,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
   name: ma-appset.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
-  namespace: openshift-gitops
+  namespace: {{ .Values.argoapp_namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: "500"
 spec:
@@ -73,6 +73,7 @@ spec:
                               dict "targetRevision" "`}}{{ .Values.source.targetRevision }}{{`"
                             )
                           )
+                          dict "argoapp_namespace" "`}}{{ .Values.argoapp_namespace}}{{`"
                       )
                     }}
                   `}}
@@ -102,6 +103,7 @@ spec:
                               dict "targetRevision" "`}}{{ .Values.source.targetRevision }}{{`"
                             )
                           )
+                          dict "argoapp_namespace" "`}}{{ .Values.argoapp_namespace}}{{`"
                       )
                     }}
                   `}}


### PR DESCRIPTION
At present our root applications always targets the openshift-gitops namespace, e.g. https://github.com/ibm-mas/gitops/blob/fa480bc16bc03f2d1654d24a947cbc9c2f0efc29/root-applications/ibm-mas-account-root/templates/000-cluster-appset.yaml#L8

However, this is not always the namespace we need to use. E.g. in MCSP we need "argocd-worker".

This PR looks for `argoapp_namespace parameter` on the root application. Its value is passed down and used by all child applications.

Accompanying PR: https://github.com/ibm-mas/cli/pull/836

Tested by spinning up a MAS instance (with MVI) in noble3 (Fyre) using an ArgoCD instance that expects Applications and ApplicationSets to be creatred in a different namespace (`argocd` instead of `openshift-gitops`). Verified that everything still works and that all Applications and ApplicationSets are created in the expected namespace:

![image](https://github.com/ibm-mas/gitops/assets/7372253/f8d40a53-c888-40c9-8f08-0cd557079e95)

![image](https://github.com/ibm-mas/gitops/assets/7372253/37908b9d-17be-4c54-b4df-25b18ab66dea)


Incidental fix for issue spotted during testing:
  - fix DRO sync hook to allow it to fetch route resources, and make sure the job fails as expected when the route host fetch fails.

