### PR TITLE
Ensure mas-xxx-core namespace is cleaned up when MAS is torn down

### DIFF
--- a/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-app.yaml
@@ -120,11 +120,7 @@ spec:
       - RespectIgnoreDifferences=true
     managedNamespaceMetadata:
       labels:
-        argocd.argoproj.io/instance: {{ $app_name }}
-        argocd.argoproj.io/managed-by: "{{ .Values.argo.namespace }}"
-      annotations:
-        argocd.argoproj.io/tracking-id: >-
-            {{ $app_name }}:/Namespace:{{ $app_dest_ns }}/{{ $app_dest_ns }}
+        app.kubernetes.io/instance: {{ $app_name }}
   ignoreDifferences:
     - group: 'cert-manager.io'
       kind: ClusterIssuer


### PR DESCRIPTION
Adds correct label to mas-xxx-core namespace to ensure ArgoCD will track it (and thus delete it) when the suite app is pruned.

[MASCORE-2818](https://jsw.ibm.com/browse/MASCORE-2818)

With this change, the mas-xxx-core namespace (created implicitly due to `syncOptions.CreateNamespace=true` being set on the suite app) is tracked properly by ArgoCD. We can see it appears as a child resource of the suite app:
![image](https://github.com/ibm-mas/gitops/assets/7372253/e663ed17-3472-4edb-81d6-9e3aa7ba97d8)

Verified that when the suite config file is deleted from the config repo (e.g. gitops-envs) causing the suite app to be pruned,  ArgoCD now deletes the mas-xxx-core namespace as expected.