### PR TITLE
[minor] [mascore-2636] Delete mongodb entries when removing MAS instance

### DIFF
--- a/instance-applications/000-ibm-sync-resources/templates/01-aws_Secret.yaml
+++ b/instance-applications/000-ibm-sync-resources/templates/01-aws_Secret.yaml
@@ -15,3 +15,4 @@ stringData:
   aws_secret_access_key: {{ .Values.sm_aws_secret_access_key }}
   aws_default_region: {{ .Values.sm_aws_region }}
 type: Opaque
+

--- a/instance-applications/130-ibm-mas-mongo-config/templates/01-mongo-credentials_Secret.yaml
+++ b/instance-applications/130-ibm-mas-mongo-config/templates/01-mongo-credentials_Secret.yaml
@@ -14,3 +14,26 @@ type: Opaque
 stringData:
   username: "{{ .Values.username }}"
   password: "{{ .Values.password }}"
+
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: mongo-db
+  namespace: mas-{{ .Values.instance_id }}-core
+  annotations:
+    argocd.argoproj.io/hook: PostDelete
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+stringData:
+  mongo_username: {{ .Values.username }}
+  mongo_password: {{ .Values.password }}
+  mas_wipe_mongo_data: "{{ .Values.mas_wipe_mongo_data }}"
+  config.yaml: |
+{{ .Values.config | toYaml | indent 4 }}
+  certificates.yaml: |
+{{ .Values.certificates | toYaml | indent 4 }}
+type: Opaque

--- a/instance-applications/130-ibm-mas-mongo-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-mas-mongo-config/templates/postdelete-delete-cr.yaml
@@ -14,7 +14,7 @@
 {{ $np_name :=   "postdelete-delete-cr-np" }}
 {{ $job_label := "postdelete-delete-cr-job" }}
 {{ $ns := printf "mas-%s-core" .Values.instance_id }}
-
+{{ $mas_instance_id := printf "%s" .Values.instance_id }}
 
 ---
 apiVersion: batch/v1
@@ -62,6 +62,20 @@ spec:
 
             - name: CR_KIND
               value: {{ $cr_kind }}
+
+            - name: MAS_INSTANCE_ID
+              value: {{ $mas_instance_id }}
+
+            - name: MONGO_USERNAME
+              value: {{ .Values.mongo_username }}
+            - name: MONGO_PASSWORD
+              value: {{ .Values.mongo_password }}
+            - name: CONFIG
+              value: {{ .Values.config }}
+            - name: CERTIFICATES
+              value: {{ .Values.certificates }}
+            - name: MAS_WIPE_MONGO_DATA
+              value: {{ .Values.mas_wipe_mongo_data }}
 
           volumeMounts: []
           command:
@@ -113,7 +127,30 @@ spec:
                 
               }
 
-              
+              echo -e "Silently wipe Mongo data"
+              #oc exec -it -n ${CR_NAMESPACE} $(oc get pods -n ${CR_NAMESPACE} -l app=${MAS_INSTANCE_ID}-coreapi -o=jsonpath='{.items[0].metadata.name}') python3 /opt/ibm/coreapi/wipeData.py silent-wipe-data
+
+              echo ""
+              echo "================================================================================"
+              echo "Settings"
+              echo "================================================================================"
+              echo "MAS_INSTANCE_ID ....................... ${COLOR_MAGENTA}${MAS_INSTANCE_ID}"
+              echo "Mongo username ........................ ${COLOR_MAGENTA}${MONGO_USERNAME}"
+              echo "Mongo password ........................ ${COLOR_MAGENTA}${MONGO_PASSWORD:0:6}<snip>"
+              echo "Mongo config .......................... ${COLOR_MAGENTA}${CONFIG}"
+              echo "Mongo certificates .................... ${COLOR_MAGENTA}${CERTIFICATES}"
+              echo "MAS_WIPE_MONGO_DATA ................... ${COLOR_MAGENTA}${MAS_WIPE_MONGO_DATA}"
+              echo ""
+              echo "================================================================================"
+
+              if [ "$MAS_WIPE_MONGO_DATA" == "True" ]; then
+                export ROLE_NAME=wipe_mongo
+                ansible-playbook ibm.mas_devops.run_role
+                rc=$?
+                echo "Role wipe_mongo completes with rc=${rc}"
+                [ $rc -ne 0 ] && exit $rc
+              fi
+
               delete_oc_resource "${CR_KIND}.${CR_API_VERSION}/${CR_NAME}" "${CR_NAMESPACE}"
 
 

--- a/instance-applications/130-ibm-mas-mongo-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-mas-mongo-config/templates/postdelete-delete-cr.yaml
@@ -63,27 +63,40 @@ spec:
             - name: CR_KIND
               value: {{ $cr_kind }}
 
-            - name: MAS_INSTANCE_ID
+            - name: INSTANCE_ID
               value: {{ $mas_instance_id }}
 
             - name: MONGO_USERNAME
