### PR TITLE
Guard against race conditions in post-sync hooks

### DIFF
--- a/applications/010-redhat-cert-manager/templates/04-postsync-update-sm_Job.yaml
+++ b/applications/010-redhat-cert-manager/templates/04-postsync-update-sm_Job.yaml
@@ -1,3 +1,11 @@
+
+
+{{- /*
+TODO:
+  The secrets being created in AWS SM by this Job are nothing to do with cert-manager
+  There *has* to be a better way of getting these bits of info into the ibm-db2u and ibm-db2u-database charts
+*/}}
+
 {{- if .Values.redhat_cert_manager.run_sync_hooks }}
 
 {{ $ns := "cert-manager-operator"}}
@@ -5,8 +13,6 @@
 {{ $role_name  :=  "postsync-rhcm-update-sm-r" }}
 {{ $sa_name    :=  "postsync-rhcm-update-sm-sa" }}
 {{ $rb_name    :=  "postsync-rhcm-update-sm-rb" }}
-{{ $job_name   :=  "postsync-rhcm-update-sm-job" }}
-
 
 
 ---
@@ -16,9 +22,7 @@ metadata:
   name: {{ $aws_secret }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-wave: "100"
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    argocd.argoproj.io/sync-wave: "013"
 data:
   aws_access_key_id: {{ .Values.sm.aws_access_key_id | b64enc }}
   aws_secret_access_key: {{ .Values.sm.aws_secret_access_key | b64enc }}
@@ -31,9 +35,7 @@ metadata:
   name: {{ $sa_name }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-wave: "100"
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    argocd.argoproj.io/sync-wave: "013"
 
 ---
 kind: ClusterRole
@@ -41,9 +43,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ $role_name }}
   annotations:
-    argocd.argoproj.io/sync-wave: "100"
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    argocd.argoproj.io/sync-wave: "013"
 rules:
   - verbs:
       - get
@@ -66,9 +66,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ $rb_name }}
   annotations:
-    argocd.argoproj.io/sync-wave: "101"
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    argocd.argoproj.io/sync-wave: "014"
 subjects:
   - kind: ServiceAccount
     name: {{ $sa_name }}
@@ -82,12 +80,14 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ $job_name }}
+  # Generate the job name by suffixing with a hash of all chart values
+  # This is to ensure that ArgoCD will delete and recreate the job if (and only if) anything changes
+  # Any change to cluster config will trigger a rerun of the job.
+  # The job is idempotent and quick so no real harm in running it when we don't actually need to.
+  name: "postsync-rhcm-update-sm-job-{{ .Values | toYaml | adler32sum }}"
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-wave: "102"
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    argocd.argoproj.io/sync-wave: "015"
 spec:
   template:
     spec:
@@ -120,7 +120,52 @@ spec:
             - -c
             - |
 
+
               set -e
+
+              # might as well take advantage of gitops_utils for sm_ functions as we're using the cli image
+              source /mascli/functions/gitops_utils
+
+              function wait_for_cluster_resource {
+                RES_TYPE="$1"
+                RES_NAME="$2"
+                RETRIES=${3:-10}
+                RETRY_DELAY_SECONDS=${4:-30}
+
+                for (( c=1; c<="${RETRIES}"; c++ )); do
+
+                  echo "... attempt ${c} of ${RETRIES}"
+
+                  rc=0
+                  oc get "${RES_TYPE}/${RES_NAME}" -n "${RES_NAMESPACE}" || rc=$?
+                  if [[ "$rc" == "0" ]]; then
+                    echo "...... success"
+                    return 0
+                  fi
+
+                  if [[ "${c}" -lt "${RETRIES}" ]]; then
+                    echo "...... failed (rc: ${rc}), retry in ${RETRY_DELAY_SECONDS}s"
+                    sleep $RETRY_DELAY_SECONDS
+                  fi
+                done
+
+                echo "...... failed, no attempts remain"
+                return 1
+              }
+
+
+              echo ""
+              echo "================================================================================"
+              echo "Waiting for PackageManifest db2u-operator to be present before continuing (timeout 300s)"
+              echo "================================================================================"
+              wait_for_cluster_resource "PackageManifest" "db2u-operator"
+
+              echo ""
+              echo "================================================================================"
+              echo "Waiting for ingress.config.openshift.io cluster to be present before continuing (timeout 300s)"
+              echo "================================================================================"
+              wait_for_cluster_resource "ingress.config.openshift.io" "cluster"
+
 
               # NOTE: cannot just render AWS secrets into here, as it will be exposed in the ArgoCD UI
               # Instead, we pass them into a secret (ArgoCD knows to hide any data fields in k8s secrets),
