### PR TITLE
Use shorter name for ArgoCD app names

### DIFF
--- a/root-applications/ibm-mas-account-root/templates/000-cluster-appset.yaml
+++ b/root-applications/ibm-mas-account-root/templates/000-cluster-appset.yaml
@@ -9,7 +9,6 @@ metadata:
   labels:
     cloud: aws
     environment: '{{ .Values.account.id }}'
-    region: '{{ .Values.region.id }}'
   annotations:
     argocd.argoproj.io/sync-wave: "000"
 spec:

--- a/root-applications/ibm-mas-account-root/templates/000-cluster-appset.yaml
+++ b/root-applications/ibm-mas-account-root/templates/000-cluster-appset.yaml
@@ -6,6 +6,10 @@ kind: ApplicationSet
 metadata:
   name: cluster-appset.{{ .Values.account.id }}
   namespace: {{ .Values.argo.namespace }}
+  labels:
+    cloud: aws
+    environment: '{{ .Values.account.id }}'
+    region: '{{ .Values.region.id }}'
   annotations:
     argocd.argoproj.io/sync-wave: "000"
 spec:
@@ -57,7 +61,7 @@ spec:
               - path: "{{ .Values.account.id }}/*/*/nvidia-gpu-operator.yaml"
   template:
     metadata:
-      name: "cluster.{{ .Values.account.id }}.{{ `{{.region.id}}` }}.{{ `{{.cluster.id}}` }}"
+      name: "cluster.{{ `{{.cluster.id}}` }}"
       labels:
         cloud: aws
         environment: '{{ .Values.account.id }}'

--- a/root-applications/ibm-mas-account-root/templates/000-cluster-appset.yaml
+++ b/root-applications/ibm-mas-account-root/templates/000-cluster-appset.yaml
@@ -7,7 +7,6 @@ metadata:
   name: cluster-appset.{{ .Values.account.id }}
   namespace: {{ .Values.argo.namespace }}
   labels:
-    cloud: aws
     environment: '{{ .Values.account.id }}'
   annotations:
     argocd.argoproj.io/sync-wave: "000"
@@ -62,7 +61,6 @@ spec:
     metadata:
       name: "cluster.{{ `{{.cluster.id}}` }}"
       labels:
-        cloud: aws
         environment: '{{ .Values.account.id }}'
         region: '{{ `{{ .region.id }}` }}'
         cluster: '{{ `{{ .cluster.id }}` }}'

--- a/root-applications/ibm-mas-account-root/templates/000-cluster-appset.yaml
+++ b/root-applications/ibm-mas-account-root/templates/000-cluster-appset.yaml
@@ -26,37 +26,37 @@ spec:
               repoURL: "{{ .Values.generator.repo_url }}"
               revision: "{{ .Values.generator.revision }}"
               files:
-              - path: "{{ .Values.account.id }}/*/*/ibm-mas-cluster-base.yaml"
+              - path: "{{ .Values.account.id }}/*/ibm-mas-cluster-base.yaml"
           - git:
               repoURL: "{{ .Values.generator.repo_url }}"
               revision: "{{ .Values.generator.revision }}"
               files:
-              - path: "{{ .Values.account.id }}/*/*/ibm-operator-catalog.yaml"
+              - path: "{{ .Values.account.id }}/*/ibm-operator-catalog.yaml"
           - git:
               repoURL: "{{ .Values.generator.repo_url }}"
               revision: "{{ .Values.generator.revision }}"
               files:
-              - path: "{{ .Values.account.id }}/*/*/redhat-cert-manager.yaml"
+              - path: "{{ .Values.account.id }}/*/redhat-cert-manager.yaml"
           - git:
               repoURL: "{{ .Values.generator.repo_url }}"
               revision: "{{ .Values.generator.revision }}"
               files:
-              - path: "{{ .Values.account.id }}/*/*/ibm-dro.yaml"
+              - path: "{{ .Values.account.id }}/*/ibm-dro.yaml"
           - git:
               repoURL: "{{ .Values.generator.repo_url }}"
               revision: "{{ .Values.generator.revision }}"
               files:
-              - path: "{{ .Values.account.id }}/*/*/ibm-db2u.yaml"
+              - path: "{{ .Values.account.id }}/*/ibm-db2u.yaml"
           - git:
               repoURL: "{{ .Values.generator.repo_url }}"
               revision: "{{ .Values.generator.revision }}"
               files:
-              - path: "{{ .Values.account.id }}/*/*/cis-compliance.yaml"
+              - path: "{{ .Values.account.id }}/*/cis-compliance.yaml"
           - git:
               repoURL: "{{ .Values.generator.repo_url }}"
               revision: "{{ .Values.generator.revision }}"
               files:
-              - path: "{{ .Values.account.id }}/*/*/nvidia-gpu-operator.yaml"
+              - path: "{{ .Values.account.id }}/*/nvidia-gpu-operator.yaml"
   template:
     metadata:
       name: "cluster.{{ `{{.cluster.id}}` }}"

