### PR TITLE
Fixes to Config CR PostDelete hooks

### DIFF
--- a/applications/130-ibm-db2u-jdbc-config/templates/postdelete-delete-cr.yaml
+++ b/applications/130-ibm-db2u-jdbc-config/templates/postdelete-delete-cr.yaml
@@ -1,72 +1,19 @@
 {{- if .Values.use_postdelete_hooks }}
 
-# Generate a suffix for all the resources so there are no name clashes if >1 config is deleted at the same time
 {{ $cr_name := .Values.mas_config_name }}
 {{ $cr_kind := .Values.mas_config_kind }}
 {{ $cr_api_version := .Values.mas_config_api_version }}
-{{ $role_name := printf "postdelete-delete-cr-r-%s" $cr_name }}
-{{ $sa_name := printf "postdelete-delete-cr-sa-%s" $cr_name }}
-{{ $rb_name := printf "postdelete-delete-cr-rb-%s" $cr_name }}
-{{ $np_name := printf "postdelete-delete-cr-np-%s" $cr_name }}
+
 {{ $job_name := printf "postdelete-delete-cr-job-%s" $cr_name }}
+
+# NOTE: depends on resources created in ibm-mas-suite chart (01-postdelete-crs-resources)
+# The values below must align with the values in that file
+{{ $role_name := "postdelete-delete-cr-r" }}
+{{ $sa_name :=   "postdelete-delete-cr-sa" }}
+{{ $rb_name :=   "postdelete-delete-cr-rb" }}
+{{ $np_name :=   "postdelete-delete-cr-np" }}
+{{ $job_label := "postdelete-delete-cr-job" }}
 {{ $ns := printf "mas-%s-core" .Values.mas_instance_id }}
-{{ $hook_delete_policy := "HookSucceeded" }}
-
----
-# Permit outbound communication by the Job pods
-# (Needed to communicate with the K8S HTTP API and AWS SM)
-kind: NetworkPolicy
-apiVersion: networking.k8s.io/v1
-metadata:
-  name: {{ $np_name }}
-  namespace: {{ $ns }}
-spec:
-  podSelector:
-    matchLabels:
-      app: {{ $job_name }}
-  egress:
-    - {}
-  policyTypes:
-    - Egress
-
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ $role_name }}
-  namespace: {{ $ns }}
-rules:
-  - verbs:
-      - delete
-      - get
-      - list
-      - watch
-    apiGroups:
-      - {{ $cr_api_version }}
-    resources:
-      - {{ $cr_kind }}
-
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: {{ $sa_name }}
-  namespace: {{ $ns }}
-
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ $rb_name }}
-  namespace: {{ $ns }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ $sa_name }}
-    namespace: {{ $ns }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ $role_name }}
 
 
 ---
@@ -77,11 +24,12 @@ metadata:
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/hook: PostDelete
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:
   template:
     metadata:
       labels:
-        app: {{ $job_name }}
+        app: {{ $job_label }}
     spec:
       containers:
         - name: run

--- a/applications/130-ibm-kafka-config/templates/postdelete-delete-cr.yaml
+++ b/applications/130-ibm-kafka-config/templates/postdelete-delete-cr.yaml
@@ -1,73 +1,19 @@
 {{- if .Values.use_postdelete_hooks }}
 
-# Generate a suffix for all the resources so there are no name clashes if >1 config is deleted at the same time
 {{ $cr_name := .Values.mas_config_name }}
 {{ $cr_kind := .Values.mas_config_kind }}
 {{ $cr_api_version := .Values.mas_config_api_version }}
-{{ $role_name := printf "postdelete-delete-cr-r-%s" $cr_name }}
-{{ $sa_name := printf "postdelete-delete-cr-sa-%s" $cr_name }}
-{{ $rb_name := printf "postdelete-delete-cr-rb-%s" $cr_name }}
-{{ $np_name := printf "postdelete-delete-cr-np-%s" $cr_name }}
+
 {{ $job_name := printf "postdelete-delete-cr-job-%s" $cr_name }}
+
+# NOTE: depends on resources created in ibm-mas-suite chart (01-postdelete-crs-resources)
+# The values below must align with the values in that file
+{{ $role_name := "postdelete-delete-cr-r" }}
+{{ $sa_name :=   "postdelete-delete-cr-sa" }}
+{{ $rb_name :=   "postdelete-delete-cr-rb" }}
+{{ $np_name :=   "postdelete-delete-cr-np" }}
+{{ $job_label := "postdelete-delete-cr-job" }}
 {{ $ns := printf "mas-%s-core" .Values.mas_instance_id }}
-{{ $hook_delete_policy := "HookSucceeded" }}
-
-
----
-# Permit outbound communication by the Job pods
-# (Needed to communicate with the K8S HTTP API and AWS SM)
-kind: NetworkPolicy
-apiVersion: networking.k8s.io/v1
-metadata:
-  name: {{ $np_name }}
-  namespace: {{ $ns }}
-spec:
-  podSelector:
-    matchLabels:
-      app: {{ $job_name }}
-  egress:
-    - {}
-  policyTypes:
-    - Egress
-
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ $role_name }}
-  namespace: {{ $ns }}
-rules:
-  - verbs:
-      - delete
-      - get
-      - list
-      - watch
-    apiGroups:
-      - {{ $cr_api_version }}
-    resources:
-      - {{ $cr_kind }}
-
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: {{ $sa_name }}
-  namespace: {{ $ns }}
-
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ $rb_name }}
-  namespace: {{ $ns }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ $sa_name }}
-    namespace: {{ $ns }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ $role_name }}
 
 
 ---