@@ -128,7 +173,6 @@ spec:
               SM_AWS_ACCESS_KEY_ID=$(cat /etc/mas/creds/aws/aws_access_key_id)
               SM_AWS_SECRET_ACCESS_KEY=$(cat /etc/mas/creds/aws/aws_secret_access_key)
 
-              # Used by gitops_db2u
               echo "Fetching defaultChannel from db2u-operator PackageManifest"
               export DB2_DEFAULT_CHANNEL=$(oc get PackageManifest db2u-operator -o=jsonpath="{.status.defaultChannel}")
               if [[ -z "${DB2_DEFAULT_CHANNEL}" ]]; then
@@ -136,7 +180,6 @@ spec:
                 exit 1
               fi
 
-              # Used by gitops_db2u_database
               echo "Fetching domain from ingress.config.openshift.io cluster"
               export CLUSTER_DOMAIN=$(oc get ingress.config.openshift.io cluster -o=jsonpath='{.spec.domain}')
               if [[ -z "${CLUSTER_DOMAIN}" ]]; then
@@ -144,23 +187,19 @@ spec:
                 exit 1
               fi
 
-              # might as well take advantage of gitops_utils for sm_ functions as we're using the cli image
-              source /mascli/functions/gitops_utils
-
-              # aws configure set aws_access_key_id $SM_AWS_ACCESS_KEY_ID
-              # aws configure set aws_secret_access_key $SM_AWS_SECRET_ACCESS_KEY
-              # aws configure set default.region $REGION_ID
-              # aws configure list
               export SM_AWS_REGION=${REGION_ID}
               sm_login
 
 
-              # TODO: combine these into a single cluster-level secret? e.g. <account>/<cluster> with db2DefaultChannel and domain keys?
+              # Used by the Subscription resource in the ibm-db2u chart (https://github.com/ibm-mas/gitops/blob/5fdeaacb9180756d52da3708f68cfcc1949c4c98/applications/060-ibm-db2u/templates/03-db2_Subscription.yaml#L10)
               SECRET_NAME_DB2_DEFAULT_CHANNEL=${ACCOUNT_ID}/${CLUSTER_ID}/db2_default_channel
               sm_update_secret $SECRET_NAME_DB2_DEFAULT_CHANNEL "{\"db2_default_channel\": \"$DB2_DEFAULT_CHANNEL\" }"
 
+              # Used by resources in the ibm-db2u-database chart (https://github.com/ibm-mas/gitops/tree/5fdeaacb9180756d52da3708f68cfcc1949c4c98/applications/120-ibm-db2u-database)
               SECRET_NAME_CLUSTER_DOMAIN=${ACCOUNT_ID}/${CLUSTER_ID}/cluster_domain
               sm_update_secret $SECRET_NAME_CLUSTER_DOMAIN "{\"cluster_domain\": \"$CLUSTER_DOMAIN\" }"
+
+
 
 
       restartPolicy: Never

--- a/applications/020-ibm-dro/templates/08-postsync-update-sm_Job.yaml
+++ b/applications/020-ibm-dro/templates/08-postsync-update-sm_Job.yaml
@@ -167,7 +167,7 @@ spec:
               export DRO_URL="https://${DRO_HOST}"
 
               echo "Fetching token from ibm-data-reporter-operator-api-token Secret in ${DRO_NAMESPACE}"
-              export DRO_API_TOKEN=$(cat /etc/mas/creds/ibm-data-reporter-operator-api-token)
+              export DRO_API_TOKEN=$(cat /etc/mas/creds/ibm-data-reporter-operator-api-token/token)
               if [[ -z "${DRO_API_TOKEN}" ]]; then
                 echo "Failed to fetch token"
                 exit 1

--- a/applications/020-ibm-dro/templates/08-postsync-update-sm_Job.yaml
+++ b/applications/020-ibm-dro/templates/08-postsync-update-sm_Job.yaml
@@ -5,7 +5,6 @@
 {{ $role_name :=  "postsync-ibm-dro-update-sm-r" }}
 {{ $sa_name :=    "postsync-ibm-dro-update-sm-sa" }}
 {{ $rb_name :=    "postsync-ibm-dro-update-sm-rb" }}
-{{ $job_name :=   "postsync-ibm-dro-update-sm-job" }}
 
 
 ---