--- a/root-applications/ibm-mas-cluster-root/templates/000-ibm-operator-catalog-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/000-ibm-operator-catalog-app.yaml
@@ -7,7 +7,6 @@ metadata:
   name: operator-catalog.{{ .Values.cluster.id }}
   namespace: {{ .Values.argo.namespace }}
   labels:
-    cloud: aws
     environment: '{{ .Values.account.id }}'
     region: '{{ .Values.region.id }}'
     cluster: '{{ .Values.cluster.id }}'

--- a/root-applications/ibm-mas-cluster-root/templates/000-ibm-operator-catalog-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/000-ibm-operator-catalog-app.yaml
@@ -4,8 +4,13 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: operator-catalog.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}
+  name: operator-catalog.{{ .Values.cluster.id }}
   namespace: {{ .Values.argo.namespace }}
+  labels:
+    cloud: aws
+    environment: '{{ .Values.account.id }}'
+    region: '{{ .Values.region.id }}'
+    cluster: '{{ .Values.cluster.id }}'
   annotations:
     argocd.argoproj.io/sync-wave: "000"
     healthCheckTimeout: "1800"

--- a/root-applications/ibm-mas-cluster-root/templates/010-ibm-redhat-cert-manager-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/010-ibm-redhat-cert-manager-app.yaml
@@ -7,7 +7,6 @@ metadata:
   name: redhat-cert-manager.{{ .Values.cluster.id }}
   namespace: {{ .Values.argo.namespace }}
   labels:
-    cloud: aws
     environment: '{{ .Values.account.id }}'
     region: '{{ .Values.region.id }}'
     cluster: '{{ .Values.cluster.id }}'

--- a/root-applications/ibm-mas-cluster-root/templates/010-ibm-redhat-cert-manager-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/010-ibm-redhat-cert-manager-app.yaml
@@ -4,8 +4,13 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: redhat-cert-manager.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}
+  name: redhat-cert-manager.{{ .Values.cluster.id }}
   namespace: {{ .Values.argo.namespace }}
+  labels:
+    cloud: aws
+    environment: '{{ .Values.account.id }}'
+    region: '{{ .Values.region.id }}'
+    cluster: '{{ .Values.cluster.id }}'
   annotations:
     argocd.argoproj.io/sync-wave: "010"
     healthCheckTimeout: "1800"

--- a/root-applications/ibm-mas-cluster-root/templates/020-ibm-dro-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/020-ibm-dro-app.yaml
@@ -7,7 +7,6 @@ metadata:
   name: dro.{{ .Values.cluster.id }}
   namespace: {{ .Values.argo.namespace }}
   labels:
-    cloud: aws
     environment: '{{ .Values.account.id }}'
     region: '{{ .Values.region.id }}'
     cluster: '{{ .Values.cluster.id }}'

--- a/root-applications/ibm-mas-cluster-root/templates/020-ibm-dro-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/020-ibm-dro-app.yaml
@@ -4,8 +4,13 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: dro.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}
+  name: dro.{{ .Values.cluster.id }}
   namespace: {{ .Values.argo.namespace }}
+  labels:
+    cloud: aws
+    environment: '{{ .Values.account.id }}'
+    region: '{{ .Values.region.id }}'
+    cluster: '{{ .Values.cluster.id }}'
   annotations:
     argocd.argoproj.io/sync-wave: "020"
     healthCheckTimeout: "1800"

--- a/root-applications/ibm-mas-cluster-root/templates/040-cis-compliance-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/040-cis-compliance-app.yaml
@@ -4,8 +4,13 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: cis-compliance.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}
+  name: cis-compliance.{{ .Values.cluster.id }}
   namespace: {{ .Values.argo.namespace }}
+  labels:
+    cloud: aws
+    environment: '{{ .Values.account.id }}'
+    region: '{{ .Values.region.id }}'
+    cluster: '{{ .Values.cluster.id }}'
   annotations:
     argocd.argoproj.io/sync-wave: "040"
     healthCheckTimeout: "1800"

--- a/root-applications/ibm-mas-cluster-root/templates/040-cis-compliance-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/040-cis-compliance-app.yaml
@@ -7,7 +7,6 @@ metadata:
   name: cis-compliance.{{ .Values.cluster.id }}
   namespace: {{ .Values.argo.namespace }}
   labels:
-    cloud: aws
     environment: '{{ .Values.account.id }}'
     region: '{{ .Values.region.id }}'
     cluster: '{{ .Values.cluster.id }}'

--- a/root-applications/ibm-mas-cluster-root/templates/041-cis-compliance-cleanup.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/041-cis-compliance-cleanup.yaml
@@ -4,8 +4,12 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: cis-compliance-cleanup.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}
+  name: cis-compliance-cleanup.{{ .Values.cluster.id }}
   namespace: {{ .Values.argo.namespace }}
