### PR TITLE
Fix "db2u apply settings not consistent" and "ibm-sync-resources application fails to deploy when docdb_port is numeric"

### DIFF
--- a/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
+++ b/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
@@ -337,14 +337,15 @@ spec:
                 echo "Creating /mnt/backup/staging in c-${DB2_INSTANCE_NAME}-db2u-0"
                 echo "--------------------------------------------------------------------------------"
                 oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0  -- su -lc "mkdir -p /mnt/backup/staging" db2inst1 || exit $?
+
+                echo ""
+                echo "================================================================================"
+                echo "Calling apply-db2cfg-settings.sh file on c-${DB2_INSTANCE_NAME}-db2u-0"
+                echo "================================================================================"
+                db2apply || exit $?
                   
               fi # [[ "$MAS_APP_ID" == "manage" ]]
 
-              echo ""
-              echo "================================================================================"
-              echo "Calling apply-db2cfg-settings.sh file on c-${DB2_INSTANCE_NAME}-db2u-0"
-              echo "================================================================================"
-              db2apply || exit $?
 
               echo ""
               echo "================================================================================"

--- a/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
+++ b/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
@@ -130,6 +130,41 @@ spec:
                 return 1
               }
 
+              # DB2 operator does not automatically apply dbConfig parameters set on the Db2uCluster CR
+              # Instead, a script /db2u/scripts/apply-db2cfg-settings.sh must be executed on one of the db2u pods
+              # However, this does not always seem to work and no indication is given in the output of the script whether it worked or not.
+              # One approach is to check the current configuration parameters (db2 get db cfg for ${DB2_DBNAME}) one by one and verify that their value aligns with that set in the CR.
+              # However, this is not straightforward since DB2 implicitly reformats certain param values (e.g. APPLHEAPSZ: '8192 AUTOMATIC' is reformatted to AUTOMATIC(8192)).
+              # Until we can come up with a better way of doing this (or the Db2u operator is fixed), we will take the approach used in ansible-devops,
+              # whereby the value of single parameter (CHNGPGS_THRESH) is checked against a known value (40) to see if the script executed successfully (and retry if not)
+              # See https://github.com/ibm-mas/ansible-devops/blob/b9f3ef5b7999640b0a31d0aba518ba85ef8b704f/ibm/mas_devops/roles/suite_db2_setup_for_manage/tasks/apply-db2-config-settings.yml#L39
+              function db2apply {
+                RETRIES=${1:-5}
+                RETRY_DELAY_SECONDS=${2:-30}
+
+                for (( c=1; c<="${RETRIES}"; c++ )); do
+                  echo ""
+                  echo "... attempt ${c} of ${RETRIES}"
+                  oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc '/db2u/scripts/apply-db2cfg-settings.sh --setting all | tee /tmp/apply-db2cfg-settings.log' db2inst1
+                  # no useful info in return code of this script
+
+                  rc=0
+                  oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc 'db2 get db cfg for ${DB2_DBNAME} | grep "(CHNGPGS_THRESH) = 40"' db2inst1 || rc=$?
+                  if [[ "$rc" == "0" ]]; then
+                    echo "...... success"
+                    return 0
+                  fi
+
+                  if [[ "${c}" -lt "${RETRIES}" ]]; then
+                    echo "...... failed (rc: ${rc}), retry in ${RETRY_DELAY_SECONDS}s"
+                    sleep $RETRY_DELAY_SECONDS
+                  fi
+                done
+
+                echo "...... failed, no attempts remain"
+                return 1
+              }
+
               export DB2_CONFIG_SECRET=${ACCOUNT_ID}/${CLUSTER_ID}/${MAS_INSTANCE_ID}/db2/${DB2_INSTANCE_NAME}/config
 
               echo ""
@@ -169,21 +204,11 @@ spec:
               echo "================================================================================"
               wait_for_resource "svc" "c-${DB2_INSTANCE_NAME}-db2u-engn-svc" "${DB2_NAMESPACE}"
 
-
               echo ""
               echo "================================================================================"
               echo "Calling apply-db2cfg-settings.sh file on c-${DB2_INSTANCE_NAME}-db2u-0"
               echo "================================================================================"