-              value: {{ .Values.username }}
-            - name: MONGO_PASSWORD
-              value: {{ .Values.password }}
-            - name: CONFIG
-              value: {{ .Values.config }}
-            - name: CERTIFICATES
-              value: {{ .Values.certificates }}
-            - name: MAS_WIPE_MONGO_DATA
-              value: {{ .Values.mas_wipe_mongo_data }}
+              valueFrom:
+                secretKeyRef:
+                  name: mongo-db
+                  key: mongo_username
 
-          volumeMounts: []
+            - name: MONGO_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mongo-db
+                  key: mongo_password
+
+            - name: MAS_WIPE_MONGO_DATA
+              valueFrom:
+                secretKeyRef:
+                  name: mongo-db
+                  key: mas_wipe_mongo_data
+
+          volumeMounts:
+            - name: "mongo-db"
+              mountPath: /etc/mas/secrets/mongo_db
+
           command:
             - /bin/sh
             - -c
             - |
 
               set -e
+
+              export CONFIG=$(cat /etc/mas/secrets/mongo_db/config.yaml | yq -r '.' )
+              export CERTIFICATES=$(cat /etc/mas/secrets/mongo_db/certificates.yaml | yq -r '.' )
 
               function delete_oc_resource(){
                 RESOURCE=$1
@@ -128,13 +141,13 @@ spec:
               }
 
               echo -e "Silently wipe Mongo data"
-              #oc exec -it -n ${CR_NAMESPACE} $(oc get pods -n ${CR_NAMESPACE} -l app=${MAS_INSTANCE_ID}-coreapi -o=jsonpath='{.items[0].metadata.name}') python3 /opt/ibm/coreapi/wipeData.py silent-wipe-data
 
+              
               echo ""
               echo "================================================================================"
               echo "Settings - wipe_mongo"
               echo "================================================================================"
-              echo "MAS_INSTANCE_ID ....................... ${COLOR_MAGENTA}${MAS_INSTANCE_ID}"
+              echo "INSTANCE_ID ........................... ${COLOR_MAGENTA}${INSTANCE_ID}"
               echo "Mongo username ........................ ${COLOR_MAGENTA}${MONGO_USERNAME}"
               echo "Mongo password ........................ ${COLOR_MAGENTA}${MONGO_PASSWORD:0:6}<snip>"
               echo "Mongo config .......................... ${COLOR_MAGENTA}${CONFIG}"
@@ -143,7 +156,8 @@ spec:
               echo ""
               echo "================================================================================"
 
-              if [ "$MAS_WIPE_MONGO_DATA" == "true" ]; then
+              if [[ "${MAS_WIPE_MONGO_DATA}" == "true" ]]; then
+
                 export ROLE_NAME=wipe_mongo
                 ansible-playbook ibm.mas_devops.run_role
                 rc=$?
@@ -156,6 +170,12 @@ spec:
 
       restartPolicy: Never
       serviceAccountName: {{ $sa_name }}
-      volumes: []
+
+      volumes:
+        - name: "mongo-db"
+          secret:
+            secretName: "mongo-db"
+            defaultMode: 420
+            optional: false
   backoffLimit: 4
 {{- end }}

--- a/instance-applications/130-ibm-mas-mongo-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-mas-mongo-config/templates/postdelete-delete-cr.yaml
@@ -67,9 +67,9 @@ spec:
               value: {{ $mas_instance_id }}
 
             - name: MONGO_USERNAME
-              value: {{ .Values.mongo_username }}
+              value: {{ .Values.username }}
             - name: MONGO_PASSWORD
-              value: {{ .Values.mongo_password }}
+              value: {{ .Values.password }}
             - name: CONFIG
               value: {{ .Values.config }}
             - name: CERTIFICATES
@@ -132,7 +132,7 @@ spec:
 
               echo ""
               echo "================================================================================"
-              echo "Settings"
+              echo "Settings - wipe_mongo"
               echo "================================================================================"
               echo "MAS_INSTANCE_ID ....................... ${COLOR_MAGENTA}${MAS_INSTANCE_ID}"
               echo "Mongo username ........................ ${COLOR_MAGENTA}${MONGO_USERNAME}"
@@ -143,7 +143,7 @@ spec:
               echo ""
               echo "================================================================================"
 
-              if [ "$MAS_WIPE_MONGO_DATA" == "True" ]; then
+              if [ "$MAS_WIPE_MONGO_DATA" == "true" ]; then
                 export ROLE_NAME=wipe_mongo
                 ansible-playbook ibm.mas_devops.run_role
                 rc=$?


### PR DESCRIPTION
Issue - https://jsw.ibm.com/browse/MASCORE-2636?filter=-1

When a MAS instance is removed, we should also remove the MAS entries in the mongodb
This removal is controlled via a param `wipe_mongo_data`.