@@ -15,9 +14,7 @@ metadata:
   name: {{ $aws_secret }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-wave: "100"
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    argocd.argoproj.io/sync-wave: "026"
 data:
   aws_access_key_id: {{ .Values.sm.aws_access_key_id | b64enc }}
   aws_secret_access_key: {{ .Values.sm.aws_secret_access_key | b64enc }}
@@ -30,9 +27,7 @@ metadata:
   name: {{ $sa_name }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-wave: "100"
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    argocd.argoproj.io/sync-wave: "026"
 
 ---
 kind: Role
@@ -41,16 +36,8 @@ metadata:
   name: {{ $role_name }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-wave: "100"
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    argocd.argoproj.io/sync-wave: "026"
 rules:
-  - verbs:
-      - get
-    apiGroups:
-      - ""
-    resources:
-      - secrets
   - verbs:
       - get
     apiGroups:
@@ -66,9 +53,7 @@ metadata:
   name: {{ $rb_name }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-wave: "101"
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    argocd.argoproj.io/sync-wave: "027"
 subjects:
   - kind: ServiceAccount
     name: {{ $sa_name }}
@@ -82,12 +67,15 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ $job_name }}
+  # Generate the job name by suffixing with a hash of all chart values
+  # This is to ensure that ArgoCD will delete and recreate the job if (and only if) anything changes
+  # Any change to cluster config will trigger a rerun of the job. 
+  # We can refine this in future to only take into account a subset of instance config (perhaps just values under ibm_dro?).
+  # But the job is idempotent and quick so no real harm in running it when we don't actually need to.
+  name: "postsync-ibm-dro-update-sm-job-{{ .Values | toYaml | adler32sum }}"
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-wave: "102"
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    argocd.argoproj.io/sync-wave: "028"
 spec:
   template:
     spec:
@@ -117,12 +105,53 @@ spec:
           volumeMounts:
             - name: aws
               mountPath: /etc/mas/creds/aws
+            - name: ibm-data-reporter-operator-api-token
+              mountPath: /etc/mas/creds/ibm-data-reporter-operator-api-token
           command:
             - /bin/sh
             - -c
             - |
 
               set -e
+
+              # might as well take advantage of gitops_utils for sm_ functions as we're using the cli image
+              source /mascli/functions/gitops_utils
+
+              function wait_for_resource {
+                RES_TYPE="$1"
+                RES_NAME="$2"
+                RES_NS="$3"
+                RETRIES=${4:-10}
+                RETRY_DELAY_SECONDS=${5:-30}
+
+                for (( c=1; c<="${RETRIES}"; c++ )); do
+
+                  echo "... attempt ${c} of ${RETRIES}"
+
+                  rc=0
+                  oc get "${RES_TYPE}/${RES_NAME}" -n "${RES_NAMESPACE}" || rc=$?
+                  if [[ "$rc" == "0" ]]; then
+                    echo "...... success"
+                    return 0
+                  fi
+
+                  if [[ "${c}" -lt "${RETRIES}" ]]; then
+                    echo "...... failed (rc: ${rc}), retry in ${RETRY_DELAY_SECONDS}s"
+                    sleep $RETRY_DELAY_SECONDS
+                  fi
+                done
+
+                echo "...... failed, no attempts remain"
+                return 1
+              }
+
+
+              echo ""
+              echo "================================================================================"
+              echo "Waiting for route ibm-data-reporter to be present before continuing (timeout 300s)"
+              echo "================================================================================"
+              wait_for_resource "route" "ibm-data-reporter" "${DRO_NAMESPACE}"
+
 
               # NOTE: cannot just render AWS secrets into here, as it will be exposed in the ArgoCD UI
               # Instead, we pass them into a secret (ArgoCD knows to hide any data fields in k8s secrets),
@@ -138,14 +167,12 @@ spec:
               export DRO_URL="https://${DRO_HOST}"
 
               echo "Fetching token from ibm-data-reporter-operator-api-token Secret in ${DRO_NAMESPACE}"
-              export DRO_API_TOKEN=$(oc get secret ibm-data-reporter-operator-api-token -n ${DRO_NAMESPACE} -o jsonpath='{.data.token}' | base64 -d ; echo)
+              export DRO_API_TOKEN=$(cat /etc/mas/creds/ibm-data-reporter-operator-api-token)
               if [[ -z "${DRO_API_TOKEN}" ]]; then
                 echo "Failed to fetch token"
                 exit 1
               fi
 
-              # might as well take advantage of gitops_utils for sm_ functions as we're using the cli image
-              source /mascli/functions/gitops_utils
 
               # aws configure set aws_access_key_id $SM_AWS_ACCESS_KEY_ID
               # aws configure set aws_secret_access_key $SM_AWS_SECRET_ACCESS_KEY
@@ -168,6 +195,11 @@ spec:
         - name: aws
           secret:
             secretName: {{ $aws_secret }}
+            defaultMode: 420
+            optional: false
+        - name: ibm-data-reporter-operator-api-token
+          secret:
+            secretName: ibm-data-reporter-operator-api-token
             defaultMode: 420
             optional: false
   backoffLimit: 4

--- a/applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
+++ b/applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
@@ -6,7 +6,8 @@
 {{ $role_name :=  "postsync-ibm-sls-update-sm-r" }}
 {{ $sa_name :=    "postsync-ibm-sls-update-sm-sa" }}
 {{ $rb_name :=    "postsync-ibm-sls-update-sm-rb" }}
-{{ $job_name :=   printf "postsync-ibm-sls-update-sm-job-%s" (randAlphaNum 5 | lower) }}
+{{ $job_label :=  "postsync-ibm-sls-update-sm-job" }}
+{{ $job_name :=   printf "postsync-ibm-sls-update-sm-job-%s" (.Values | toYaml | adler32sum) }}
 
 
 
@@ -23,7 +24,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: {{ $job_name }}
+      app: {{ $job_label }}
   egress:
     - {}
   policyTypes:
@@ -99,7 +100,7 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ $job_name }}
+        app: {{ $job_label }}
     spec:
       containers:
         - name: run