-              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc '/db2u/scripts/apply-db2cfg-settings.sh --setting all | tee /tmp/apply-db2cfg-settings.log' db2inst1
-              echo ".... rc $?"
-
-              echo ""
-              echo "================================================================================"
-              echo "Calling apply-db2cfg-settings.sh file on c-${DB2_INSTANCE_NAME}-db2u-0 again as db2u doesn't always apply the first time"
-              echo "================================================================================"
-              sleep 30
-              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc '/db2u/scripts/apply-db2cfg-settings.sh --setting all | tee /tmp/apply-db2cfg-settings.log' db2inst1
-              echo ".... rc $?"
+              db2apply || exit $?
 
               echo ""
               echo "================================================================================"

--- a/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
+++ b/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
@@ -204,109 +204,6 @@ spec:
               echo "================================================================================"
               wait_for_resource "svc" "c-${DB2_INSTANCE_NAME}-db2u-engn-svc" "${DB2_NAMESPACE}"
 
-              echo ""
-              echo "================================================================================"
-              echo "Calling apply-db2cfg-settings.sh file on c-${DB2_INSTANCE_NAME}-db2u-0"
-              echo "================================================================================"
-              db2apply || exit $?
-
-              echo ""
-              echo "================================================================================"
-              echo "Invoke Suite DB2 Backup"
-              echo "================================================================================"
-              # Some parameters like LOGARCHMETH1 being set can cause a backup to be needed as it moves
-              # to archival logging. 
-              # Copy and run a script on the db2u pod to perform that backup now if we are in that state.
-
-              # Path to the generated script, on both this pod and on the db2u pod
-              BACKUPDB_SH_PATH="/tmp/backupdb.sh"
-
-              echo ""
-              echo "Create ${BACKUPDB_SH_PATH}"
-              echo "--------------------------------------------------------------------------------"
-
-              # Generate a script to copy and run on the db2u pod
-              cat > ${BACKUPDB_SH_PATH} << EOF
-                #!/bin/bash
-
-                # Check that connect returns SQL1116N which means BACKUP PENDING state
-                if db2 connect to ${DB2_DBNAME} | grep SQL1116N >/dev/null; then
-                  echo "backupdb.sh: Database connect returning SQL1116N, do backup now"
-                else
-                  echo "backupdb.sh: Database connect not returning SQL1116N, nothing to do, exit now"
-                  exit 0
-                fi
-
-                echo "backupdb.sh: Creating backup folder /mnt/backup"
-                mkdir -p /mnt/backup
-                rc=\$?
-                [ \$rc -ne 0 ] && exit \$rc
-
-                echo "backupdb.sh: db2 force applications"
-                db2 force application all
-                rc=\$?
-                [ \$rc -ne 0 ] && exit \$rc
-
-                echo "backupdb.sh: Turn off comms manager"
-                db2set -null DB2COMM
-                rc=\$?
-                [ \$rc -ne 0 ] && exit \$rc
-
-                echo "backupdb.sh: Deactivate database"
-                db2 deactivate database ${DB2_DBNAME}
-                rc=\$?
-                [ \$rc -ne 0 ] && exit \$rc
-
-                echo "backupdb.sh: db2stop"
-                db2stop force
-                rc=\$?
-                [ \$rc -ne 0 ] && exit \$rc
-
-                echo "backupdb.sh: db2start in admin mode"
-                db2start admin mode restricted access
-                rc=\$?
-                [ \$rc -ne 0 ] && exit \$rc
-
-                # dbstart does not always start straight away, wait 20 seconds
-                sleep 20
-
-                echo "backupdb.sh: db2 backup db ${DB2_DBNAME} on all dbpartitionnums"
-                db2 backup db ${DB2_DBNAME} on all dbpartitionnums to /mnt/backup
-                rc=\$?
-                [ \$rc -ne 0 ] && exit \$rc
-
-                echo "backupdb.sh: db2stop"
-                db2stop force
-                rc=\$?
-                [ \$rc -ne 0 ] && exit \$rc
-
-                echo "backupdb.sh: db2set comms manager"
-                db2set DB2COMM=TCPIP,SSL
-                rc=\$?
-                [ \$rc -ne 0 ] && exit \$rc
-
-                echo "backupdb.sh: db2start"
-                db2start
-                rc=\$?
-                [ \$rc -ne 0 ] && exit \$rc
-              EOF
-              # IMPORTANT: Do not make any changes to the "EOF" line above (including its indentation)
-
-              chmod +x ${BACKUPDB_SH_PATH}
-
-              echo ""
-              echo "Copy ${BACKUPDB_SH_PATH} to ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0"
-              echo "--------------------------------------------------------------------------------"
-              oc cp ${BACKUPDB_SH_PATH} ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:${BACKUPDB_SH_PATH} -c db2u
-              echo ".... rc $?"
-
-              echo ""
-              echo "Executing ${BACKUPDB_SH_PATH} file on ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0"
-              echo "--------------------------------------------------------------------------------"
-              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "${BACKUPDB_SH_PATH} | tee /tmp/backupdb.log" db2inst1
-              echo ".... rc $?"
-
-
               if [[ "$MAS_APP_ID" == "manage" ]]; then
                 echo ""
                 echo "================================================================================"
