### PR TITLE
Fix MAS Config CRs deletion hangs if Suite is deleted at the same time

### DIFF
--- a/instance-applications/130-ibm-db2u-jdbc-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-db2u-jdbc-config/templates/postdelete-delete-cr.yaml
@@ -90,14 +90,6 @@ spec:
                 return_code=$?
                 set -e
 
-                if [ $return_code -ne 0 ]; then
-                  echo "oc delete timed out after 300s, forcing delete by removing finalizers"
-                  echo "oc patch $RESOURCE -n $NAMESPACE"
-
-                  # NOTE: set -e, so job will exit if this fails (which is what we want)
-                  oc patch $RESOURCE -n $NAMESPACE --type="json" -p '[{"op": "remove", "path":"/metadata/finalizers"}]' 2>/dev/null
-                fi
-
                 echo "Verify that resource $RESOURCE is now absent in namespace $NAMESPACE "
                 # don't want a non-zero rc from oc delete to cause the job to fail
                 # so, temporarily set +e

--- a/instance-applications/130-ibm-kafka-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-kafka-config/templates/postdelete-delete-cr.yaml
@@ -90,14 +90,6 @@ spec:
                 return_code=$?
                 set -e
 
-                if [ $return_code -ne 0 ]; then
-                  echo "oc delete timed out after 300s, forcing delete by removing finalizers"
-                  echo "oc patch $RESOURCE -n $NAMESPACE"
-
-                  # NOTE: set -e, so job will exit if this fails (which is what we want)
-                  oc patch $RESOURCE -n $NAMESPACE --type="json" -p '[{"op": "remove", "path":"/metadata/finalizers"}]' 2>/dev/null
-                fi
-
                 echo "Verify that resource $RESOURCE is now absent in namespace $NAMESPACE "
                 # don't want a non-zero rc from oc delete to cause the job to fail
                 # so, temporarily set +e

--- a/instance-applications/130-ibm-mas-bas-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-mas-bas-config/templates/postdelete-delete-cr.yaml
@@ -90,14 +90,6 @@ spec:
                 return_code=$?
                 set -e
 
-                if [ $return_code -ne 0 ]; then
-                  echo "oc delete timed out after 300s, forcing delete by removing finalizers"
-                  echo "oc patch $RESOURCE -n $NAMESPACE"
-
-                  # NOTE: set -e, so job will exit if this fails (which is what we want)
-                  oc patch $RESOURCE -n $NAMESPACE --type="json" -p '[{"op": "remove", "path":"/metadata/finalizers"}]' 2>/dev/null
-                fi
-
                 echo "Verify that resource $RESOURCE is now absent in namespace $NAMESPACE "
                 # don't want a non-zero rc from oc delete to cause the job to fail
                 # so, temporarily set +e

--- a/instance-applications/130-ibm-mas-idp-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-mas-idp-config/templates/postdelete-delete-cr.yaml
@@ -90,14 +90,6 @@ spec:
                 return_code=$?
                 set -e
 
-                if [ $return_code -ne 0 ]; then
-                  echo "oc delete timed out after 300s, forcing delete by removing finalizers"
-                  echo "oc patch $RESOURCE -n $NAMESPACE"
-
-                  # NOTE: set -e, so job will exit if this fails (which is what we want)
-                  oc patch $RESOURCE -n $NAMESPACE --type="json" -p '[{"op": "remove", "path":"/metadata/finalizers"}]' 2>/dev/null
-                fi
-
                 echo "Verify that resource $RESOURCE is now absent in namespace $NAMESPACE "
                 # don't want a non-zero rc from oc delete to cause the job to fail
                 # so, temporarily set +e

--- a/instance-applications/130-ibm-mas-mongo-config/templates/01-mongo-credentials_Secret.yaml
+++ b/instance-applications/130-ibm-mas-mongo-config/templates/01-mongo-credentials_Secret.yaml
@@ -1,4 +1,3 @@
-{{- if not .Values.delete }}
 ---
 kind: Secret
 apiVersion: v1
@@ -11,4 +10,3 @@ type: Opaque
 stringData:
   username: "{{ .Values.username }}"
   password: "{{ .Values.password }}"
-{{- end }}

--- a/instance-applications/130-ibm-mas-mongo-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-mas-mongo-config/templates/postdelete-delete-cr.yaml
@@ -90,14 +90,6 @@ spec:
                 return_code=$?
                 set -e
 
-                if [ $return_code -ne 0 ]; then
-                  echo "oc delete timed out after 300s, forcing delete by removing finalizers"
-                  echo "oc patch $RESOURCE -n $NAMESPACE"
-
-                  # NOTE: set -e, so job will exit if this fails (which is what we want)
-                  oc patch $RESOURCE -n $NAMESPACE --type="json" -p '[{"op": "remove", "path":"/metadata/finalizers"}]' 2>/dev/null
-                fi
-
                 echo "Verify that resource $RESOURCE is now absent in namespace $NAMESPACE "
                 # don't want a non-zero rc from oc delete to cause the job to fail
                 # so, temporarily set +e

--- a/instance-applications/130-ibm-mas-sls-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-mas-sls-config/templates/postdelete-delete-cr.yaml
@@ -90,14 +90,6 @@ spec:
                 return_code=$?
                 set -e
 
