### PR TITLE
Execute "user exists check" command on correct db2u pod

### DIFF
--- a/applications/130-ibm-db2u-jdbc-config/templates/00-presync-create-db2-user_Job.yaml
+++ b/applications/130-ibm-db2u-jdbc-config/templates/00-presync-create-db2-user_Job.yaml
@@ -162,9 +162,23 @@ spec:
               echo "Checking if ${DB2_LDAP_USERNAME} user exists already"
               echo "================================================================================"
               
+              echo ""
+              echo "Looking up name of DB2 db2u pod"
+              echo "--------------------------------------------------------------------------------"
+              export DB2_DB2U_POD_NAME=$(oc get pods -o custom-columns=POD:.metadata.name -l app=${DB2_INSTANCE_NAME},role=db -n ${DB2_NAMESPACE}  --no-headers)
+              if [[ -z "${DB2_DB2U_POD_NAME}" ]]; then
+                echo "Failed to look up DB2 db2u pod name"
+                exit 1
+              fi
+              echo "DB2_DB2U_POD_NAME .......................... ${DB2_DB2U_POD_NAME}"
+
+
+              echo ""
+              echo "Executing command on DB2 db2u pod; su -lc \"id ${DB2_LDAP_USERNAME}\""
+              echo "--------------------------------------------------------------------------------"
               # Using the || syntax to avoid surfacing a non 0 rc and exitting the job (without having to disable set -e)
               DB2_USER_FOUND=true
-              oc exec -it c-db2wh-tgka-iot-db2u-0 -c db2u -n db2u -- su -lc "id ${DB2_LDAP_USERNAME}" || DB2_USER_FOUND=false
+              oc exec -it ${DB2_DB2U_POD_NAME}-c db2u -n db2u -- su -lc "id ${DB2_LDAP_USERNAME}" || DB2_USER_FOUND=false
               if [[ "${DB2_USER_FOUND}" == "true" ]]; then
                 echo "DB2 user exists already, exiting now"
                 exit 0


### PR DESCRIPTION
[MASCORE-2096](https://jsw.ibm.com/browse/MASCORE-2096)

Verified by creating the Job resource manually in the fvtsaas cluster. Output logs:
```
================================================================================
Settings
================================================================================
DB2_NAMESPACE ....................... db2u
DB2_INSTANCE_NAME ................... db2wh-rick-manage
DB2_DBNAME .......................... BLUDB
DB2_CREDENTIALS_SECRET_PATH ......... /etc/mas/creds/db2-credentials

================================================================================
Checking DB2 CRD db2uclusters.db2u.databases.ibm.com is ready (retries every ~10 seconds for ~5 minutes)
================================================================================
DB2_CRD_NAMES_ACCEPTED_STATUS .... True

================================================================================
Reading LDAP credentials from /etc/mas/creds/db2-credentials
================================================================================

================================================================================
Checking if db2_manage user exists already
================================================================================

Looking up name of DB2 db2u pod
--------------------------------------------------------------------------------
DB2_DB2U_POD_NAME .......................... c-db2wh-rick-manage-db2u-0

Executing command on DB2 db2u pod; su -lc "id db2_manage"
--------------------------------------------------------------------------------
Defaulted container "db2u" out of: db2u, init-labels (init), init-kernel (init)
Unable to use a TTY - input is not a terminal or the right kind of file
uid=5003(db2_manage) gid=3000(bluadmin) groups=3000(bluadmin)
DB2 user exists already, exiting now
```

Job now correctly notices that the user already exists, does not try to create the user, and the job completes successfully.