@@ -448,6 +345,108 @@ spec:
                 echo ".... rc $?"
                   
               fi # [[ "$MAS_APP_ID" == "manage" ]]
+
+              echo ""
+              echo "================================================================================"
+              echo "Calling apply-db2cfg-settings.sh file on c-${DB2_INSTANCE_NAME}-db2u-0"
+              echo "================================================================================"
+              db2apply || exit $?
+
+              echo ""
+              echo "================================================================================"
+              echo "Invoke Suite DB2 Backup"
+              echo "================================================================================"
+              # Some parameters like LOGARCHMETH1 being set can cause a backup to be needed as it moves
+              # to archival logging. 
+              # Copy and run a script on the db2u pod to perform that backup now if we are in that state.
+
+              # Path to the generated script, on both this pod and on the db2u pod
+              BACKUPDB_SH_PATH="/tmp/backupdb.sh"
+
+              echo ""
+              echo "Create ${BACKUPDB_SH_PATH}"
+              echo "--------------------------------------------------------------------------------"
+
+              # Generate a script to copy and run on the db2u pod
+              cat > ${BACKUPDB_SH_PATH} << EOF
+                #!/bin/bash
+
+                # Check that connect returns SQL1116N which means BACKUP PENDING state
+                if db2 connect to ${DB2_DBNAME} | grep SQL1116N >/dev/null; then
+                  echo "backupdb.sh: Database connect returning SQL1116N, do backup now"
+                else
+                  echo "backupdb.sh: Database connect not returning SQL1116N, nothing to do, exit now"
+                  exit 0
+                fi
+
+                echo "backupdb.sh: Creating backup folder /mnt/backup"
+                mkdir -p /mnt/backup
+                rc=\$?
+                [ \$rc -ne 0 ] && exit \$rc
+
+                echo "backupdb.sh: db2 force applications"
+                db2 force application all
+                rc=\$?
+                [ \$rc -ne 0 ] && exit \$rc
+
+                echo "backupdb.sh: Turn off comms manager"
+                db2set -null DB2COMM
+                rc=\$?
+                [ \$rc -ne 0 ] && exit \$rc
+
+                echo "backupdb.sh: Deactivate database"
+                db2 deactivate database ${DB2_DBNAME}
+                rc=\$?
+                [ \$rc -ne 0 ] && exit \$rc
+
+                echo "backupdb.sh: db2stop"
+                db2stop force
+                rc=\$?
+                [ \$rc -ne 0 ] && exit \$rc
+
+                echo "backupdb.sh: db2start in admin mode"
+                db2start admin mode restricted access
+                rc=\$?
+                [ \$rc -ne 0 ] && exit \$rc
+
+                # dbstart does not always start straight away, wait 20 seconds
+                sleep 20
+
+                echo "backupdb.sh: db2 backup db ${DB2_DBNAME} on all dbpartitionnums"
+                db2 backup db ${DB2_DBNAME} on all dbpartitionnums to /mnt/backup
+                rc=\$?
+                [ \$rc -ne 0 ] && exit \$rc
+
+                echo "backupdb.sh: db2stop"
+                db2stop force
+                rc=\$?
+                [ \$rc -ne 0 ] && exit \$rc
+
+                echo "backupdb.sh: db2set comms manager"
+                db2set DB2COMM=TCPIP,SSL
+                rc=\$?
+                [ \$rc -ne 0 ] && exit \$rc
+
+                echo "backupdb.sh: db2start"
+                db2start
+                rc=\$?
+                [ \$rc -ne 0 ] && exit \$rc
+              EOF
+              # IMPORTANT: Do not make any changes to the "EOF" line above (including its indentation)
+
+              chmod +x ${BACKUPDB_SH_PATH}
+
+              echo ""
+              echo "Copy ${BACKUPDB_SH_PATH} to ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0"
+              echo "--------------------------------------------------------------------------------"
+              oc cp ${BACKUPDB_SH_PATH} ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:${BACKUPDB_SH_PATH} -c db2u
+              echo ".... rc $?"
+
+              echo ""
+              echo "Executing ${BACKUPDB_SH_PATH} file on ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0"
+              echo "--------------------------------------------------------------------------------"
+              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "${BACKUPDB_SH_PATH} | tee /tmp/backupdb.log" db2inst1
+              echo ".... rc $?"
 
               echo ""
               echo "================================================================================"

