### PR TITLE
[patch] support for multiple docdb host and port

### DIFF
--- a/instance-applications/010-ibm-sync-jobs/templates/00-aws-docdb-add-user_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/00-aws-docdb-add-user_Job.yaml
@@ -94,15 +94,22 @@ spec:
               OUTPUT_FILE=${MAS_CONFIG_DIR}/docdb-${MAS_INSTANCE_ID}-instance-credentials.yml
               export USER_ACTION="add"
 
-              # Grab one of the hosts/ports out of docdb master info
-              export DOCDB_HOST=$(echo "${DOCDB_MASTER_INFO}" | sed 's/\\n/\n/g' | sed 's/\\"//g' | /usr/bin/yq '.config.hosts[1].host')
-              export DOCDB_PORT=$(echo "${DOCDB_MASTER_INFO}" | sed 's/\\n/\n/g' | /usr/bin/yq '.config.hosts[1].port')
+              DOCDB_HOST_COUNT=$(echo "${DOCDB_MASTER_INFO}" | sed 's/\\n/\n/g' | sed 's/\\"//g' | /usr/bin/yq '.config.hosts'  | length)
+              for ((i=0; i<$DOCDB_HOST_COUNT; i++)); do
+                # Grab hosts/ports from docdb master info
+                export DOCDB_HOST=$(echo "${DOCDB_MASTER_INFO}" | sed 's/\\n/\n/g' | sed 's/\\"//g' | /usr/bin/yq '.config.hosts[i].host')
+                export DOCDB_PORT=$(echo "${DOCDB_MASTER_INFO}" | sed 's/\\n/\n/g' | /usr/bin/yq '.config.hosts[i].port')
+                export DOCDB_HOSTS="$DOCDB_HOSTS$DOCDB_HOST:$DOCDB_PORT,"
+              done
+              # remove trailing comma
+              export DOCDB_HOSTS=${DOCDB_HOSTS%,}
 
               echo "Params:"
               echo "    - MAS_INSTANCE_ID         ................... ${MAS_INSTANCE_ID}"
               echo "    - MAS_CONFIG_DIR          ................... ${MAS_CONFIG_DIR}"
               echo "    - DOCDB_HOST              ................... ${DOCDB_HOST}"
               echo "    - DOCDB_PORT              ................... ${DOCDB_PORT}"
+              echo "    - DOCDB_HOSTS             ................... ${DOCDB_HOSTS}"
               echo "    - DOCDB_MASTER_USERNAME   ................... ${DOCDB_MASTER_USERNAME:0:2}<snip>"
               echo "    - DOCDB_MASTER_PASSWORD   ................... ${DOCDB_MASTER_PASSWORD:0:2}<snip>"
               echo "    - DOCDB_INSTANCE_PASSWORD ................... ${DOCDB_INSTANCE_PASSWORD:0:2}<snip>"


### PR DESCRIPTION
This PR has logic change to construct comma separated docdb:host to support connection via mongosh

Re: https://github.com/ibm-mas/ansible-devops/pull/1374