### PR TITLE
[minor] Add MVI Resource Quota

### DIFF
--- a/instance-applications/500-540-ibm-mas-suite-app-install/templates/04-ibm-mas-mvi_ResourceQuota.yaml
+++ b/instance-applications/500-540-ibm-mas-suite-app-install/templates/04-ibm-mas-mvi_ResourceQuota.yaml
@@ -1,0 +1,17 @@
+{{- if eq .Values.mas_app_id "visualinspection" }}
+
+kind: ResourceQuota 
+apiVersion: v1 
+  annotations:
+    argocd.argoproj.io/sync-wave: "502"
+  name: "gpu-{{ .Values.instance_id }}-quota"
+  namespace: {{ .Values.mas_app_namespace }}
+  labels:
+{{- if .Values.custom_labels }}
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+spec: 
+  hard: 
+    requests.nvidia.com/gpu: "{{ .Values.gpu_request_quota }}"
+
+{{- end }}

--- a/instance-applications/500-540-ibm-mas-suite-app-install/values.yaml
+++ b/instance-applications/500-540-ibm-mas-suite-app-install/values.yaml
@@ -1,7 +1,7 @@
 ---
 run_sync_hooks: true
 mas_manual_cert_mgmt: "False"
-
+gpu_request_quota: "2"
 
 # ####################################################
 # # Required values. No defaults provided.

--- a/root-applications/ibm-mas-instance-root/templates/500-ibm-mas-masapp-visualinspection-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/500-ibm-mas-masapp-visualinspection-install.yaml
@@ -59,6 +59,8 @@ spec:
             {{- if .Values.custom_labels }}
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}
+            gpu_request_quota: "{{ .Values.ibm_suite_app_visualinspection_install.gpu_request_quota }}"
+
         - name: ARGOCD_APP_NAME
           value: "visualinspection-install"
         {{- if not (empty .Values.avp.secret) }}


### PR DESCRIPTION
Adds a ResourceQuota if the app is visualinspection, to control the `requests.nvidia.com/gpu` for that namespace