--- a/applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
+++ b/applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
@@ -96,7 +96,7 @@ metadata:
   # Any change to instance config will trigger a rerun of the job. 
   # We can refine this in future to only take into account a subset of instance config (perhaps just values under ibm_sls?).
   # But the job is idempotent and quick so no real harm in running it when we don't actually need to.
-  name: "{{ $job_label }}-{{ .Values.db2_instance_name }}-{{ .Values | toYaml | adler32sum }}"
+  name: "{{ $job_label }}-{{ .Values | toYaml | adler32sum }}"
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "112"

--- a/applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
+++ b/applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
@@ -6,7 +6,7 @@
 {{ $role_name :=  "postsync-ibm-sls-update-sm-r" }}
 {{ $sa_name :=    "postsync-ibm-sls-update-sm-sa" }}
 {{ $rb_name :=    "postsync-ibm-sls-update-sm-rb" }}
-{{ $job_name :=   "postsync-ibm-sls-update-sm-job" }}
+{{ $job_name :=   printf "postsync-ibm-sls-update-sm-job-%s" (randAlphaNum 5) }}
 
 
 
@@ -91,7 +91,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  generateName: {{ $job_name }}
+  name: {{ $job_name }}
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "112"

--- a/applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
+++ b/applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
@@ -91,7 +91,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ $job_name }}
+  generateName: {{ $job_name }}
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "112"

--- a/applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
+++ b/applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
@@ -7,7 +7,6 @@
 {{ $sa_name :=    "postsync-ibm-sls-update-sm-sa" }}
 {{ $rb_name :=    "postsync-ibm-sls-update-sm-rb" }}
 {{ $job_label :=  "postsync-ibm-sls-update-sm-job" }}
-{{ $job_name :=   printf "postsync-ibm-sls-update-sm-job-%s" (.Values | toYaml | adler32sum) }}
 
 
 
@@ -92,7 +91,12 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ $job_name }}
+  # Generate the job name by suffixing the label with a hash of all chart values
+  # This is to ensure that ArgoCD will delete and recreate the job if (and only if) anything changes
+  # Any change to instance config will trigger a rerun of the job. 
+  # We can refine this in future to only take into account a subset of instance config (perhaps just values under ibm_sls?).
+  # But the job is idempotent and quick so no real harm in running it when we don't actually need to.
+  name: "{{ $job_label }}-{{ .Values.db2_instance_name }}-{{ .Values | toYaml | adler32sum }}"
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "112"

--- a/applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
+++ b/applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
@@ -6,7 +6,7 @@
 {{ $role_name :=  "postsync-ibm-sls-update-sm-r" }}
 {{ $sa_name :=    "postsync-ibm-sls-update-sm-sa" }}
 {{ $rb_name :=    "postsync-ibm-sls-update-sm-rb" }}
-{{ $job_name :=   printf "postsync-ibm-sls-update-sm-job-%s" (randAlphaNum 5) }}
+{{ $job_name :=   printf "postsync-ibm-sls-update-sm-job-%s" (randAlphaNum 5 | lower) }}
 
 
 

--- a/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
+++ b/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
@@ -88,6 +88,8 @@ spec:
           volumeMounts:
             - name: aws
               mountPath: /etc/mas/creds/aws
+            - name: db2u-certificate
+              mountPath: /etc/mas/creds/db2u-certificate
           command:
             - /bin/sh
             - -c
@@ -395,7 +397,7 @@ spec:
               echo ""
               echo "Fetch CA cert from db2u-certicate-${DB2_INSTANCE_NAME} secret in ${DB2_NAMESPACE}"
               echo "--------------------------------------------------------------------------------"