@@ -78,11 +24,12 @@ metadata:
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/hook: PostDelete
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:
   template:
     metadata:
       labels:
-        app: {{ $job_name }}
+        app: {{ $job_label }}
     spec:
       containers:
         - name: run

--- a/applications/130-ibm-mas-bas-config/templates/postdelete-delete-cr.yaml
+++ b/applications/130-ibm-mas-bas-config/templates/postdelete-delete-cr.yaml
@@ -1,73 +1,19 @@
 {{- if .Values.use_postdelete_hooks }}
 
-# Generate a suffix for all the resources so there are no name clashes if >1 config is deleted at the same time
 {{ $cr_name := .Values.mas_config_name }}
 {{ $cr_kind := .Values.mas_config_kind }}
 {{ $cr_api_version := .Values.mas_config_api_version }}
-{{ $role_name := printf "postdelete-delete-cr-r-%s" $cr_name }}
-{{ $sa_name := printf "postdelete-delete-cr-sa-%s" $cr_name }}
-{{ $rb_name := printf "postdelete-delete-cr-rb-%s" $cr_name }}
-{{ $np_name := printf "postdelete-delete-cr-np-%s" $cr_name }}
+
 {{ $job_name := printf "postdelete-delete-cr-job-%s" $cr_name }}
+
+# NOTE: depends on resources created in ibm-mas-suite chart (01-postdelete-crs-resources)
+# The values below must align with the values in that file
+{{ $role_name := "postdelete-delete-cr-r" }}
+{{ $sa_name :=   "postdelete-delete-cr-sa" }}
+{{ $rb_name :=   "postdelete-delete-cr-rb" }}
+{{ $np_name :=   "postdelete-delete-cr-np" }}
+{{ $job_label := "postdelete-delete-cr-job" }}
 {{ $ns := printf "mas-%s-core" .Values.mas_instance_id }}
-{{ $hook_delete_policy := "HookSucceeded" }}
-
-
----
-# Permit outbound communication by the Job pods
-# (Needed to communicate with the K8S HTTP API and AWS SM)
-kind: NetworkPolicy
-apiVersion: networking.k8s.io/v1
-metadata:
-  name: {{ $np_name }}
-  namespace: {{ $ns }}
-spec:
-  podSelector:
-    matchLabels:
-      app: {{ $job_name }}
-  egress:
-    - {}
-  policyTypes:
-    - Egress
-
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ $role_name }}
-  namespace: {{ $ns }}
-rules:
-  - verbs:
-      - delete
-      - get
-      - list
-      - watch
-    apiGroups:
-      - {{ $cr_api_version }}
-    resources:
-      - {{ $cr_kind }}
-
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: {{ $sa_name }}
-  namespace: {{ $ns }}
-
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ $rb_name }}
-  namespace: {{ $ns }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ $sa_name }}
-    namespace: {{ $ns }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ $role_name }}
 
 
 ---
@@ -78,11 +24,12 @@ metadata:
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/hook: PostDelete
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:
   template:
     metadata:
       labels:
-        app: {{ $job_name }}
+        app: {{ $job_label }}
     spec:
       containers:
         - name: run

--- a/applications/130-ibm-mas-idp-config/templates/postdelete-delete-cr.yaml
+++ b/applications/130-ibm-mas-idp-config/templates/postdelete-delete-cr.yaml
@@ -1,73 +1,19 @@
 {{- if .Values.use_postdelete_hooks }}
 
-# Generate a suffix for all the resources so there are no name clashes if >1 config is deleted at the same time
 {{ $cr_name := .Values.mas_config_name }}
 {{ $cr_kind := .Values.mas_config_kind }}
 {{ $cr_api_version := .Values.mas_config_api_version }}
-{{ $role_name := printf "postdelete-delete-cr-r-%s" $cr_name }}
-{{ $sa_name := printf "postdelete-delete-cr-sa-%s" $cr_name }}
-{{ $rb_name := printf "postdelete-delete-cr-rb-%s" $cr_name }}
-{{ $np_name := printf "postdelete-delete-cr-np-%s" $cr_name }}
+
 {{ $job_name := printf "postdelete-delete-cr-job-%s" $cr_name }}
+
+# NOTE: depends on resources created in ibm-mas-suite chart (01-postdelete-crs-resources)
+# The values below must align with the values in that file
+{{ $role_name := "postdelete-delete-cr-r" }}
+{{ $sa_name :=   "postdelete-delete-cr-sa" }}
+{{ $rb_name :=   "postdelete-delete-cr-rb" }}
+{{ $np_name :=   "postdelete-delete-cr-np" }}
+{{ $job_label := "postdelete-delete-cr-job" }}
 {{ $ns := printf "mas-%s-core" .Values.mas_instance_id }}