-                if [ $return_code -ne 0 ]; then
-                  echo "oc delete timed out after 300s, forcing delete by removing finalizers"
-                  echo "oc patch $RESOURCE -n $NAMESPACE"
-
-                  # NOTE: set -e, so job will exit if this fails (which is what we want)
-                  oc patch $RESOURCE -n $NAMESPACE --type="json" -p '[{"op": "remove", "path":"/metadata/finalizers"}]' 2>/dev/null
-                fi
-
                 echo "Verify that resource $RESOURCE is now absent in namespace $NAMESPACE "
                 # don't want a non-zero rc from oc delete to cause the job to fail
                 # so, temporarily set +e

--- a/instance-applications/130-ibm-mas-smtp-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-mas-smtp-config/templates/postdelete-delete-cr.yaml
@@ -90,14 +90,6 @@ spec:
                 return_code=$?
                 set -e
 
-                if [ $return_code -ne 0 ]; then
-                  echo "oc delete timed out after 300s, forcing delete by removing finalizers"
-                  echo "oc patch $RESOURCE -n $NAMESPACE"
-
-                  # NOTE: set -e, so job will exit if this fails (which is what we want)
-                  oc patch $RESOURCE -n $NAMESPACE --type="json" -p '[{"op": "remove", "path":"/metadata/finalizers"}]' 2>/dev/null
-                fi
-
                 echo "Verify that resource $RESOURCE is now absent in namespace $NAMESPACE "
                 # don't want a non-zero rc from oc delete to cause the job to fail
                 # so, temporarily set +e

--- a/instance-applications/130-ibm-objectstorage-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-objectstorage-config/templates/postdelete-delete-cr.yaml
@@ -90,14 +90,6 @@ spec:
                 return_code=$?
                 set -e
 
-                if [ $return_code -ne 0 ]; then
-                  echo "oc delete timed out after 300s, forcing delete by removing finalizers"
-                  echo "oc patch $RESOURCE -n $NAMESPACE"
-
-                  # NOTE: set -e, so job will exit if this fails (which is what we want)
-                  oc patch $RESOURCE -n $NAMESPACE --type="json" -p '[{"op": "remove", "path":"/metadata/finalizers"}]' 2>/dev/null
-                fi
-
                 echo "Verify that resource $RESOURCE is now absent in namespace $NAMESPACE "
                 # don't want a non-zero rc from oc delete to cause the job to fail
                 # so, temporarily set +e

--- a/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-app.yaml
@@ -16,6 +16,7 @@ metadata:
     notifications.argoproj.io/subscribe.on-sync-failed.workspace1: {{ .Values.notifications.slack_channel_id }}
     notifications.argoproj.io/subscribe.on-sync-succeeded.workspace1: {{ .Values.notifications.slack_channel_id }}
     {{- end }}
+    argocd.argoproj.io/sync-options: PruneLast=true
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:


### PR DESCRIPTION
This issue was being caused by the fact that the suite and the suite-config apps are all in syncwave 130. This is necessary since the suite app depends on system mongo/bas/sls suite-config apps to become healthy when standing up a new MAS instance. 

However, on teardown, this meant that the suite app is pruned at the same time as the suite-config apps, meaning the suite-config entity managers were being torn down before processing completed on the suite-config CR finalizers and causing deletion of the CR to hang indefinitely.

This PR solves this issue by annotation the suite app with `argocd.argoproj.io/sync-options: PruneLast=true`. This causes ArgoCD to issue deletion of the suite app (and thus the suite CR) only once the suite-config app deletions have completed.

Note: this will likely only work with ArgoCD version > 2.11 due to this [commit](https://github.com/argoproj/argo-cd/commit/e5c88c914b73e455f3f36dc24583e65c743da792) that resolves an issue where resources are pruned all at once instead of in reverse syncwave order.

I've also removed the "hack" that patches out the finalizers on the suite-config CRs in case deletion fails. This is not something we should be doing. If a deletion hangs, manual intervention is required to make sure all claimed resources are cleaned up properly.

https://jsw.ibm.com/browse/MASCORE-2122

#### Testing

MAS instance with various suite-configs installed:
![image](https://github.com/ibm-mas/gitops/assets/7372253/8dee3dff-9b42-48b3-916d-f43f794e79b1)


Delete suite+configs+workspace in a single commit:
![image](https://github.com/ibm-mas/gitops/assets/7372253/6710e61f-be03-445e-9355-2931cd010192)



All resources are marked for pruning, workspace (wave 200) prune is actioned first:
![image](https://github.com/ibm-mas/gitops/assets/7372253/687dd06e-1956-48c7-acea-848db65c009a)

Next, suite-config apps (wave 130) prunes are actioned:
![image](https://github.com/ibm-mas/gitops/assets/7372253/8cdafd91-80dd-495c-87bd-1abbbe67df98)

Once (and only once) suite-config apps have been pruned successfully, suite (wave 130) prune is actioned:
![image](https://github.com/ibm-mas/gitops/assets/7372253/170aa422-df01-488d-8d63-1cbc24bc2e05)


Suite is pruned successfully:
![image](https://github.com/ibm-mas/gitops/assets/7372253/b402717b-1ba3-47e0-8967-875ceda43b8b)