-              export DB2_CA_PEM=$(oc get secret db2u-certificate-${DB2_INSTANCE_NAME} -n ${DB2_NAMESPACE} -o "jsonpath={.data['ca\.crt']}")
+              export DB2_CA_PEM=$(cat /etc/mas/creds/db2u-certificate/ca.crt | base64 -w0)
               if [[ -z "${DB2_CA_PEM}" ]]; then
                 echo "Failed to fetch db2 ca pem"
                 exit 1
@@ -438,6 +440,11 @@ spec:
         - name: aws
           secret:
             secretName: "aws-{{ .Values.db2_instance_name }}"
+            defaultMode: 420
+            optional: false
+        - name: aws
+          secret:
+            secretName: "db2u-certificate-{{ .Values.db2_instance_name }}"
             defaultMode: 420
             optional: false
   backoffLimit: 4

--- a/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
+++ b/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
@@ -157,6 +157,8 @@ spec:
              
               export DB2CFG_SETTINGS_APPLIED=$(sm_get_secret_value ${SETTINGS_APPLIED_SECRET} "db2cfg_settings_applied")
               # TODO: or we could skip rendering of this hook (and related templates) altogether if DB2CFG_SETTINGS_APPLIED is "true"?
+              # -- in theory yes, but since it would have to be passed in via AVP in order to be referenced via { .Values.db2_namespace }, 
+              #     we'll only ever see the first value due to AVP caching
               echo "DB2CFG_SETTINGS_APPLIED ............. ${DB2CFG_SETTINGS_APPLIED}"
 
               if [[ "${DB2CFG_SETTINGS_APPLIED}" == "true" ]]; then

--- a/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
+++ b/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
@@ -99,6 +99,34 @@ spec:
 
               source /mascli/functions/gitops_utils
 
+              function wait_for_resource {
+                RES_TYPE="$1"
+                RES_NAME="$2"
+                RES_NS="$3"
+                RETRIES=${4:-10}
+                RETRY_DELAY_SECONDS=${5:-30}
+
+                for (( c=1; c<="${RETRIES}"; c++ )); do
+
+                  echo "... attempt ${c} of ${RETRIES}"
+
+                  rc=0
+                  oc get "${RES_TYPE}/${RES_NAME}" -n "${RES_NAMESPACE}" || rc=$?
+                  if [[ "$rc" == "0" ]]; then
+                    echo "...... success"
+                    return 0
+                  fi
+
+                  if [[ "${c}" -lt "${RETRIES}" ]]; then
+                    echo "...... failed (rc: ${rc}), retry in ${RETRY_DELAY_SECONDS}s"
+                    sleep $RETRY_DELAY_SECONDS
+                  fi
+                done
+
+                echo "...... failed, no attempts remain"
+                return 1
+              }
+
               export SETTINGS_APPLIED_SECRET=${ACCOUNT_ID}/${CLUSTER_ID}/${MAS_INSTANCE_ID}/db2/${DB2_INSTANCE_NAME}/settings_applied
               export DB2_CONFIG_SECRET=${ACCOUNT_ID}/${CLUSTER_ID}/${MAS_INSTANCE_ID}/db2/${DB2_INSTANCE_NAME}/config
 
@@ -137,8 +165,24 @@ spec:
               fi
 
 
-              # TODO: what's the purpose of the DB2_INTERNAL flag (used in gitops_db2u_database).. 
-              # surely any DB2 being spun up in this way via ArgoCD is considered "internal"?
+              echo ""
+              echo "================================================================================"
+              echo "Waiting for pod c-${DB2_INSTANCE_NAME}-db2u-0 to be present before continuing (timeout 300s)"
+              echo "================================================================================"
+              wait_for_resource "pod" "c-${DB2_INSTANCE_NAME}-db2u-0" "${DB2_NAMESPACE}"
+
+              echo ""
+              echo "================================================================================"
+              echo "Waiting for pod c-${DB2_INSTANCE_NAME}-db2u-0 to report Ready=True before continuing (timeout 300s)"
+              echo "================================================================================"
+              oc wait --for=condition=Ready pod/c-${DB2_INSTANCE_NAME}-db2u-0 --timeout 300s -n ${DB2_NAMESPACE}
+
+              echo ""
+              echo "================================================================================"
+              echo "Waiting for service c-${DB2_INSTANCE_NAME}-db2u-engn-svc to be present before continuing (timeout 300s)"
+              echo "================================================================================"
+              wait_for_resource "svc" "c-${DB2_INSTANCE_NAME}-db2u-engn-svc" "${DB2_NAMESPACE}"
+
 
               echo ""
               echo "================================================================================"