--- a/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
+++ b/applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
@@ -149,7 +149,7 @@ spec:
                   # no useful info in return code of this script
 
                   rc=0
-                  oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc 'db2 get db cfg for ${DB2_DBNAME} | grep "(CHNGPGS_THRESH) = 40"' db2inst1 || rc=$?
+                  oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc 'db2 get db cfg for '${DB2_DBNAME}' | grep "(CHNGPGS_THRESH) = 40"' db2inst1 || rc=$?
                   if [[ "$rc" == "0" ]]; then
                     echo "...... success"
                     return 0
@@ -184,7 +184,6 @@ spec:
               export SM_AWS_ACCESS_KEY_ID=$(cat /etc/mas/creds/aws/aws_access_key_id)
               export SM_AWS_SECRET_ACCESS_KEY=$(cat /etc/mas/creds/aws/aws_secret_access_key)
               export SM_AWS_REGION=${REGION_ID}
-              sm_login
              
               echo ""
               echo "================================================================================"
@@ -317,32 +316,27 @@ spec:
                 echo ""
                 echo "Copy ${SETUPDB_SH_PATH} to ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0"
                 echo "--------------------------------------------------------------------------------"
-                oc cp ${SETUPDB_SH_PATH} ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:${SETUPDB_SH_PATH} -c db2u
-                echo ".... rc $?"
+                oc cp ${SETUPDB_SH_PATH} ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:${SETUPDB_SH_PATH} -c db2u || exit $?
 
                 echo ""
                 echo "Executing ${SETUPDB_SH_PATH} file on ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0"
                 echo "--------------------------------------------------------------------------------"
-                oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "${SETUPDB_SH_PATH} | tee /tmp/setupdb.log" db2inst1
-                echo ".... rc $?"
+                oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "${SETUPDB_SH_PATH} | tee /tmp/setupdb.log" db2inst1 || exit $?
 
                 echo ""
                 echo "Creating /mnt/backup/MIRRORLOGPATH in c-${DB2_INSTANCE_NAME}-db2u-0"
                 echo "--------------------------------------------------------------------------------"
-                oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0  -- su -lc "mkdir -p /mnt/backup/MIRRORLOGPATH" db2inst1
-                echo ".... rc $?"
+                oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0  -- su -lc "mkdir -p /mnt/backup/MIRRORLOGPATH" db2inst1 || exit $?
 
                 echo ""
                 echo "Creating /mnt/bludata0/db2/archive_log in c-${DB2_INSTANCE_NAME}-db2u-0"
                 echo "--------------------------------------------------------------------------------"
-                oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0  -- su -lc "mkdir -p /mnt/bludata0/db2/archive_log/" db2inst1
-                echo ".... rc $?"
+                oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0  -- su -lc "mkdir -p /mnt/bludata0/db2/archive_log/" db2inst1 || exit $?
 
                 echo ""
                 echo "Creating /mnt/backup/staging in c-${DB2_INSTANCE_NAME}-db2u-0"
                 echo "--------------------------------------------------------------------------------"