+  labels:
+    environment: '{{ .Values.account.id }}'
+    region: '{{ .Values.region.id }}'
+    cluster: '{{ .Values.cluster.id }}'
   annotations:
     argocd.argoproj.io/sync-wave: "041"
     healthCheckTimeout: "1800"

--- a/root-applications/ibm-mas-cluster-root/templates/050-nvidia-gpu-operator-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/050-nvidia-gpu-operator-app.yaml
@@ -7,7 +7,6 @@ metadata:
   name: nvidia-gpu.{{ .Values.cluster.id }}
   namespace: {{ .Values.argo.namespace }}
   labels:
-    cloud: aws
     environment: '{{ .Values.account.id }}'
     region: '{{ .Values.region.id }}'
     cluster: '{{ .Values.cluster.id }}'

--- a/root-applications/ibm-mas-cluster-root/templates/050-nvidia-gpu-operator-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/050-nvidia-gpu-operator-app.yaml
@@ -4,8 +4,13 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: nvidia-gpu.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}
+  name: nvidia-gpu.{{ .Values.cluster.id }}
   namespace: {{ .Values.argo.namespace }}
+  labels:
+    cloud: aws
+    environment: '{{ .Values.account.id }}'
+    region: '{{ .Values.region.id }}'
+    cluster: '{{ .Values.cluster.id }}'
   annotations:
     argocd.argoproj.io/sync-wave: "050"
     healthCheckTimeout: "1800"

--- a/root-applications/ibm-mas-cluster-root/templates/060-ibm-db2u-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/060-ibm-db2u-app.yaml
@@ -7,7 +7,6 @@ metadata:
   name: db2u.{{ .Values.cluster.id }}
   namespace: {{ .Values.argo.namespace }}
   labels:
-    cloud: aws
     environment: '{{ .Values.account.id }}'
     region: '{{ .Values.region.id }}'
     cluster: '{{ .Values.cluster.id }}'

--- a/root-applications/ibm-mas-cluster-root/templates/060-ibm-db2u-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/060-ibm-db2u-app.yaml
@@ -4,8 +4,13 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: db2u.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}
+  name: db2u.{{ .Values.cluster.id }}
   namespace: {{ .Values.argo.namespace }}
+  labels:
+    cloud: aws
+    environment: '{{ .Values.account.id }}'
+    region: '{{ .Values.region.id }}'
+    cluster: '{{ .Values.cluster.id }}'
   annotations:
     argocd.argoproj.io/sync-wave: "060"
     healthCheckTimeout: "1800"

--- a/root-applications/ibm-mas-cluster-root/templates/099-instance-appset.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/099-instance-appset.yaml
@@ -4,8 +4,13 @@
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
-  name: instance-appset.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}
+  name: instance-appset.{{ .Values.cluster.id }}
   namespace: {{ .Values.argo.namespace }}
+  labels:
+    cloud: aws
+    environment: '{{ .Values.account.id }}'
+    region: '{{ .Values.region.id }}'
+    cluster: '{{ .Values.cluster.id }}'
   annotations:
     argocd.argoproj.io/sync-wave: "099"
 spec:
@@ -97,7 +102,7 @@ spec:
               - path: "{{ .Values.account.id }}/{{ .Values.region.id }}/{{ .Values.cluster.id }}/*/ibm-mas-masapp-configs.yaml"
   template:
     metadata:
-      name: "instance.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}.{{ `{{.instance.id}}` }}"
+      name: "instance.{{ .Values.cluster.id }}.{{ `{{.instance.id}}` }}"
       labels:
         cloud: aws
         environment: '{{ .Values.account.id }}'

--- a/root-applications/ibm-mas-cluster-root/templates/099-instance-appset.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/099-instance-appset.yaml
@@ -7,7 +7,6 @@ metadata:
   name: instance-appset.{{ .Values.cluster.id }}
   namespace: {{ .Values.argo.namespace }}
   labels:
-    cloud: aws
     environment: '{{ .Values.account.id }}'
     region: '{{ .Values.region.id }}'
     cluster: '{{ .Values.cluster.id }}'
@@ -104,7 +103,6 @@ spec:
     metadata:
       name: "instance.{{ .Values.cluster.id }}.{{ `{{.instance.id}}` }}"
       labels:
-        cloud: aws
         environment: '{{ .Values.account.id }}'
         region: '{{ .Values.region.id }}'
         cluster: '{{ .Values.cluster.id }}'

--- a/root-applications/ibm-mas-cluster-root/templates/099-instance-appset.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/099-instance-appset.yaml
@@ -28,77 +28,77 @@ spec:
               repoURL: "{{ .Values.generator.repo_url }}"
               revision: "{{ .Values.generator.revision }}"
               files:
-              - path: "{{ .Values.account.id }}/{{ .Values.region.id }}/{{ .Values.cluster.id }}/*/ibm-mas-instance-base.yaml"
+              - path: "{{ .Values.account.id }}/{{ .Values.cluster.id }}/*/ibm-mas-instance-base.yaml"
           - git:
               repoURL: "{{ .Values.generator.repo_url }}"
               revision: "{{ .Values.generator.revision }}"
               files:
-              - path: "{{ .Values.account.id }}/{{ .Values.region.id }}/{{ .Values.cluster.id }}/*/ibm-mas-suite.yaml"
+              - path: "{{ .Values.account.id }}/{{ .Values.cluster.id }}/*/ibm-mas-suite.yaml"
           - git:
               repoURL: "{{ .Values.generator.repo_url }}"
               revision: "{{ .Values.generator.revision }}"
               files:
-              - path: "{{ .Values.account.id }}/{{ .Values.region.id }}/{{ .Values.cluster.id }}/*/ibm-sls.yaml"
+              - path: "{{ .Values.account.id }}/{{ .Values.cluster.id }}/*/ibm-sls.yaml"
           - git:
               repoURL: "{{ .Values.generator.repo_url }}"
               revision: "{{ .Values.generator.revision }}"
               files:
-              - path: "{{ .Values.account.id }}/{{ .Values.region.id }}/{{ .Values.cluster.id }}/*/ibm-mas-workspaces.yaml"
+              - path: "{{ .Values.account.id }}/{{ .Values.cluster.id }}/*/ibm-mas-workspaces.yaml"
           - git:
               repoURL: "{{ .Values.generator.repo_url }}"
               revision: "{{ .Values.generator.revision }}"
               files:
-              - path: "{{ .Values.account.id }}/{{ .Values.region.id }}/{{ .Values.cluster.id }}/*/ibm-mas-suite-configs.yaml"
+              - path: "{{ .Values.account.id }}/{{ .Values.cluster.id }}/*/ibm-mas-suite-configs.yaml"
           - git:
               repoURL: "{{ .Values.generator.repo_url }}"
               revision: "{{ .Values.generator.revision }}"
               files:
-              - path: "{{ .Values.account.id }}/{{ .Values.region.id }}/{{ .Values.cluster.id }}/*/ibm-db2u-databases.yaml"
+              - path: "{{ .Values.account.id }}/{{ .Values.cluster.id }}/*/ibm-db2u-databases.yaml"
           - git:
               repoURL: "{{ .Values.generator.repo_url }}"
               revision: "{{ .Values.generator.revision }}"
               files:
-              - path: "{{ .Values.account.id }}/{{ .Values.region.id }}/{{ .Values.cluster.id }}/*/ibm-mas-masapp-manage-install.yaml"
+              - path: "{{ .Values.account.id }}/{{ .Values.cluster.id }}/*/ibm-mas-masapp-manage-install.yaml"
           - git:
               repoURL: "{{ .Values.generator.repo_url }}"
               revision: "{{ .Values.generator.revision }}"
               files:
-              - path: "{{ .Values.account.id }}/{{ .Values.region.id }}/{{ .Values.cluster.id }}/*/ibm-mas-masapp-iot-install.yaml"
+              - path: "{{ .Values.account.id }}/{{ .Values.cluster.id }}/*/ibm-mas-masapp-iot-install.yaml"
           - git:
               repoURL: "{{ .Values.generator.repo_url }}"
               revision: "{{ .Values.generator.revision }}"
               files:
-              - path: "{{ .Values.account.id }}/{{ .Values.region.id }}/{{ .Values.cluster.id }}/*/ibm-mas-masapp-assist-install.yaml"
+              - path: "{{ .Values.account.id }}/{{ .Values.cluster.id }}/*/ibm-mas-masapp-assist-install.yaml"
           - git:
               repoURL: "{{ .Values.generator.repo_url }}"
               revision: "{{ .Values.generator.revision }}"
               files:
-              - path: "{{ .Values.account.id }}/{{ .Values.region.id }}/{{ .Values.cluster.id }}/*/ibm-mas-masapp-visualinspection-install.yaml"
+              - path: "{{ .Values.account.id }}/{{ .Values.cluster.id }}/*/ibm-mas-masapp-visualinspection-install.yaml"
           - git:
               repoURL: "{{ .Values.generator.repo_url }}"
               revision: "{{ .Values.generator.revision }}"
               files:
-              - path: "{{ .Values.account.id }}/{{ .Values.region.id }}/{{ .Values.cluster.id }}/*/ibm-mas-masapp-optimizer-install.yaml"
+              - path: "{{ .Values.account.id }}/{{ .Values.cluster.id }}/*/ibm-mas-masapp-optimizer-install.yaml"
           - git:
               repoURL: "{{ .Values.generator.repo_url }}"
               revision: "{{ .Values.generator.revision }}"
               files:
-              - path: "{{ .Values.account.id }}/{{ .Values.region.id }}/{{ .Values.cluster.id }}/*/ibm-mas-masapp-monitor-install.yaml"
+              - path: "{{ .Values.account.id }}/{{ .Values.cluster.id }}/*/ibm-mas-masapp-monitor-install.yaml"
           - git:
               repoURL: "{{ .Values.generator.repo_url }}"
               revision: "{{ .Values.generator.revision }}"
               files:
-              - path: "{{ .Values.account.id }}/{{ .Values.region.id }}/{{ .Values.cluster.id }}/*/ibm-mas-masapp-predict-install.yaml"
+              - path: "{{ .Values.account.id }}/{{ .Values.cluster.id }}/*/ibm-mas-masapp-predict-install.yaml"
           - git:
               repoURL: "{{ .Values.generator.repo_url }}"
               revision: "{{ .Values.generator.revision }}"
               files:
-              - path: "{{ .Values.account.id }}/{{ .Values.region.id }}/{{ .Values.cluster.id }}/*/ibm-mas-masapp-health-install.yaml"
+              - path: "{{ .Values.account.id }}/{{ .Values.cluster.id }}/*/ibm-mas-masapp-health-install.yaml"
           - git:
               repoURL: "{{ .Values.generator.repo_url }}"
               revision: "{{ .Values.generator.revision }}"
               files:
-              - path: "{{ .Values.account.id }}/{{ .Values.region.id }}/{{ .Values.cluster.id }}/*/ibm-mas-masapp-configs.yaml"
+              - path: "{{ .Values.account.id }}/{{ .Values.cluster.id }}/*/ibm-mas-masapp-configs.yaml"
   template:
     metadata:
       name: "instance.{{ .Values.cluster.id }}.{{ `{{.instance.id}}` }}"

--- a/root-applications/ibm-mas-instance-root/templates/000-ibm-sync-resources.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/000-ibm-sync-resources.yaml
@@ -2,8 +2,14 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: syncres.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
+  name: syncres.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
   namespace: {{ .Values.argo.namespace }}
+  labels:
+    cloud: aws
+    environment: '{{ .Values.account.id }}'
+    region: '{{ .Values.region.id }}'
+    cluster: '{{ .Values.cluster.id }}'
+    instance: '{{ .Values.instance.id }}'
   annotations:
     argocd.argoproj.io/sync-wave: "000"
     {{- if and .Values.notifications .Values.notifications.slack_channel_id }}

--- a/root-applications/ibm-mas-instance-root/templates/000-ibm-sync-resources.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/000-ibm-sync-resources.yaml
@@ -5,7 +5,6 @@ metadata:
   name: syncres.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
   namespace: {{ .Values.argo.namespace }}
   labels:
-    cloud: aws
     environment: '{{ .Values.account.id }}'
     region: '{{ .Values.region.id }}'
     cluster: '{{ .Values.cluster.id }}'

--- a/root-applications/ibm-mas-instance-root/templates/010-ibm-sync-jobs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/010-ibm-sync-jobs.yaml
@@ -5,7 +5,6 @@ metadata:
   name: syncjobs.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
   namespace: {{ .Values.argo.namespace }}
   labels:
-    cloud: aws
     environment: '{{ .Values.account.id }}'
     region: '{{ .Values.region.id }}'
     cluster: '{{ .Values.cluster.id }}'

--- a/root-applications/ibm-mas-instance-root/templates/010-ibm-sync-jobs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/010-ibm-sync-jobs.yaml
@@ -2,8 +2,14 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: syncjobs.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
+  name: syncjobs.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
   namespace: {{ .Values.argo.namespace }}
+  labels:
+    cloud: aws
+    environment: '{{ .Values.account.id }}'
+    region: '{{ .Values.region.id }}'
+    cluster: '{{ .Values.cluster.id }}'
+    instance: '{{ .Values.instance.id }}'
   annotations:
     argocd.argoproj.io/sync-wave: "010"
     {{- if and .Values.notifications .Values.notifications.slack_channel_id }}

--- a/root-applications/ibm-mas-instance-root/templates/100-ibm-sls-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/100-ibm-sls-app.yaml
@@ -4,8 +4,14 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: sls.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
+  name: sls.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
   namespace: {{ .Values.argo.namespace }}
+  labels:
+    cloud: aws
+    environment: '{{ .Values.account.id }}'
+    region: '{{ .Values.region.id }}'
+    cluster: '{{ .Values.cluster.id }}'
+    instance: '{{ .Values.instance.id }}'
   annotations:
     argocd.argoproj.io/sync-wave: "100"
     {{- if and .Values.notifications .Values.notifications.slack_channel_id }}

--- a/root-applications/ibm-mas-instance-root/templates/100-ibm-sls-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/100-ibm-sls-app.yaml
@@ -7,7 +7,6 @@ metadata:
   name: sls.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
   namespace: {{ .Values.argo.namespace }}
   labels:
-    cloud: aws
     environment: '{{ .Values.account.id }}'
     region: '{{ .Values.region.id }}'
     cluster: '{{ .Values.cluster.id }}'