--- a/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
+++ b/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
@@ -54,7 +54,7 @@ spec:
         - name: run
           # TODO: use a dedicated image with a smaller footprint for this sort of thing?
           # Just using cli for now since it has all the deps we need to talk with AWS SM
-          image: quay.io/ibmmas/cli:7.10.0-pre.mascore1425
+          image: quay.io/ibmmas/cli:7.10.0-pre.gitops
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
+++ b/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
@@ -56,7 +56,7 @@ spec:
         - name: run
           # TODO: use a dedicated image with a smaller footprint for this sort of thing?
           # Just using cli for now since it has all the deps we need to talk with AWS SM
-          image: quay.io/ibmmas/cli:7.10.0-pre.gitops
+          image: quay.io/ibmmas/cli:8.1.0-pre.gitops
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
+++ b/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
@@ -47,6 +47,7 @@ metadata:
   namespace: "{{ .Values.db2_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "129"
+    argocd.argoproj.io/sync-options: Replace=true
 spec:
   template:
     spec:

--- a/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
+++ b/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
@@ -85,6 +85,10 @@ spec:
               value: "{{ .Values.db2_dbname }}"
             - name: TLS_VERSION
               value: "{{ .Values.tls_version }}"
+
+            # Hash all chart values, this is to ensure the Job will rerun if anything changes in the DB2 config
+            - name: CONFIG_HASH
+            - value: "{{ .Values | toYaml | sha256sum }}"
           volumeMounts:
             - name: aws
               mountPath: /etc/mas/creds/aws
@@ -127,7 +131,6 @@ spec:
                 return 1
               }
 
-              export SETTINGS_APPLIED_SECRET=${ACCOUNT_ID}/${CLUSTER_ID}/${MAS_INSTANCE_ID}/db2/${DB2_INSTANCE_NAME}/settings_applied
               export DB2_CONFIG_SECRET=${ACCOUNT_ID}/${CLUSTER_ID}/${MAS_INSTANCE_ID}/db2/${DB2_INSTANCE_NAME}/config
 
               echo ""
@@ -143,30 +146,12 @@ spec:
               echo "DB2_NAMESPACE ....................... ${DB2_NAMESPACE}"
               echo "DB2_INSTANCE_NAME ................... ${DB2_INSTANCE_NAME}"
               echo "DB2_DBNAME .......................... ${DB2_DBNAME}"
-              echo "SETTINGS_APPLIED_SECRET ............. ${SETTINGS_APPLIED_SECRET}"
-
-              echo ""
-              echo "================================================================================"
-              echo "Checking ${SETTINGS_APPLIED_SECRET}#db2cfg_settings_applied"
-              echo "================================================================================"
 
               export SM_AWS_ACCESS_KEY_ID=$(cat /etc/mas/creds/aws/aws_access_key_id)
               export SM_AWS_SECRET_ACCESS_KEY=$(cat /etc/mas/creds/aws/aws_secret_access_key)
               export SM_AWS_REGION=${REGION_ID}
               sm_login
              
-              export DB2CFG_SETTINGS_APPLIED=$(sm_get_secret_value ${SETTINGS_APPLIED_SECRET} "db2cfg_settings_applied")
-              # TODO: or we could skip rendering of this hook (and related templates) altogether if DB2CFG_SETTINGS_APPLIED is "true"?
-              # -- in theory yes, but since it would have to be passed in via AVP in order to be referenced via { .Values.db2_namespace }, 
-              #     we'll only ever see the first value due to AVP caching
-              echo "DB2CFG_SETTINGS_APPLIED ............. ${DB2CFG_SETTINGS_APPLIED}"
-
-              if [[ "${DB2CFG_SETTINGS_APPLIED}" == "true" ]]; then
-                echo "DB2 settings have been applied since the last change was made to the database configuration, exiting now "
-                exit 0
-              fi
-
-
               echo ""
               echo "================================================================================"
               echo "Waiting for pod c-${DB2_INSTANCE_NAME}-db2u-0 to be present before continuing (timeout 300s)"
@@ -470,16 +455,6 @@ spec:
               echo "Updating Secrets Manager"
               echo "--------------------------------------------------------------------------------"
               sm_update_secret ${DB2_CONFIG_SECRET} "{ \"tls_serviceport\": \"${DB2_TLS_SERVICEPORT}\", \"ca_b64\": \"${DB2_CA_PEM}\" }"
-              echo ".... rc $?"
-
-
-              echo ""
-              echo "================================================================================"
-              echo "Setting ${SETTINGS_APPLIED_SECRET}#db2cfg_settings_applied to true"
-              echo "================================================================================"
-
-              export DB2CFG_SETTINGS_APPLIED="true"
-              sm_update_secret ${SETTINGS_APPLIED_SECRET} "{ \"db2cfg_settings_applied\": \"${DB2CFG_SETTINGS_APPLIED}\" }"
               echo ".... rc $?"
 
 