-{{ $hook_delete_policy := "HookSucceeded" }}
-
-
----
-# Permit outbound communication by the Job pods
-# (Needed to communicate with the K8S HTTP API and AWS SM)
-kind: NetworkPolicy
-apiVersion: networking.k8s.io/v1
-metadata:
-  name: {{ $np_name }}
-  namespace: {{ $ns }}
-spec:
-  podSelector:
-    matchLabels:
-      app: {{ $job_name }}
-  egress:
-    - {}
-  policyTypes:
-    - Egress
-
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ $role_name }}
-  namespace: {{ $ns }}
-rules:
-  - verbs:
-      - delete
-      - get
-      - list
-      - watch
-    apiGroups:
-      - {{ $cr_api_version }}
-    resources:
-      - {{ $cr_kind }}
-
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: {{ $sa_name }}
-  namespace: {{ $ns }}
-
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ $rb_name }}
-  namespace: {{ $ns }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ $sa_name }}
-    namespace: {{ $ns }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ $role_name }}
 
 
 ---
@@ -78,11 +24,12 @@ metadata:
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/hook: PostDelete
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:
   template:
     metadata:
       labels:
-        app: {{ $job_name }}
+        app: {{ $job_label }}
     spec:
       containers:
         - name: run

--- a/applications/130-ibm-mas-mongo-config/templates/postdelete-delete-cr.yaml
+++ b/applications/130-ibm-mas-mongo-config/templates/postdelete-delete-cr.yaml
@@ -1,73 +1,19 @@
 {{- if .Values.use_postdelete_hooks }}
 
-# Generate a suffix for all the resources so there are no name clashes if >1 config is deleted at the same time
 {{ $cr_name := .Values.mas_config_name }}
 {{ $cr_kind := .Values.mas_config_kind }}
 {{ $cr_api_version := .Values.mas_config_api_version }}
-{{ $role_name := printf "postdelete-delete-cr-r-%s" $cr_name }}
-{{ $sa_name := printf "postdelete-delete-cr-sa-%s" $cr_name }}
-{{ $rb_name := printf "postdelete-delete-cr-rb-%s" $cr_name }}
-{{ $np_name := printf "postdelete-delete-cr-np-%s" $cr_name }}
+
 {{ $job_name := printf "postdelete-delete-cr-job-%s" $cr_name }}
+
+# NOTE: depends on resources created in ibm-mas-suite chart (01-postdelete-crs-resources)
+# The values below must align with the values in that file
+{{ $role_name := "postdelete-delete-cr-r" }}
+{{ $sa_name :=   "postdelete-delete-cr-sa" }}
+{{ $rb_name :=   "postdelete-delete-cr-rb" }}
+{{ $np_name :=   "postdelete-delete-cr-np" }}
+{{ $job_label := "postdelete-delete-cr-job" }}
 {{ $ns := printf "mas-%s-core" .Values.mas_instance_id }}
-{{ $hook_delete_policy := "HookSucceeded" }}
-
-
----
-# Permit outbound communication by the Job pods
-# (Needed to communicate with the K8S HTTP API and AWS SM)
-kind: NetworkPolicy
-apiVersion: networking.k8s.io/v1
-metadata:
-  name: {{ $np_name }}
-  namespace: {{ $ns }}
-spec:
-  podSelector:
-    matchLabels:
-      app: {{ $job_name }}
-  egress:
-    - {}
-  policyTypes:
-    - Egress
-
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ $role_name }}
-  namespace: {{ $ns }}
-rules:
-  - verbs:
-      - delete
-      - get
-      - list
-      - watch
-    apiGroups:
-      - {{ $cr_api_version }}
-    resources:
-      - {{ $cr_kind }}
-
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: {{ $sa_name }}
-  namespace: {{ $ns }}
-
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ $rb_name }}
-  namespace: {{ $ns }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ $sa_name }}
-    namespace: {{ $ns }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ $role_name }}
 
 
 ---
@@ -78,11 +24,12 @@ metadata:
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/hook: PostDelete
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:
   template:
     metadata:
       labels:
-        app: {{ $job_name }}
+        app: {{ $job_label }}
     spec:
       containers:
         - name: run

--- a/applications/130-ibm-mas-sls-config/templates/postdelete-delete-cr.yaml
+++ b/applications/130-ibm-mas-sls-config/templates/postdelete-delete-cr.yaml
@@ -1,73 +1,19 @@
 {{- if .Values.use_postdelete_hooks }}
 
-# Generate a suffix for all the resources so there are no name clashes if >1 config is deleted at the same time
 {{ $cr_name := .Values.mas_config_name }}
 {{ $cr_kind := .Values.mas_config_kind }}
 {{ $cr_api_version := .Values.mas_config_api_version }}
-{{ $role_name := printf "postdelete-delete-cr-r-%s" $cr_name }}
-{{ $sa_name := printf "postdelete-delete-cr-sa-%s" $cr_name }}
-{{ $rb_name := printf "postdelete-delete-cr-rb-%s" $cr_name }}
-{{ $np_name := printf "postdelete-delete-cr-np-%s" $cr_name }}
+
 {{ $job_name := printf "postdelete-delete-cr-job-%s" $cr_name }}
