### PR TITLE
Ensure sls secret is updated before proceeding to subsequent syncwaves

### DIFF
--- a/applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
+++ b/applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
@@ -19,9 +19,7 @@ metadata:
   name: {{ $np_name }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-wave: "100"
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    argocd.argoproj.io/sync-wave: "110"
 spec:
   podSelector:
     matchLabels:
@@ -39,9 +37,7 @@ metadata:
   name: {{ $aws_secret }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-wave: "100"
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    argocd.argoproj.io/sync-wave: "110"
 data:
   aws_access_key_id: {{ .Values.sm.aws_access_key_id | b64enc }}
   aws_secret_access_key: {{ .Values.sm.aws_secret_access_key | b64enc }}
@@ -54,9 +50,7 @@ metadata:
   name: {{ $sa_name }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-wave: "100"
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    argocd.argoproj.io/sync-wave: "110"
 
 ---
 kind: Role
@@ -65,9 +59,7 @@ metadata:
   name: {{ $role_name }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-wave: "100"
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    argocd.argoproj.io/sync-wave: "110"
 rules:
   - verbs:
       - get
@@ -85,9 +77,7 @@ metadata:
   name: {{ $rb_name }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-wave: "101"
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    argocd.argoproj.io/sync-wave: "111"
 subjects:
   - kind: ServiceAccount
     name: {{ $sa_name }}
@@ -104,9 +94,7 @@ metadata:
   name: {{ $job_name }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-wave: "102"
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    argocd.argoproj.io/sync-wave: "112"
 spec:
   template:
     metadata:
@@ -139,6 +127,8 @@ spec:
           volumeMounts:
             - name: aws
               mountPath: /etc/mas/creds/aws
+            - name: sls-suite-registration
+              mountPath: /etc/mas/creds/sls-suite-registration
           command:
             - /bin/sh
             - -c
@@ -153,14 +143,14 @@ spec:
               SM_AWS_SECRET_ACCESS_KEY=$(cat /etc/mas/creds/aws/aws_secret_access_key)
 
               echo "Fetching registrationKey from sls-suite-registration ConfigMap in mas-${INSTANCE_ID}-sls"
-              export SLS_REGISTRATION_KEY=$(oc get cm sls-suite-registration -n mas-${INSTANCE_ID}-sls -o jsonpath='{.data.registrationKey}')
+              SLS_REGISTRATION_KEY=$(cat /etc/mas/creds/sls-suite-registration/registrationKey)
               if [[ -z "${SLS_REGISTRATION_KEY}" ]]; then
                 echo "Failed to fetch registrationKey"
                 exit 1
               fi
 
               echo "Fetching ca from sls-suite-registration ConfigMap in mas-${INSTANCE_ID}-sls"
-              export SLS_CA=$(oc get cm sls-suite-registration -n mas-${INSTANCE_ID}-sls -o jsonpath='{.data.ca}' | base64 -w0)
+              SLS_CA=$(cat /etc/mas/creds/sls-suite-registration/ca | base64 -w0)
               if [[ -z "${SLS_CA}" ]]; then
                 echo "Failed to fetch ca"
                 exit 1
@@ -192,5 +182,10 @@ spec:
             secretName: {{ $aws_secret }}
             defaultMode: 420
             optional: false
+        - name: sls-suite-registration
+          configMap:
+            name: sls-suite-registration
+            optional: false
+
   backoffLimit: 4
 {{- end }}


### PR DESCRIPTION
This PR causes the ibm-sls Application to run the code that updates the sls secret in AWS SM as a normal job, instead of as a PostSync hook.

Since normal jobs are taken into account when computing the health status of an ArgoCD application, this change ensures that the secret is established before ArgoCD proceeds to sync applications in later syncwaves that depend on this secret (e.g. ibm-mas-sls-config).

The job is in the last syncwave within this application so should only be started once the SLSCfg CR reports Ready=True. As a further precaution, I've mounted the required ConfigMap into the Job pod (rather than looking it up via the K8S API), which will cause K8S to wait for the configmap to appear before attempting to start the Job.

I've verified that the Job works as expected, and that it must be complete before ArgoCD moves on to applications in subsequent syncwaves.

https://jsw.ibm.com/browse/MASCORE-1839

NOTE: if you are spinning up an instance that has existed previously, AVP will have cached the value of the `<account-id>/<cluster-id>/<instance-id>/sls` secret (e.g. `fyre-dev/noble3/tgke/sls`), so the updated value written by this job will not be picked up (even though it is now definitely being updated before being read). Deleting the secret from the last run does not resolve this issue. For now, you must manually hard-refresh the `<instance-id>-sls-system` application.