--- a/root-applications/ibm-mas-instance-root/templates/120-db2-databases-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-db2-databases-app.yaml
@@ -11,7 +11,6 @@ metadata:
   name: "db2-db.{{ $.Values.cluster.id }}.{{ $.Values.instance.id }}.{{ $value.mas_application_id }}"
   namespace: {{ $.Values.argo.namespace }}
   labels:
-    cloud: aws
     environment: '{{ $.Values.account.id }}'
     region: '{{ $.Values.region.id }}'
     cluster: '{{ $.Values.cluster.id }}'
@@ -26,7 +25,6 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
   labels:
-    cloud: aws
     environment: '{{ $.Values.account.id }}'
     region: '{{ $.Values.region.id }}'
     cluster: '{{ $.Values.cluster.id }}'

--- a/root-applications/ibm-mas-instance-root/templates/120-db2-databases-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-db2-databases-app.yaml
@@ -8,8 +8,15 @@ For example: {{ $.Values.account.id }} (instead of {{ .Values.account.id }} )
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: "db2-db.{{ $.Values.account.id }}.{{ $.Values.region.id }}.{{ $.Values.cluster.id }}.{{ $.Values.instance.id }}.{{ $value.mas_application_id }}"
+  name: "db2-db.{{ $.Values.cluster.id }}.{{ $.Values.instance.id }}.{{ $value.mas_application_id }}"
   namespace: {{ $.Values.argo.namespace }}
+  labels:
+    cloud: aws
+    environment: '{{ $.Values.account.id }}'
+    region: '{{ $.Values.region.id }}'
+    cluster: '{{ $.Values.cluster.id }}'
+    instance: '{{ $.Values.instance.id }}'
+    appId: '{{ $value.mas_application_id }}'
   annotations:
     argocd.argoproj.io/sync-wave: "120"
     {{- if and $.Values.notifications $.Values.notifications.slack_channel_id }}

--- a/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-app.yaml
@@ -11,7 +11,6 @@ metadata:
   name: {{ $app_name }}
   namespace: {{ .Values.argo.namespace }}
   labels:
-    cloud: aws
     environment: '{{ .Values.account.id }}'
     region: '{{ .Values.region.id }}'
     cluster: '{{ .Values.cluster.id }}'

--- a/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-app.yaml
@@ -1,6 +1,6 @@
 {{- if not (empty .Values.ibm_mas_suite) }}
 
-{{ $app_name := printf "suite.%s.%s.%s.%s" .Values.account.id .Values.region.id .Values.cluster.id .Values.instance.id }}
+{{ $app_name := printf "suite.%s.%s" .Values.cluster.id .Values.instance.id }}
 {{ $app_dest_ns := printf "mas-%s-core" .Values.instance.id }}
 
 ---
@@ -10,6 +10,12 @@ kind: Application
 metadata:
   name: {{ $app_name }}
   namespace: {{ .Values.argo.namespace }}
+  labels:
+    cloud: aws
+    environment: '{{ .Values.account.id }}'
+    region: '{{ .Values.region.id }}'
+    cluster: '{{ .Values.cluster.id }}'
+    instance: '{{ .Values.instance.id }}'
   annotations:
     argocd.argoproj.io/sync-wave: "130"
     {{- if and .Values.notifications .Values.notifications.slack_channel_id }}

--- a/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-configs-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-configs-app.yaml
@@ -11,7 +11,6 @@ metadata:
   name: "{{ $value.mas_config_name }}.{{ $.Values.cluster.id  }}"
   namespace: {{ $.Values.argo.namespace }}
   labels:
-    cloud: aws
     environment: '{{ $.Values.account.id }}'
     region: '{{ $.Values.region.id }}'
     cluster: '{{ $.Values.cluster.id }}'
@@ -27,7 +26,6 @@ metadata:
     - post-delete-finalizer.argocd.argoproj.io	
     - post-delete-finalizer.argocd.argoproj.io/cleanup
   labels:
-    cloud: aws
     environment: '{{ $.Values.account.id }}'
     region: '{{ $.Values.region.id }}'
     cluster: '{{ $.Values.cluster.id }}'

--- a/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-configs-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-configs-app.yaml
@@ -8,7 +8,7 @@ For example: {{ $.Values.account.id }} (instead of {{ .Values.account.id }} )
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: "{{ $value.mas_config_name }}.{{ $.Values.cluster.id  }}.{{ $.Values.instance.id }}"
+  name: "{{ $value.mas_config_name }}.{{ $.Values.cluster.id  }}"
   namespace: {{ $.Values.argo.namespace }}
   labels:
     cloud: aws

--- a/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-configs-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-configs-app.yaml
@@ -8,8 +8,14 @@ For example: {{ $.Values.account.id }} (instead of {{ .Values.account.id }} )
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: "{{ $value.mas_config_name }}.{{ $.Values.account.id  }}.{{ $.Values.region.id }}.{{ $.Values.cluster.id  }}.{{ $.Values.instance.id }}"
+  name: "{{ $value.mas_config_name }}.{{ $.Values.cluster.id  }}.{{ $.Values.instance.id }}"
   namespace: {{ $.Values.argo.namespace }}