+
+# NOTE: depends on resources created in ibm-mas-suite chart (01-postdelete-crs-resources)
+# The values below must align with the values in that file
+{{ $role_name := "postdelete-delete-cr-r" }}
+{{ $sa_name :=   "postdelete-delete-cr-sa" }}
+{{ $rb_name :=   "postdelete-delete-cr-rb" }}
+{{ $np_name :=   "postdelete-delete-cr-np" }}
+{{ $job_label := "postdelete-delete-cr-job" }}
 {{ $ns := printf "mas-%s-core" .Values.mas_instance_id }}
-{{ $hook_delete_policy := "HookSucceeded" }}
-
-
----
-# Permit outbound communication by the Job pods
-# (Needed to communicate with the K8S HTTP API and AWS SM)
-kind: NetworkPolicy
-apiVersion: networking.k8s.io/v1
-metadata:
-  name: {{ $np_name }}
-  namespace: {{ $ns }}
-spec:
-  podSelector:
-    matchLabels:
-      app: {{ $job_name }}
-  egress:
-    - {}
-  policyTypes:
-    - Egress
-
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ $role_name }}
-  namespace: {{ $ns }}
-rules:
-  - verbs:
-      - delete
-      - get
-      - list
-      - watch
-    apiGroups:
-      - {{ $cr_api_version }}
-    resources:
-      - {{ $cr_kind }}
-
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: {{ $sa_name }}
-  namespace: {{ $ns }}
-
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ $rb_name }}
-  namespace: {{ $ns }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ $sa_name }}
-    namespace: {{ $ns }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ $role_name }}
 
 
 ---
@@ -78,11 +24,12 @@ metadata:
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/hook: PostDelete
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:
   template:
     metadata:
       labels:
-        app: {{ $job_name }}
+        app: {{ $job_label }}
     spec:
       containers:
         - name: run

--- a/applications/130-ibm-mas-smtp-config/templates/postdelete-delete-cr.yaml
+++ b/applications/130-ibm-mas-smtp-config/templates/postdelete-delete-cr.yaml
@@ -21,6 +21,8 @@ apiVersion: networking.k8s.io/v1
 metadata:
   name: {{ $np_name }}
   namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 spec:
   podSelector:
     matchLabels:
@@ -36,6 +38,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ $role_name }}
   namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
 rules:
   - verbs:
       - delete
@@ -53,6 +57,8 @@ apiVersion: v1
 metadata:
   name: {{ $sa_name }}
   namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
 
 ---
 kind: RoleBinding
@@ -60,6 +66,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ $rb_name }}
   namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 subjects:
   - kind: ServiceAccount
     name: {{ $sa_name }}

--- a/applications/130-ibm-mas-smtp-config/templates/postdelete-delete-cr.yaml
+++ b/applications/130-ibm-mas-smtp-config/templates/postdelete-delete-cr.yaml
@@ -16,6 +16,10 @@
 ---
 # Permit outbound communication by the Job pods
 # (Needed to communicate with the K8S HTTP API and AWS SM)
+
+# argocd.argoproj.io/sync-options: Delete=false annotation is *required* on this resource
+# so that it is not deleted before the PostDelete job that depends on it is run
+# (NOTE: it is not currently possible to annotate this type of resource with PostDelete due to a bug in ArgoCD: https://github.com/argoproj/argo-cd/issues/17191)
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
@@ -33,6 +37,9 @@ spec:
     - Egress
 
 ---
+# argocd.argoproj.io/sync-options: Delete=false annotation is *required* on this resource
+# so that it is not deleted before the PostDelete job that depends on it is run
+# (NOTE: it is not currently possible to annotate this type of resource with PostDelete due to a bug in ArgoCD: https://github.com/argoproj/argo-cd/issues/17191)
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -52,6 +59,9 @@ rules:
       - {{ $cr_kind }}
 
 ---
+# argocd.argoproj.io/sync-options: Delete=false annotation is *required* on this resource
+# so that it is not deleted before the PostDelete job that depends on it is run
+# (NOTE: it is not currently possible to annotate this type of resource with PostDelete due to a bug in ArgoCD: https://github.com/argoproj/argo-cd/issues/17191)
 kind: ServiceAccount
 apiVersion: v1
 metadata:
@@ -61,6 +71,9 @@ metadata:
     argocd.argoproj.io/sync-options: Delete=false
 
 ---
+# argocd.argoproj.io/sync-options: Delete=false annotation is *required* on this resource
+# so that it is not deleted before the PostDelete job that depends on it is run
+# (NOTE: it is not currently possible to annotate this type of resource with PostDelete due to a bug in ArgoCD: https://github.com/argoproj/argo-cd/issues/17191)
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -86,6 +99,7 @@ metadata:
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/hook: PostDelete
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:
   template:
     metadata:

--- a/applications/130-ibm-mas-smtp-config/templates/postdelete-delete-cr.yaml
+++ b/applications/130-ibm-mas-smtp-config/templates/postdelete-delete-cr.yaml
@@ -22,7 +22,7 @@ metadata:
   name: {{ $np_name }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-options: PruneLast=true
+    argocd.argoproj.io/sync-options: Prune=false
 spec:
   podSelector:
     matchLabels:
@@ -39,7 +39,7 @@ metadata:
   name: {{ $role_name }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-options: PruneLast=true
+    argocd.argoproj.io/sync-options: Prune=false
 rules:
   - verbs:
       - delete
@@ -58,7 +58,7 @@ metadata:
   name: {{ $sa_name }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-options: PruneLast=true
+    argocd.argoproj.io/sync-options: Prune=false
 
 ---
 kind: RoleBinding
@@ -67,7 +67,7 @@ metadata:
   name: {{ $rb_name }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-options: PruneLast=true
+    argocd.argoproj.io/sync-options: Prune=false
 subjects:
   - kind: ServiceAccount
     name: {{ $sa_name }}

--- a/applications/130-ibm-mas-smtp-config/templates/postdelete-delete-cr.yaml
+++ b/applications/130-ibm-mas-smtp-config/templates/postdelete-delete-cr.yaml
@@ -22,7 +22,7 @@ metadata:
   name: {{ $np_name }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-options: Prune=false
+    argocd.argoproj.io/sync-options: Delete=false
 spec:
   podSelector:
     matchLabels:
@@ -39,7 +39,7 @@ metadata:
   name: {{ $role_name }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-options: Prune=false
+    argocd.argoproj.io/sync-options: Delete=false
 rules:
   - verbs:
       - delete
@@ -58,7 +58,7 @@ metadata:
   name: {{ $sa_name }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-options: Prune=false
+    argocd.argoproj.io/sync-options: Delete=false
 
 ---
 kind: RoleBinding
@@ -67,7 +67,7 @@ metadata:
   name: {{ $rb_name }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-options: Prune=false
+    argocd.argoproj.io/sync-options: Delete=false
 subjects:
   - kind: ServiceAccount
     name: {{ $sa_name }}

--- a/applications/130-ibm-mas-smtp-config/templates/postdelete-delete-cr.yaml
+++ b/applications/130-ibm-mas-smtp-config/templates/postdelete-delete-cr.yaml
@@ -82,7 +82,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ $job_name }}
+  generateName: {{ $job_name }}
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/hook: PostDelete

--- a/applications/130-ibm-mas-smtp-config/templates/postdelete-delete-cr.yaml
+++ b/applications/130-ibm-mas-smtp-config/templates/postdelete-delete-cr.yaml
@@ -1,101 +1,24 @@
 {{- if .Values.use_postdelete_hooks }}
 
-# Generate a suffix for all the resources so there are no name clashes if >1 config is deleted at the same time
 {{ $cr_name := .Values.mas_config_name }}
 {{ $cr_kind := .Values.mas_config_kind }}
 {{ $cr_api_version := .Values.mas_config_api_version }}
-{{ $role_name := printf "postdelete-delete-cr-r-%s" $cr_name }}
-{{ $sa_name := printf "postdelete-delete-cr-sa-%s" $cr_name }}
-{{ $rb_name := printf "postdelete-delete-cr-rb-%s" $cr_name }}
-{{ $np_name := printf "postdelete-delete-cr-np-%s" $cr_name }}
-{{ $job_name := printf "postdelete-delete-cr-job-%s" $cr_name }}
+
+# NOTE: depends on resources created in ibm-mas-suite chart (01-postdelete-crs-resources)
+# The values below must align with the values in that file
+{{ $role_name := "postdelete-delete-cr-r" }}
+{{ $sa_name :=   "postdelete-delete-cr-sa" }}
+{{ $rb_name :=   "postdelete-delete-cr-rb" }}
+{{ $np_name :=   "postdelete-delete-cr-np" }}
+{{ $job_label := "postdelete-delete-cr-job" }}
 {{ $ns := printf "mas-%s-core" .Values.mas_instance_id }}
-{{ $hook_delete_policy := "HookSucceeded" }}
-
-
----
-# Permit outbound communication by the Job pods
-# (Needed to communicate with the K8S HTTP API and AWS SM)
-
-# argocd.argoproj.io/sync-options: Delete=false annotation is *required* on this resource
-# so that it is not deleted before the PostDelete job that depends on it is run
-# (NOTE: it is not currently possible to annotate this type of resource with PostDelete due to a bug in ArgoCD: https://github.com/argoproj/argo-cd/issues/17191)
-kind: NetworkPolicy
-apiVersion: networking.k8s.io/v1
-metadata:
-  name: {{ $np_name }}
-  namespace: {{ $ns }}
-  annotations:
-    argocd.argoproj.io/sync-options: Delete=false
-spec:
-  podSelector:
-    matchLabels:
-      app: {{ $job_name }}
-  egress:
-    - {}
-  policyTypes:
-    - Egress
-
----
-# argocd.argoproj.io/sync-options: Delete=false annotation is *required* on this resource
-# so that it is not deleted before the PostDelete job that depends on it is run
-# (NOTE: it is not currently possible to annotate this type of resource with PostDelete due to a bug in ArgoCD: https://github.com/argoproj/argo-cd/issues/17191)
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ $role_name }}
-  namespace: {{ $ns }}
-  annotations:
-    argocd.argoproj.io/sync-options: Delete=false
-rules:
-  - verbs:
-      - delete
-      - get
-      - list
-      - watch
-    apiGroups:
-      - {{ $cr_api_version }}
-    resources:
-      - {{ $cr_kind }}
-
----
-# argocd.argoproj.io/sync-options: Delete=false annotation is *required* on this resource
-# so that it is not deleted before the PostDelete job that depends on it is run
-# (NOTE: it is not currently possible to annotate this type of resource with PostDelete due to a bug in ArgoCD: https://github.com/argoproj/argo-cd/issues/17191)
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: {{ $sa_name }}
-  namespace: {{ $ns }}
-  annotations:
-    argocd.argoproj.io/sync-options: Delete=false
-
----
-# argocd.argoproj.io/sync-options: Delete=false annotation is *required* on this resource
-# so that it is not deleted before the PostDelete job that depends on it is run
-# (NOTE: it is not currently possible to annotate this type of resource with PostDelete due to a bug in ArgoCD: https://github.com/argoproj/argo-cd/issues/17191)
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ $rb_name }}
-  namespace: {{ $ns }}
-  annotations:
-    argocd.argoproj.io/sync-options: Delete=false
-subjects:
-  - kind: ServiceAccount
-    name: {{ $sa_name }}
-    namespace: {{ $ns }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ $role_name }}
 
 
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ $job_name }}
+  generateName: {{ $job_label }}
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/hook: PostDelete
@@ -104,7 +27,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ $job_name }}
+        app: {{ $job_label }}
     spec:
       containers:
         - name: run