-                oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0  -- su -lc "mkdir -p /mnt/backup/staging" db2inst1
-                echo ".... rc $?"
+                oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0  -- su -lc "mkdir -p /mnt/backup/staging" db2inst1 || exit $?
                   
               fi # [[ "$MAS_APP_ID" == "manage" ]]
 
@@ -434,19 +428,17 @@ spec:
               EOF
               # IMPORTANT: Do not make any changes to the "EOF" line above (including its indentation)
 
-              chmod +x ${BACKUPDB_SH_PATH}
+              chmod +x ${BACKUPDB_SH_PATH} || exit $?
 
               echo ""
               echo "Copy ${BACKUPDB_SH_PATH} to ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0"
               echo "--------------------------------------------------------------------------------"
-              oc cp ${BACKUPDB_SH_PATH} ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:${BACKUPDB_SH_PATH} -c db2u
-              echo ".... rc $?"
+              oc cp ${BACKUPDB_SH_PATH} ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:${BACKUPDB_SH_PATH} -c db2u || exit $?
 
               echo ""
               echo "Executing ${BACKUPDB_SH_PATH} file on ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0"
               echo "--------------------------------------------------------------------------------"
-              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "${BACKUPDB_SH_PATH} | tee /tmp/backupdb.log" db2inst1
-              echo ".... rc $?"
+              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "${BACKUPDB_SH_PATH} | tee /tmp/backupdb.log" db2inst1 || exit $?
 
               echo ""
               echo "================================================================================"
@@ -477,8 +469,8 @@ spec:
               echo ""
               echo "Updating Secrets Manager"
               echo "--------------------------------------------------------------------------------"
-              sm_update_secret ${DB2_CONFIG_SECRET} "{ \"tls_serviceport\": \"${DB2_TLS_SERVICEPORT}\", \"ca_b64\": \"${DB2_CA_PEM}\" }"
-              echo ".... rc $?"
+              sm_login
+              sm_update_secret ${DB2_CONFIG_SECRET} "{ \"tls_serviceport\": \"${DB2_TLS_SERVICEPORT}\", \"ca_b64\": \"${DB2_CA_PEM}\" }" || exit $?
 
 
       restartPolicy: Never

--- a/applications/90-ibm-sync-resources/templates/01-aws-docdb_Secret.yaml
+++ b/applications/90-ibm-sync-resources/templates/01-aws-docdb_Secret.yaml
@@ -13,7 +13,5 @@ stringData:
   docdb_master_password: {{ .Values.docdb.master_password }}
   docdb_master_info: {{ .Values.docdb.master_info }}
   docdb_instance_password: {{ .Values.docdb.instance_password }}
-  docdb_host: {{ .Values.docdb.host }}
-  docdb_port: {{ .Values.docdb.port }}
 type: Opaque
 {{- end }}

--- a/applications/91-ibm-sync-jobs/templates/00-aws-docdb-add-user_Job.yaml
+++ b/applications/91-ibm-sync-jobs/templates/00-aws-docdb-add-user_Job.yaml
@@ -104,7 +104,7 @@ spec:
               echo
 
               mkdir -p ${MAS_CONFIG_DIR}
-              /opt/app-root/src/run-role.sh aws_documentdb_user
+              /opt/app-root/src/run-role.sh aws_documentdb_user || exit $?
 
               # The role should have created a file ${OUTPUT_FILE} containing the username/password it applied
               # Read these so we can set the values in the instance's mongo secret in AWS SM
@@ -137,8 +137,8 @@ spec:
               
 
               source /mascli/functions/gitops_utils
-              sm_login     
-              sm_update_secret $SECRET_NAME_MONGO "{\"info\":\"$DOCDB_MASTER_INFO_ESCAPED\", \"username\":\"$DOCDB_INSTANCE_USERNAME\", \"password\":\"$DOCDB_INSTANCE_PASSWORD\"}"
+              sm_login
+              sm_update_secret $SECRET_NAME_MONGO "{\"info\":\"$DOCDB_MASTER_INFO_ESCAPED\", \"username\":\"$DOCDB_INSTANCE_USERNAME\", \"password\":\"$DOCDB_INSTANCE_PASSWORD\"}" || exit $?
 
       restartPolicy: Never
       serviceAccountName: aws-docdb-user-job

