### PR TITLE
 [minor] [mascore-2417] Add support for Manage customizationList 

### DIFF
--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/01-ibm-manage_customization_archive_secrets.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/01-ibm-manage_customization_archive_secrets.yaml
@@ -1,0 +1,18 @@
+{{- if (or (eq $.Values.mas_app_id "manage") (eq $.Values.mas_app_id "health")) }}
+{{- range $key, $value := $.Values.customization_archive_secret_names }}
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "600"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  name: {{ $value.secret_name }}
+  namespace: mas-{{ $.Values.mas_instance_id }}-manage
+stringData:
+  password: {{ $value.password }}
+  username: {{ $value.username }}
+type: Opaque
+{{- end }}
+{{- end }}
+

--- a/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
@@ -60,7 +60,7 @@ spec:
             mas_app_namespace: "{{ $value.mas_app_namespace }}"
             mas_app_ws_apiversion: "{{ $value.mas_app_ws_apiversion }}"
             mas_app_ws_kind: "{{ $value.mas_app_ws_kind }}"
-            mas_appws_spec: {{ $value.mas_appws_spec | toYaml | nindent 14 }}
+            mas_appws_spec: {{ $value.mas_appws_spec | toYaml | indent 14 }}
 
             mas_manual_cert_mgmt: "{{ $value.mas_manual_cert_mgmt }}"
             {{- if eq $value.mas_manual_cert_mgmt true }}
@@ -73,11 +73,15 @@ spec:
               {{ $value.tls_key }}
             {{- end }}
             {{- if (or (eq $value.mas_app_id "manage") (eq $value.mas_app_id "health")) }}
-            mas_app_server_bundles_combined_add_server_config: {{ $value.mas_app_server_bundles_combined_add_server_config | toYaml | nindent 14 }}
+            mas_app_server_bundles_combined_add_server_config: {{ $value.mas_app_server_bundles_combined_add_server_config | toYaml | indent 14 }}
+            {{- end }}
+
+            {{- if (or (eq $value.mas_app_id "manage") (eq $value.mas_app_id "health")) }}
+            customization_archive_secret_names: {{ $value.customization_archive_secret_names | toYaml | indent 14 }}
             {{- end }}
 
             {{- if eq $value.mas_app_id "assist" }}
-            wd_yaml: {{ $value.wd_yaml | toYaml | nindent 14 }}
+            wd_yaml: {{ $value.wd_yaml | toYaml | indent 14 }}
             cpd_admin_password: "{{ $value.cpd_admin_password }}"
             cpd_admin_username: "{{ $value.cpd_admin_username }}"
             {{- end }}

--- a/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
@@ -72,8 +72,12 @@ spec:
             tls_key: |
               {{ $value.tls_key }}
             {{- end }}
+
             {{- if (or (eq $value.mas_app_id "manage") (eq $value.mas_app_id "health")) }}
             mas_app_server_bundles_combined_add_server_config: {{ $value.mas_app_server_bundles_combined_add_server_config | toYaml | nindent 14 }}
+
+            customization_archive_secret_names: {{ $value.customization_archive_secret_names | toYaml | nindent 14 }}
+
             {{- end }}
 
             {{- if eq $value.mas_app_id "assist" }}

--- a/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
@@ -76,9 +76,7 @@ spec:
             {{- if (or (eq $value.mas_app_id "manage") (eq $value.mas_app_id "health")) }}
             mas_app_server_bundles_combined_add_server_config: {{ $value.mas_app_server_bundles_combined_add_server_config | toYaml | nindent 14 }}
 
-
             customization_archive_secret_names: {{ $value.customization_archive_secret_names | toYaml | nindent 14 }}
-
 
             {{- end }}
 

--- a/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
@@ -60,7 +60,7 @@ spec:
             mas_app_namespace: "{{ $value.mas_app_namespace }}"
             mas_app_ws_apiversion: "{{ $value.mas_app_ws_apiversion }}"
             mas_app_ws_kind: "{{ $value.mas_app_ws_kind }}"
-            mas_appws_spec: {{ $value.mas_appws_spec | toYaml | indent 14 }}
+            mas_appws_spec: {{ $value.mas_appws_spec | toYaml | nindent 14 }}
 
             mas_manual_cert_mgmt: "{{ $value.mas_manual_cert_mgmt }}"
             {{- if eq $value.mas_manual_cert_mgmt true }}
@@ -73,15 +73,11 @@ spec:
               {{ $value.tls_key }}
             {{- end }}
             {{- if (or (eq $value.mas_app_id "manage") (eq $value.mas_app_id "health")) }}
-            mas_app_server_bundles_combined_add_server_config: {{ $value.mas_app_server_bundles_combined_add_server_config | toYaml | indent 14 }}
-            {{- end }}
-
-            {{- if (or (eq $value.mas_app_id "manage") (eq $value.mas_app_id "health")) }}
-            customization_archive_secret_names: {{ $value.customization_archive_secret_names | toYaml | indent 14 }}
+            mas_app_server_bundles_combined_add_server_config: {{ $value.mas_app_server_bundles_combined_add_server_config | toYaml | nindent 14 }}
             {{- end }}
 
             {{- if eq $value.mas_app_id "assist" }}
-            wd_yaml: {{ $value.wd_yaml | toYaml | indent 14 }}
+            wd_yaml: {{ $value.wd_yaml | toYaml | nindent 14 }}
             cpd_admin_password: "{{ $value.cpd_admin_password }}"
             cpd_admin_username: "{{ $value.cpd_admin_username }}"
             {{- end }}

--- a/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
@@ -73,7 +73,7 @@ spec:
               {{ $value.tls_key }}
             {{- end }}
             {{- if (or (eq $value.mas_app_id "manage") (eq $value.mas_app_id "health")) }}
-            mas_app_server_bundles_combined_add_server_config: {{ $value.mas_app_server_bundles_combined_add_server_config }}
+            mas_app_server_bundles_combined_add_server_config: {{ $value.mas_app_server_bundles_combined_add_server_config | toYaml | nindent 14 }}
             {{- end }}
 
             {{- if eq $value.mas_app_id "assist" }}


### PR DESCRIPTION
Issue: https://jsw.ibm.com/browse/MASCORE-2417?filter=-1

What changed in this PR:

Added support to read secretName from manage mas_appws_spec, and created K8S secret.
mas_appws_spec will only have the secret name.
The actual secret with the username and password will be pre-created by SRE team following the below naming convention. 

`arn:aws:secretsmanager:<<region>>:<<aws_account>>:secret:<<account>>/<<cluster>>/<<mas_instance>/<<secret_name>>
`

The ManageWorkspace CR can have a customizationList section like this:

```
    customizationList:
      - customizationArchiveCredentials:
          secretName: masdev-manage-cl0--cac--sn
        customizationArchiveName: fvtcustomarchive
        customizationArchiveUrl: >-
          https://na.artifactory.swg-devops.com/artifactory/wiotp-generic-release/maximoappsuite/fvt-ibm-mas-manage/latest/fvt-manage-custom-archive-latest.zip
```