--- a/applications/130-ibm-mas-smtp-config/templates/postdelete-delete-cr.yaml
+++ b/applications/130-ibm-mas-smtp-config/templates/postdelete-delete-cr.yaml
@@ -4,6 +4,8 @@
 {{ $cr_kind := .Values.mas_config_kind }}
 {{ $cr_api_version := .Values.mas_config_api_version }}
 
+{{ $job_name := printf "postdelete-delete-cr-job-%s" $cr_name }}
+
 # NOTE: depends on resources created in ibm-mas-suite chart (01-postdelete-crs-resources)
 # The values below must align with the values in that file
 {{ $role_name := "postdelete-delete-cr-r" }}
@@ -18,7 +20,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  generateName: {{ $job_label }}
+  name: {{ $job_name }}
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/hook: PostDelete

--- a/applications/130-ibm-mas-smtp-config/templates/postdelete-delete-cr.yaml
+++ b/applications/130-ibm-mas-smtp-config/templates/postdelete-delete-cr.yaml
@@ -22,7 +22,7 @@ metadata:
   name: {{ $np_name }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-options: PruneLast=true
 spec:
   podSelector:
     matchLabels:
@@ -39,7 +39,7 @@ metadata:
   name: {{ $role_name }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-wave: "-2"
+    argocd.argoproj.io/sync-options: PruneLast=true
 rules:
   - verbs:
       - delete
@@ -58,7 +58,7 @@ metadata:
   name: {{ $sa_name }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-wave: "-2"
+    argocd.argoproj.io/sync-options: PruneLast=true
 
 ---
 kind: RoleBinding
@@ -67,7 +67,7 @@ metadata:
   name: {{ $rb_name }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-options: PruneLast=true
 subjects:
   - kind: ServiceAccount
     name: {{ $sa_name }}
@@ -82,7 +82,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  generateName: {{ $job_name }}
+  name: {{ $job_name }}
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/hook: PostDelete

--- a/applications/130-ibm-mas-suite/templates/01-postdelete-crs-resources.yaml
+++ b/applications/130-ibm-mas-suite/templates/01-postdelete-crs-resources.yaml
@@ -16,7 +16,7 @@
 {{ $rb_name :=   "postdelete-delete-cr-rb" }}
 {{ $np_name :=   "postdelete-delete-cr-np" }}
 {{ $job_label := "postdelete-delete-cr-job" }}
-{{ $ns := printf "mas-%s-core" .Values.mas_instance_id }}
+{{ $ns := printf "mas-%s-core" .Values.ibm_mas_suite.mas_instance_id }}
 
 ---
 # Permit outbound communication by the Job pods

--- a/applications/130-ibm-mas-suite/templates/01-postdelete-crs-resources.yaml
+++ b/applications/130-ibm-mas-suite/templates/01-postdelete-crs-resources.yaml
@@ -31,7 +31,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: {{ $job_name }}
+      app: {{ $job_label }}
   egress:
     - {}
   policyTypes:

--- a/applications/130-ibm-mas-suite/templates/01-postdelete-crs-resources.yaml
+++ b/applications/130-ibm-mas-suite/templates/01-postdelete-crs-resources.yaml
@@ -11,7 +11,6 @@
 
 
 
-
 {{ $role_name := "postdelete-delete-cr-r" }}
 {{ $sa_name :=   "postdelete-delete-cr-sa" }}
 {{ $rb_name :=   "postdelete-delete-cr-rb" }}

--- a/applications/130-ibm-mas-suite/templates/01-postdelete-crs-resources.yaml
+++ b/applications/130-ibm-mas-suite/templates/01-postdelete-crs-resources.yaml
@@ -66,9 +66,6 @@ metadata:
     argocd.argoproj.io/sync-wave: "131"
 
 ---
-# argocd.argoproj.io/sync-options: Delete=false annotation is *required* on this resource
-# so that it is not deleted before the PostDelete job that depends on it is run
-# (NOTE: it is not currently possible to annotate this type of resource with PostDelete due to a bug in ArgoCD: https://github.com/argoproj/argo-cd/issues/17191)
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/applications/130-ibm-mas-suite/templates/01-postdelete-crs-resources.yaml
+++ b/applications/130-ibm-mas-suite/templates/01-postdelete-crs-resources.yaml
@@ -1,0 +1,82 @@
+# A collection of resources for supporting the PostDelete hooks on ibm-mas-*-config applications
+# They are created in this chart (instead of the config application charts) to:
+#   1. ensure the resources are not deleted by ArgoCD before ArgoCD runs the PostDelete hook jobs that depend on them
+#   2. reduce code and resource duplication
+# ( NOTE: this is a workaround for the fact it is not currently possible to annotate these types of resource with 
+#   PostDelete due to a bug in ArgoCD: https://github.com/argoproj/argo-cd/issues/17191) and the fact that ArgoCD
+#   does not yet support PreDelete hooks: https://github.com/argoproj/argo-cd/issues/13975, either of which
+#   would offer a preferable solution to this workaround )
+
+{{ $role_name := "postdelete-delete-cr-r" }}
+{{ $sa_name :=   "postdelete-delete-cr-sa" }}
+{{ $rb_name :=   "postdelete-delete-cr-rb" }}
+{{ $np_name :=   "postdelete-delete-cr-np" }}
+{{ $job_label := "postdelete-delete-cr-job" }}
+{{ $ns := printf "mas-%s-core" .Values.mas_instance_id }}
+
+---
+# Permit outbound communication by the Job pods
+# (Needed to communicate with the K8S HTTP API and AWS SM)
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ $np_name }}
+  namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "131"
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $job_name }}
+  egress:
+    - {}
+  policyTypes:
+    - Egress
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ $role_name }}
+  namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "131"
+rules:
+  - verbs:
+      - delete
+      - get
+      - list
+      - watch
+    apiGroups:
+      - "config.mas.ibm.com"
+    resources:
+      - "*"
+
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: {{ $sa_name }}
+  namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "131"
+
+---
+# argocd.argoproj.io/sync-options: Delete=false annotation is *required* on this resource
+# so that it is not deleted before the PostDelete job that depends on it is run
+# (NOTE: it is not currently possible to annotate this type of resource with PostDelete due to a bug in ArgoCD: https://github.com/argoproj/argo-cd/issues/17191)
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ $rb_name }}
+  namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "132"
+subjects:
+  - kind: ServiceAccount
+    name: {{ $sa_name }}
+    namespace: {{ $ns }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $role_name }}