--- a/applications/91-ibm-sync-jobs/templates/00-aws-docdb-add-user_Job.yaml
+++ b/applications/91-ibm-sync-jobs/templates/00-aws-docdb-add-user_Job.yaml
@@ -33,16 +33,6 @@ spec:
             - name: MAS_INSTANCE_ID
               value: "{{ .Values.instance.id }}"
 
-            - name: DOCDB_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: aws-docdb
-                  key: docdb_host
-            - name: DOCDB_PORT
-              valueFrom:
-                secretKeyRef:
-                  name: aws-docdb
-                  key: docdb_port
             - name: DOCDB_MASTER_USERNAME
               valueFrom:
                 secretKeyRef:
@@ -96,6 +86,10 @@ spec:
               export MAS_CONFIG_DIR="/tmp/${MAS_INSTANCE_ID}/aws_documentdb_user"
               OUTPUT_FILE=${MAS_CONFIG_DIR}/docdb-${MAS_INSTANCE_ID}-instance-credentials.yml
               export USER_ACTION="add"
+
+              # Grab one of the hosts/ports out of docdb master info
+              export DOCDB_HOST=$(echo "${DOCDB_MASTER_INFO}" | sed 's/\\n/\n/g' | sed 's/\\"//g' | /usr/bin/yq '.config.hosts[0].host')
+              export DOCDB_PORT=$(echo "${DOCDB_MASTER_INFO}" | sed 's/\\n/\n/g' | /usr/bin/yq '.config.hosts[0].port')
 
               echo "Params:"
               echo "    - MAS_INSTANCE_ID         ................... ${MAS_INSTANCE_ID}"

--- a/applications/91-ibm-sync-jobs/templates/00-aws-docdb-add-user_Job.yaml
+++ b/applications/91-ibm-sync-jobs/templates/00-aws-docdb-add-user_Job.yaml
@@ -13,7 +13,7 @@ metadata:
   name: aws-docdb-add-user-{{ .Values.docdb | toYaml | adler32sum }}
   namespace: mas-{{ .Values.instance.id }}-syncres
   annotations:
-    argocd.argoproj.io/sync-wave: "02"
+    argocd.argoproj.io/sync-wave: "00"
 spec:
   template:
     metadata:

--- a/applications/91-ibm-sync-jobs/templates/00-placeholder_ConfigMap.yaml
+++ b/applications/91-ibm-sync-jobs/templates/00-placeholder_ConfigMap.yaml
@@ -1,0 +1,12 @@
+---
+# This to prevent AVP from complaining about there being no manifests
+# if none of the other resources in this chart end up being rendered
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: placeholder
+  namespace: mas-{{ .Values.instance.id }}-syncres
+  annotations:
+    argocd.argoproj.io/sync-wave: "00"
+data:
+  nodata: ""

--- a/applications/91-ibm-sync-jobs/templates/PostDelete-aws-docdb-remove-user_Job.yaml
+++ b/applications/91-ibm-sync-jobs/templates/PostDelete-aws-docdb-remove-user_Job.yaml
@@ -29,16 +29,6 @@ spec:
             - name: MAS_INSTANCE_ID
               value: "{{ .Values.instance.id }}"
 
-            - name: DOCDB_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: aws-docdb
-                  key: docdb_host
-            - name: DOCDB_PORT
-              valueFrom:
-                secretKeyRef:
-                  name: aws-docdb
-                  key: docdb_port
             - name: DOCDB_MASTER_USERNAME
               valueFrom:
                 secretKeyRef:
@@ -78,6 +68,10 @@ spec:
 
               export MAS_CONFIG_DIR="/tmp/${MAS_INSTANCE_ID}/aws_documentdb_user"
               export USER_ACTION="remove"
+
+              # Grab one of the hosts/ports out of docdb master info
+              export DOCDB_HOST=$(echo "${DOCDB_MASTER_INFO}" | sed 's/\\n/\n/g' | sed 's/\\"//g' | /usr/bin/yq '.config.hosts[0].host')
+              export DOCDB_PORT=$(echo "${DOCDB_MASTER_INFO}" | sed 's/\\n/\n/g' | /usr/bin/yq '.config.hosts[0].port')
 
               echo "Params:"
               echo "    - MAS_INSTANCE_ID         ................... ${MAS_INSTANCE_ID}"