--- a/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
+++ b/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
@@ -88,7 +88,7 @@ spec:
 
             # Hash all chart values, this is to ensure the Job will rerun if anything changes in the DB2 config
             - name: CONFIG_HASH
-            - value: "{{ .Values | toYaml | sha256sum }}"
+              value: "{{ .Values | toYaml | sha256sum }}"
           volumeMounts:
             - name: aws
               mountPath: /etc/mas/creds/aws

--- a/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
+++ b/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
@@ -43,16 +43,13 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "postsync-setup-db2-{{ .Values.db2_instance_name }}"
+  # Suffix the Job name with a hash of all chart values
+  # This is to ensure that ArgoCD will delete and recreate the job if (and only if) anything changes in the DB2 config
+  name: "postsync-setup-db2-{{ .Values.db2_instance_name }}-{{ .Values | toYaml | sha256sum }}"
   namespace: "{{ .Values.db2_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "129"
-    argocd.argoproj.io/sync-options: Replace=true
 spec:
-  template:
-    metadata:
-      labels:
-        app: "postsync-setup-db2-{{ .Values.db2_instance_name }}"
     spec:
       containers:
         - name: run
@@ -90,9 +87,6 @@ spec:
             - name: TLS_VERSION
               value: "{{ .Values.tls_version }}"
 
-            # Hash all chart values, this is to ensure the Job will rerun if anything changes in the DB2 config
-            - name: CONFIG_HASH
-              value: "{{ .Values | toYaml | sha256sum }}"
           volumeMounts:
             - name: aws
               mountPath: /etc/mas/creds/aws

--- a/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
+++ b/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
@@ -50,6 +50,9 @@ metadata:
     argocd.argoproj.io/sync-options: Replace=true
 spec:
   template:
+    metadata:
+      labels:
+        app: "postsync-setup-db2-{{ .Values.db2_instance_name }}"
     spec:
       containers:
         - name: run

--- a/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
+++ b/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
@@ -45,7 +45,7 @@ kind: Job
 metadata:
   # Suffix the Job name with a hash of all chart values
   # This is to ensure that ArgoCD will delete and recreate the job if (and only if) anything changes in the DB2 config
-  name: "postsync-setup-db2-{{ .Values.db2_instance_name }}-{{ .Values | toYaml | sha256sum }}"
+  name: "postsync-setup-db2-{{ .Values.db2_instance_name }}-{{ .Values | toYaml | adler32sum }}"
   namespace: "{{ .Values.db2_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "129"

--- a/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
+++ b/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
@@ -43,11 +43,14 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
+  # Suffix the Job name with a hash of all chart values
+  # This is to ensure that ArgoCD will delete and recreate the job if (and only if) anything changes in the DB2 config
   name: "postsync-setup-db2-{{ .Values.db2_instance_name }}-{{ .Values | toYaml | sha256sum }}"
   namespace: "{{ .Values.db2_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "129"
 spec:
+  template:
     spec:
       containers:
         - name: run

--- a/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
+++ b/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
@@ -4,6 +4,8 @@ apiVersion: v1
 metadata:
   name: "aws-{{ .Values.db2_instance_name }}"
   namespace: "{{ .Values.db2_namespace }}"
+  annotations:
+    argocd.argoproj.io/sync-wave: "127"
 data:
   aws_access_key_id: {{ .Values.sm.aws_access_key_id | b64enc }}
   aws_secret_access_key: {{ .Values.sm.aws_secret_access_key | b64enc }}
@@ -17,12 +19,16 @@ apiVersion: v1
 metadata:
   name: "postsync-sa-{{ .Values.db2_instance_name }}"
   namespace: "{{ .Values.db2_namespace }}"
+  annotations:
+    argocd.argoproj.io/sync-wave: "127"
 
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: "db2-database-postsync-sa-rb-{{ .Values.db2_instance_name }}"
+  annotations:
+    argocd.argoproj.io/sync-wave: "128"
 subjects:
   - kind: ServiceAccount
     name: "postsync-sa-{{ .Values.db2_instance_name }}"
@@ -40,8 +46,7 @@ metadata:
   name: "postsync-setup-db2-{{ .Values.db2_instance_name }}"
   namespace: "{{ .Values.db2_namespace }}"
   annotations:
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    argocd.argoproj.io/sync-wave: "129"
 spec:
   template:
     spec:
@@ -49,7 +54,7 @@ spec:
         - name: run
           # TODO: use a dedicated image with a smaller footprint for this sort of thing?
           # Just using cli for now since it has all the deps we need to talk with AWS SM