--- a/applications/130-ibm-mas-suite/templates/01-postdelete-crs-resources.yaml
+++ b/applications/130-ibm-mas-suite/templates/01-postdelete-crs-resources.yaml
@@ -1,11 +1,16 @@
-# A collection of resources for supporting the PostDelete hooks on ibm-mas-*-config applications
-# They are created in this chart (instead of the config application charts) to:
-#   1. ensure the resources are not deleted by ArgoCD before ArgoCD runs the PostDelete hook jobs that depend on them
-#   2. reduce code and resource duplication
-# ( NOTE: this is a workaround for the fact it is not currently possible to annotate these types of resource with 
-#   PostDelete due to a bug in ArgoCD: https://github.com/argoproj/argo-cd/issues/17191) and the fact that ArgoCD
-#   does not yet support PreDelete hooks: https://github.com/argoproj/argo-cd/issues/13975, either of which
-#   would offer a preferable solution to this workaround )
+{{- /*
+ A collection of resources for supporting the PostDelete hooks on ibm-mas-*-config applications
+ They are created in this chart (instead of the config application charts) to:
+   1. ensure the resources are not deleted by ArgoCD before ArgoCD runs the PostDelete hook jobs that depend on them
+   2. reduce code and resource duplication
+ ( NOTE: this is a workaround for the fact it is not currently possible to annotate these types of resource with 
+   PostDelete due to a bug in ArgoCD: https://github.com/argoproj/argo-cd/issues/17191) and the fact that ArgoCD
+   does not yet support PreDelete hooks: https://github.com/argoproj/argo-cd/issues/13975, either of which
+   would offer a preferable solution to this workaround )
+*/}}
+
+
+
 
 {{ $role_name := "postdelete-delete-cr-r" }}
 {{ $sa_name :=   "postdelete-delete-cr-sa" }}

--- a/applications/130-ibm-objectstorage-config/templates/postdelete-delete-cr.yaml
+++ b/applications/130-ibm-objectstorage-config/templates/postdelete-delete-cr.yaml
@@ -1,73 +1,19 @@
 {{- if .Values.use_postdelete_hooks }}
 
-# Generate a suffix for all the resources so there are no name clashes if >1 config is deleted at the same time
 {{ $cr_name := .Values.mas_config_name }}
 {{ $cr_kind := .Values.mas_config_kind }}
 {{ $cr_api_version := .Values.mas_config_api_version }}
-{{ $role_name := printf "postdelete-delete-cr-r-%s" $cr_name }}
-{{ $sa_name := printf "postdelete-delete-cr-sa-%s" $cr_name }}
-{{ $rb_name := printf "postdelete-delete-cr-rb-%s" $cr_name }}
-{{ $np_name := printf "postdelete-delete-cr-np-%s" $cr_name }}
+
 {{ $job_name := printf "postdelete-delete-cr-job-%s" $cr_name }}