--- a/applications/91-ibm-sync-jobs/templates/PostDelete-aws-docdb-remove-user_Job.yaml
+++ b/applications/91-ibm-sync-jobs/templates/PostDelete-aws-docdb-remove-user_Job.yaml
@@ -39,6 +39,11 @@ spec:
                 secretKeyRef:
                   name: aws-docdb
                   key: docdb_master_password
+            - name: DOCDB_MASTER_INFO
+              valueFrom:
+                secretKeyRef:
+                  name: aws-docdb
+                  key: docdb_master_info
 
             - name: SM_AWS_REGION
               valueFrom:
@@ -85,7 +90,7 @@ spec:
               echo
 
               mkdir -p ${MAS_CONFIG_DIR}
-              /opt/app-root/src/run-role.sh aws_documentdb_user
+              /opt/app-root/src/run-role.sh aws_documentdb_user || exit $?
 
               echo 
               echo "================================================================================"
@@ -107,7 +112,7 @@ spec:
 
               source /mascli/functions/gitops_utils
               sm_login
-              sm_delete_secret "${SECRET_NAME_MONGO}"
+              sm_delete_secret "${SECRET_NAME_MONGO}" || exit $?
 
       restartPolicy: Never
       serviceAccountName: aws-docdb-user-job

--- a/root-applications/ibm-mas-instance-root/templates/120-db2-databases-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-db2-databases-app.yaml
@@ -41,9 +41,6 @@ spec:
         - name: ARGOCD_APP_NAME
           value: "db2dbapp-{{ $value.mas_application_id }}"
   syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
     syncOptions:
       - CreateNamespace=false
       - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-instance-root/templates/120-db2-databases-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-db2-databases-app.yaml
@@ -41,6 +41,9 @@ spec:
         - name: ARGOCD_APP_NAME
           value: "db2dbapp-{{ $value.mas_application_id }}"
   syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
     syncOptions:
       - CreateNamespace=false
       - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-instance-root/templates/90-ibm-sync-resources.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/90-ibm-sync-resources.yaml
@@ -56,8 +56,6 @@ spec:
               master_password: {{ .Values.ibm_sls.docdb_master_password }}
               instance_password: {{ .Values.ibm_sls.sls_mongo_password }}
               master_info: {{ .Values.ibm_sls.docdb_master_info }}
-              host: {{ .Values.ibm_sls.docdb_host }}
-              port: {{ .Values.ibm_sls.docdb_port }}
             {{- end }}
             {{- end }}
         - name: ARGOCD_APP_NAME

--- a/root-applications/ibm-mas-instance-root/templates/91-ibm-sync-jobs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/91-ibm-sync-jobs.yaml
@@ -49,10 +49,8 @@ spec:
             docdb:
               master_username: {{ .Values.ibm_sls.docdb_master_username }}
               master_password: {{ .Values.ibm_sls.docdb_master_password }}
-              master_info: {{ .Values.ibm_sls.docdb_master_info }}
               instance_password: {{ .Values.ibm_sls.sls_mongo_password }}
-              host: {{ .Values.ibm_sls.docdb_host }}
-              port: {{ .Values.ibm_sls.docdb_port }}
+              master_info: {{ .Values.ibm_sls.docdb_master_info }}
             {{- end }}
             {{- end }}
         - name: ARGOCD_APP_NAME

--- a/root-applications/ibm-mas-instance-root/templates/91-ibm-sync-jobs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/91-ibm-sync-jobs.yaml
@@ -59,7 +59,6 @@ spec:
     automated:
       prune: true
       selfHeal: true
-      allowEmpty: true
     syncOptions:
       - CreateNamespace=false
       - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-instance-root/templates/91-ibm-sync-jobs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/91-ibm-sync-jobs.yaml
@@ -59,6 +59,7 @@ spec:
     automated:
       prune: true
       selfHeal: true
+      allowEmpty: true
     syncOptions:
       - CreateNamespace=false
       - RespectIgnoreDifferences=true