+  labels:
+    cloud: aws
+    environment: '{{ $.Values.account.id }}'
+    region: '{{ $.Values.region.id }}'
+    cluster: '{{ $.Values.cluster.id }}'
+    instance: '{{ $.Values.instance.id }}'
   annotations:
     argocd.argoproj.io/sync-wave: "130"
     {{- if and $.Values.notifications $.Values.notifications.slack_channel_id }}

--- a/root-applications/ibm-mas-instance-root/templates/200-ibm-mas-workspaces.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/200-ibm-mas-workspaces.yaml
@@ -9,8 +9,14 @@ For example: {{ $.Values.account.id }} (instead of {{ .Values.account.id }} )
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: {{ $value.mas_workspace_id }}.suite.{{ $.Values.account.id }}.{{ $.Values.region.id }}.{{ $.Values.cluster.id }}.{{ $.Values.instance.id }}
+  name: {{ $value.mas_workspace_id }}.suite.{{ $.Values.cluster.id }}.{{ $.Values.instance.id }}
   namespace: {{ $.Values.argo.namespace }}
+  labels:
+    cloud: aws
+    environment: '{{ $.Values.account.id }}'
+    region: '{{ $.Values.region.id }}'
+    cluster: '{{ $.Values.cluster.id }}'
+    instance: '{{ $.Values.instance.id }}'
   annotations:
     argocd.argoproj.io/sync-wave: "200"
     {{- if and $.Values.notifications $.Values.notifications.slack_channel_id }}

--- a/root-applications/ibm-mas-instance-root/templates/200-ibm-mas-workspaces.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/200-ibm-mas-workspaces.yaml
@@ -12,7 +12,6 @@ metadata:
   name: {{ $value.mas_workspace_id }}.suite.{{ $.Values.cluster.id }}.{{ $.Values.instance.id }}
   namespace: {{ $.Values.argo.namespace }}
   labels:
-    cloud: aws
     environment: '{{ $.Values.account.id }}'
     region: '{{ $.Values.region.id }}'
     cluster: '{{ $.Values.cluster.id }}'

--- a/root-applications/ibm-mas-instance-root/templates/500-ibm-mas-masapp-assist-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/500-ibm-mas-masapp-assist-install.yaml
@@ -7,7 +7,6 @@ metadata:
   name: assist.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
   namespace: {{ .Values.argo.namespace }}
   labels:
-    cloud: aws
     environment: '{{ .Values.account.id }}'
     region: '{{ .Values.region.id }}'
     cluster: '{{ .Values.cluster.id }}'

--- a/root-applications/ibm-mas-instance-root/templates/500-ibm-mas-masapp-assist-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/500-ibm-mas-masapp-assist-install.yaml
@@ -4,7 +4,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: assist.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
+  name: assist.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
   namespace: {{ .Values.argo.namespace }}
   labels:
     cloud: aws

--- a/root-applications/ibm-mas-instance-root/templates/500-ibm-mas-masapp-iot-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/500-ibm-mas-masapp-iot-install.yaml
@@ -7,7 +7,6 @@ metadata:
   name: iot.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
   namespace: {{ .Values.argo.namespace }}
   labels:
-    cloud: aws
     environment: '{{ .Values.account.id }}'
     region: '{{ .Values.region.id }}'
     cluster: '{{ .Values.cluster.id }}'

--- a/root-applications/ibm-mas-instance-root/templates/500-ibm-mas-masapp-iot-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/500-ibm-mas-masapp-iot-install.yaml
@@ -4,7 +4,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: iot.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
+  name: iot.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
   namespace: {{ .Values.argo.namespace }}
   labels:
     cloud: aws

--- a/root-applications/ibm-mas-instance-root/templates/500-ibm-mas-masapp-manage-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/500-ibm-mas-masapp-manage-install.yaml
@@ -7,7 +7,6 @@ metadata:
   name: manage.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
   namespace: {{ .Values.argo.namespace }}
   labels:
-    cloud: aws
     environment: '{{ .Values.account.id }}'
     region: '{{ .Values.region.id }}'
     cluster: '{{ .Values.cluster.id }}'

--- a/root-applications/ibm-mas-instance-root/templates/500-ibm-mas-masapp-manage-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/500-ibm-mas-masapp-manage-install.yaml
@@ -4,7 +4,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: manage.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
+  name: manage.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
   namespace: {{ .Values.argo.namespace }}
   labels:
     cloud: aws

--- a/root-applications/ibm-mas-instance-root/templates/500-ibm-mas-masapp-visualinspection-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/500-ibm-mas-masapp-visualinspection-install.yaml
@@ -4,7 +4,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: visualinspection.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
+  name: visualinspection.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
   namespace: {{ .Values.argo.namespace }}
   labels:
     cloud: aws