-          image: quay.io/ibmmas/cli:8.1.0-pre.gitops
+          image: quay.io/ibmmas/cli:7.10.0-pre.mascore1425
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -128,6 +133,10 @@ spec:
                 echo "DB2 settings have been applied since the last change was made to the database configuration, exiting now "
                 exit 0
               fi
+
+
+              # TODO: what's the purpose of the DB2_INTERNAL flag (used in gitops_db2u_database).. 
+              # surely any DB2 being spun up in this way via ArgoCD is considered "internal"?
 
               echo ""
               echo "================================================================================"
@@ -376,13 +385,6 @@ spec:
                   
               fi # [[ "$MAS_APP_ID" == "manage" ]]
 
-              echo ""
-              echo "================================================================================"
-              echo "Calling apply-db2cfg-settings.sh file on c-${DB2_INSTANCE_NAME}-db2u-0 again as db2u doesn't always apply the first time"
-              echo "================================================================================"
-              sleep 30
-              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc '/db2u/scripts/apply-db2cfg-settings.sh --setting all | tee /tmp/apply-db2cfg-settings.log' db2inst1
-              echo ".... rc $?"
 
               echo ""
               echo "================================================================================"

--- a/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
+++ b/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
@@ -494,7 +494,7 @@ spec:
             secretName: "aws-{{ .Values.db2_instance_name }}"
             defaultMode: 420
             optional: false
-        - name: aws
+        - name: db2u-certificate
           secret:
             secretName: "db2u-certificate-{{ .Values.db2_instance_name }}"
             defaultMode: 420

--- a/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
+++ b/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
@@ -43,8 +43,6 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  # Suffix the Job name with a hash of all chart values
-  # This is to ensure that ArgoCD will delete and recreate the job if (and only if) anything changes in the DB2 config
   name: "postsync-setup-db2-{{ .Values.db2_instance_name }}-{{ .Values | toYaml | sha256sum }}"
   namespace: "{{ .Values.db2_namespace }}"
   annotations:


### PR DESCRIPTION
https://jsw.ibm.com/browse/MASCORE-2279

This PR changes all existing PostSync hooks responsible for updating AWS SM with secrets needed in subsequent sync waves to just be "ordinary" kubernetes Jobs (i.e. the `argocd.argoproj.io/hook: PostSync` annotation has been removed from the Jobs and supporting resources).

This has the effect of making the Jobs part of the main sync cycle for an application, thus ensuring that ArgoCD will wait for the Jobs to complete successfully before allowing resources in subsequent syncwaves that depend on these secrets to proceed.

The change has two main side effects that have required some further modifications:
 -  the job runs themselves are no longer deferred until after the application they belongs to is fully synced and healthy. To address this I've added additional wait conditions into the Job scripts themselves to ensure they will wait (up to a finite limit) for the resources (pods, routes, secrets, etc) that they inspect to be present and ready.
- ArgoCD would not rerun the jobs after the initial sync. To address this I've added a hash (`adler32sum`) of the application config into the Job name. This causes ArgoCD to delete and recreate the job on resync if (and only) there is some change to configuration. At present, this hash takes into configuration that may not be relevant in some cases, but since the jobs are idempotent and fairly quick it doesn't hurt to rerun them sometimes when not strictly necessary. We can refine this future if needed. Another thing of note is that, for the db2u-database chart in particular, this has allowed me to deprecate the old method of determining if the job needs to be rerun using the `db2_settings_applied` flag in AWS SM (associated [ibm-mas/cli PR](https://github.com/ibm-mas/cli/pull/907)). This new approach means that ArgoCD is capable of coordinating this aspect of the deployment without requiring an additional script to also update the flag.

### Testing


#### db2u-database

Verified that the DB2 postsync job still runs on resync if (and only if) db2u database config is modified, and that it successfully waits for all the necessary resources to be up and running before proceeding.

![image](https://github.com/ibm-mas/gitops/assets/7372253/5e516eb0-581d-4170-94de-da84b95fda89)


#### SLS
Here is ArgoCD regenerating a new job (and marking the old one for deletion) in response to a config update / resync:

![image](https://github.com/ibm-mas/gitops/assets/7372253/c618e737-1704-4b3e-b580-e38d83160c81)

The new job completed successfully:
![image](https://github.com/ibm-mas/gitops/assets/7372253/f0790060-891a-4aa7-8e3b-e408db467fe8)


#### DRO
![image](https://github.com/ibm-mas/gitops/assets/7372253/e3892f1c-e161-4272-b03d-ef77175e5e44)

#### RHCM
![image](https://github.com/ibm-mas/gitops/assets/7372253/83670100-b4a4-41b3-a74d-76b63a151bcf)