### PR DESCRIPTION
The PR combines fixes for two bugs:
- [db2u apply settings not consistent](https://jsw.ibm.com/browse/MASCORE-2427)
- [ibm-sync-resources application fails to deploy when docdb_port is numeric](https://jsw.ibm.com/browse/MASCORE-2563)


## [db2u apply settings not consistent](https://jsw.ibm.com/browse/MASCORE-2427)

We need some custom configuration to be applied to the DB2 Database setup for Manage (otherwise Manage FVTs will fail down the line).

We set these parameters on the DbuCluster CR, but this is not sufficient as the DB2 operator does not (at present) automatically apply them. Instead, as documented [here](https://www.ibm.com/docs/en/cloud-paks/cp-data/4.8.x?topic=administering-changing-db2-warehouse-configuration-settings), a script /db2u/scripts/apply-db2cfg-settings.sh must be executed on one of the db2u pods. However, this does not always seem to work and no indication is given in the output of the script whether it worked or not.

This PR introduces a temporary fix to unblock fvtsaas runs was introduced. This copies the approach used by the [suite_db2_setup_for_manage](https://github.com/ibm-mas/ansible-devops/blob/368ed13480dc66dd046b4b07f443f0607ba2e468/ibm/mas_devops/roles/suite_db2_setup_for_manage/tasks/apply-db2-config-settings.yml) role from ansible-devops, whereby the value of single parameter (CHNGPGS_THRESH) is checked against a known value (40) to see if the script executed successfully (and retry if not).

This is not ideal since it will no longer work as intended if any of the manage db2 database configuration is changed. I have raised https://jsw.ibm.com/browse/MASCORE-2566 to make sure this limitation will be addressed before we start requiring DB2 to be present in our next-gen SaaS offerings.

This PR also fixes some other issues in the postsync job script (need to run the db2 setup for manage before attempting to apply settings, ensure the script exits and fails the job if any of the commands fail).

> NOTE: While testing these changes I upgraded DB2 engine version to DB2 from `s11.5.8.0-cn2` -> `s11.5.9.0-cn1`. This aligns us with fvtstable, and is also the version officially supported by the version of the db2u operator that we are using (`v110509.0`) as specified in the [db2u docs](https://www.ibm.com/docs/en/db2/11.5?topic=deployments-db2-rhos-k8s):
> 
> ![image](https://media.github.ibm.com/user/9052/files/46910cc0-153a-4e0c-9024-aa76d2ad1647)
> 
> The PR to apply this change to fvtsaas is here: https://github.ibm.com/maximoappsuite/saas-envs/pull/47

### Testing

Retry logic being invoked when changes are not applied successfully:
![image](https://github.com/ibm-mas/gitops/assets/7372253/9b874ec6-2d3e-42d0-8488-9e9b43625640)

Successful (monitor database):
![image](https://github.com/ibm-mas/gitops/assets/7372253/3046ae2a-efd5-4b53-87cd-51edcf58e578)

Successful (iot database):
![image](https://github.com/ibm-mas/gitops/assets/7372253/fa23a942-ffe2-422e-9403-9ff4104dd803)
(no attempt is made to apply or verify custom db properties for now - this is safe at the moment since IoT does not specify any custom params. This will be improved in future under https://jsw.ibm.com/browse/MASCORE-2566

## [ibm-sync-resources application fails to deploy when docdb_port is numeric](https://jsw.ibm.com/browse/MASCORE-2563)

The issue is fixed by removing the redundant `docdb_port` (and `docdb_host`) parameters from the syncjob charts and obtaining this information from the `docdb_master_info` YAML instead.

This PR also fixes an issue where AVP would throw an error for the sync-jobs application when it contains no manifests (which it may not, if docdb is not configured). It fixes it by simply adding in a placeholder configmap that is always rendered.

### Testing

On create:

![image](https://github.com/ibm-mas/gitops/assets/7372253/217c38c8-00a4-435b-a294-96905b7c8fd3)

![image](https://github.com/ibm-mas/gitops/assets/7372253/910c1450-92b3-43e7-b465-c8f0c293e225)

On delete:
![image](https://github.com/ibm-mas/gitops/assets/7372253/3ceb0d1d-cfbf-402b-813c-8b08072d5f33)

sync-jobs application syncing successfully despite there being no docdb config:
![image](https://github.com/ibm-mas/gitops/assets/7372253/c2987e87-3a08-400e-a856-c491103b4eb0)