--- a/root-applications/ibm-mas-instance-root/templates/500-ibm-mas-masapp-visualinspection-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/500-ibm-mas-masapp-visualinspection-install.yaml
@@ -7,7 +7,6 @@ metadata:
   name: visualinspection.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
   namespace: {{ .Values.argo.namespace }}
   labels:
-    cloud: aws
     environment: '{{ .Values.account.id }}'
     region: '{{ .Values.region.id }}'
     cluster: '{{ .Values.cluster.id }}'

--- a/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
@@ -8,7 +8,7 @@ For example: {{ $.Values.account.id }} (instead of {{ .Values.account.id }} )
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: "{{ $value.mas_workspace_id }}.{{ $value.mas_app_id }}.{{ $.Values.account.id }}.{{ $.Values.region.id }}.{{ $.Values.cluster.id }}.{{ $.Values.instance.id }}"
+  name: "{{ $value.mas_workspace_id }}.{{ $value.mas_app_id }}.{{ $.Values.cluster.id }}.{{ $.Values.instance.id }}"
   namespace: {{ $.Values.argo.namespace }}
   annotations:
     {{- if eq $value.mas_app_id "assist" }}

--- a/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
@@ -35,7 +35,6 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
   labels:
-    cloud: aws
     environment: '{{ $.Values.account.id }}'
     region: '{{ $.Values.region.id }}'
     cluster: '{{ $.Values.cluster.id }}'

--- a/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-health-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-health-install.yaml
@@ -7,7 +7,6 @@ metadata:
   name: health.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
   namespace: {{ .Values.argo.namespace }}
   labels:
-    cloud: aws
     environment: '{{ .Values.account.id }}'
     region: '{{ .Values.region.id }}'
     cluster: '{{ .Values.cluster.id }}'

--- a/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-health-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-health-install.yaml
@@ -4,7 +4,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: health.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
+  name: health.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
   namespace: {{ .Values.argo.namespace }}
   labels:
     cloud: aws

--- a/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-monitor-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-monitor-install.yaml
@@ -7,7 +7,6 @@ metadata:
   name: monitor.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
   namespace: {{ .Values.argo.namespace }}
   labels:
-    cloud: aws
     environment: '{{ .Values.account.id }}'
     region: '{{ .Values.region.id }}'
     cluster: '{{ .Values.cluster.id }}'

--- a/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-monitor-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-monitor-install.yaml
@@ -4,7 +4,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: monitor.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
+  name: monitor.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
   namespace: {{ .Values.argo.namespace }}
   labels:
     cloud: aws

--- a/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-optimizer-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-optimizer-install.yaml
@@ -7,7 +7,6 @@ metadata:
   name: optimizer.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
   namespace: {{ .Values.argo.namespace }}
   labels:
-    cloud: aws
     environment: '{{ .Values.account.id }}'
     region: '{{ .Values.region.id }}'
     cluster: '{{ .Values.cluster.id }}'

--- a/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-optimizer-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-optimizer-install.yaml
@@ -4,7 +4,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: optimizer.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
+  name: optimizer.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
   namespace: {{ .Values.argo.namespace }}
   labels:
     cloud: aws

--- a/root-applications/ibm-mas-instance-root/templates/540-ibm-mas-masapp-predict-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/540-ibm-mas-masapp-predict-install.yaml
@@ -4,7 +4,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: predict.{{.Values.account.id}}.{{.Values.region.id}}.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
+  name: predict.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
   namespace: {{ .Values.argo.namespace }}
   labels:
     cloud: aws

--- a/root-applications/ibm-mas-instance-root/templates/540-ibm-mas-masapp-predict-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/540-ibm-mas-masapp-predict-install.yaml
@@ -7,7 +7,6 @@ metadata:
   name: predict.{{ .Values.cluster.id }}.{{ .Values.instance.id }}
   namespace: {{ .Values.argo.namespace }}
   labels:
-    cloud: aws
     environment: '{{ .Values.account.id }}'
     region: '{{ .Values.region.id }}'
     cluster: '{{ .Values.cluster.id }}'


### PR DESCRIPTION
The default tracking method used in argocd means that a label gets added to each resource Argo creates. The kubernetes label values lengths need to be 63 characters or less. As we generate our ArgoCD Application names then it is quite easy to breach this limit. This PR will shorten the name but still keep the uniqueness of the app names.

The main change is to remove the `account_id.region_id` section in the argocd app names. This assumes that the OCP cluster name is uniquely named across the different accounts and regions that might be installed via the same ArgoCD instance. All these apps also have labels added to list the account, region, cluster, instance where applicable.

One difference is the mas_config_name value which already contains the mas instance id so the mas_instance_id is dropped from this mas config app names as it is already present.

![image](https://github.com/ibm-mas/gitops/assets/6817894/6c94a05b-2dd9-43e1-8a7e-b26462651a52)

https://jsw.ibm.com/browse/MASCORE-2682

ALso removes the `cloud: aws` label as we don't want to assume aws