+
+# NOTE: depends on resources created in ibm-mas-suite chart (01-postdelete-crs-resources)
+# The values below must align with the values in that file
+{{ $role_name := "postdelete-delete-cr-r" }}
+{{ $sa_name :=   "postdelete-delete-cr-sa" }}
+{{ $rb_name :=   "postdelete-delete-cr-rb" }}
+{{ $np_name :=   "postdelete-delete-cr-np" }}
+{{ $job_label := "postdelete-delete-cr-job" }}
 {{ $ns := printf "mas-%s-core" .Values.mas_instance_id }}
-{{ $hook_delete_policy := "HookSucceeded" }}
-
-
----
-# Permit outbound communication by the Job pods
-# (Needed to communicate with the K8S HTTP API and AWS SM)
-kind: NetworkPolicy
-apiVersion: networking.k8s.io/v1
-metadata:
-  name: {{ $np_name }}
-  namespace: {{ $ns }}
-spec:
-  podSelector:
-    matchLabels:
-      app: {{ $job_name }}
-  egress:
-    - {}
-  policyTypes:
-    - Egress
-
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ $role_name }}
-  namespace: {{ $ns }}
-rules:
-  - verbs:
-      - delete
-      - get
-      - list
-      - watch
-    apiGroups:
-      - {{ $cr_api_version }}
-    resources:
-      - {{ $cr_kind }}
-
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  name: {{ $sa_name }}
-  namespace: {{ $ns }}
-
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ $rb_name }}
-  namespace: {{ $ns }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ $sa_name }}
-    namespace: {{ $ns }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ $role_name }}
 
 
 ---
@@ -78,11 +24,12 @@ metadata:
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/hook: PostDelete
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:
   template:
     metadata:
       labels:
-        app: {{ $job_name }}
+        app: {{ $job_label }}
     spec:
       containers:
         - name: run

--- a/root-applications/ibm-mas-instance-root/templates/120-db2-databases-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-db2-databases-app.yaml
@@ -16,6 +16,8 @@ metadata:
     notifications.argoproj.io/subscribe.on-sync-failed.slack: {{ $.Values.notifications.slack_channel_id }}
     notifications.argoproj.io/subscribe.on-sync-succeeded.slack: {{ $.Values.notifications.slack_channel_id }}
     {{- end }}
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
   labels:
     cloud: aws
     environment: '{{ $.Values.account.id }}'

--- a/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-configs-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-configs-app.yaml
@@ -16,6 +16,10 @@ metadata:
     notifications.argoproj.io/subscribe.on-sync-failed.slack: {{ $.Values.notifications.slack_channel_id }}
     notifications.argoproj.io/subscribe.on-sync-succeeded.slack: {{ $.Values.notifications.slack_channel_id }}
     {{- end }}
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+    - post-delete-finalizer.argocd.argoproj.io	
+    - post-delete-finalizer.argocd.argoproj.io/cleanup
   labels:
     cloud: aws
     environment: '{{ $.Values.account.id }}'

--- a/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-configs-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-configs-app.yaml
@@ -17,7 +17,6 @@ metadata:
     notifications.argoproj.io/subscribe.on-sync-succeeded.slack: {{ $.Values.notifications.slack_channel_id }}
     {{- end }}
   finalizers:
-    - resources-finalizer.argocd.argoproj.io
     - post-delete-finalizer.argocd.argoproj.io	
     - post-delete-finalizer.argocd.argoproj.io/cleanup
   labels:

--- a/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-configs-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-configs-app.yaml
@@ -17,6 +17,7 @@ metadata:
     notifications.argoproj.io/subscribe.on-sync-succeeded.slack: {{ $.Values.notifications.slack_channel_id }}
     {{- end }}
   finalizers:
+    - resources-finalizer.argocd.argoproj.io
     - post-delete-finalizer.argocd.argoproj.io	
     - post-delete-finalizer.argocd.argoproj.io/cleanup
   labels:


### PR DESCRIPTION
The Config CR PostDeletion hooks added under https://github.com/ibm-mas/gitops/pull/42 weren't actually working as I thought -  ArgoCD's resource finalizer was not being set on the config apps meaning that things were not being cleaned up properly in some cases. After enabling the finalizer, config app deletion would hang due to the resources (rbac, networkpolicy) that the hook job depends on being deleted before the Job gets a chance to run. 

This PR provides a workaround for this; the supporting rbac, networkpolicy resources are created in the ibm-mas-suite chart, meaning they will persist beyond the lifetime of individual config applications. This approach also reduces code and resource duplication.

NOTE: This works fine when deleting/recreating configs (without removing the suite). However, if you also delete the suite application around the same time, because the suite application is (necessarily) in the same syncwave as the config apps (because the suite requires mongo and sls configs to become healthy and visa versa), ArgoCD will remove the Suite CR and thus the entitymanagers, meaning the Cfg CR finalizers never get processed and the deletion will hang. PreDelete hooks [ArgoCD feature request](https://github.com/argoproj/argo-cd/issues/13975) are the obvious solution to this. I suggest we wait to see if ArgoCD PreDelete hooks get implemented soon. If not, we'll need to revisit this and explore alternative solutions.