### PR TITLE
 [minor] [MASCORE-3232] Setup ingress-controller for cis-proxy #1141 

### DIFF
--- a/cluster-applications/030-ibm-cis-cert-manager/templates/00-8-ibm-cis-webhook_cis-ingress-controller.yaml
+++ b/cluster-applications/030-ibm-cis-cert-manager/templates/00-8-ibm-cis-webhook_cis-ingress-controller.yaml
@@ -1,0 +1,24 @@
+{{- if and (eq .Values.dns_provider "cis") (.Values.ingress) }}
+---
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: public
+  namespace: openshift-ingress-operator
+spec:
+  domain: "{{ .Values.ocp_public_cluster_domain }}"
+  routeSelector:
+    matchLabels:
+      type: external
+  tuningOptions: {}
+  unsupportedConfigOverrides: null
+  httpErrorCodePages:
+    name: ''
+  replicas: 3
+  httpEmptyRequestsPolicy: Respond
+  endpointPublishingStrategy:
+    loadBalancer:
+      dnsManagementPolicy: Managed
+      scope: Internal
+    type: LoadBalancerService
+{{- end }}

--- a/instance-applications/000-ibm-sync-resources/templates/01-ibm-suite-certs_Secret.yaml
+++ b/instance-applications/000-ibm-sync-resources/templates/01-ibm-suite-certs_Secret.yaml
@@ -15,8 +15,6 @@ metadata:
 
 stringData:
   cis_apikey: {{ .Values.cis_apikey }}
-  sm_aws_access_key_id: {{ .Values.sm_aws_access_key_id }}
-  sm_aws_secret_access_key: {{ .Values.sm_aws_secret_access_key }}
   manual_certs.yaml: |
     manual_certs:
 {{ .Values.manual_certs | toYaml | indent 6 }}

--- a/instance-applications/000-ibm-sync-resources/templates/01-ibm-suite-certs_Secret.yaml
+++ b/instance-applications/000-ibm-sync-resources/templates/01-ibm-suite-certs_Secret.yaml
@@ -15,6 +15,8 @@ metadata:
 
 stringData:
   cis_apikey: {{ .Values.cis_apikey }}
+  sm_aws_access_key_id: {{ .Values.sm_aws_access_key_id }}
+  sm_aws_secret_access_key: {{ .Values.sm_aws_secret_access_key }}
   manual_certs.yaml: |
     manual_certs:
 {{ .Values.manual_certs | toYaml | indent 6 }}

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
@@ -85,7 +85,7 @@ spec:
               #if DNS name is set in AWS SM path account/cluster/public-elb#dns, set that name to OCP_INGRESS
               export PUBLIC_ELB_DNS_NAME_FILE="/tmp/public-elb-dns-name-file.json"
               sm_get_secret_file ${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}public-elb#dns ${PUBLIC_ELB_DNS_NAME_FILE}
-              export OCP_INGRESS=$(jq -r .name $PUBLIC_ELB_DNS_NAME_FILE)
+              export OCP_INGRESS=$(jq -r .dns $PUBLIC_ELB_DNS_NAME_FILE)
               echo ""
               echo "================================================================================"
               echo "Settings"

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
@@ -34,9 +34,6 @@ spec:
             - name: MAS_INSTANCE_ID
               value: "{{ .Values.instance_id }}"
 
-            - name: SECRETS_KEY_SEPERATOR
-              value: "/"
-
             # dns
             - name: DNS_PROVIDER
               value: "{{ .Values.dns_provider }}"
@@ -89,7 +86,6 @@ spec:
               echo "IBM CLOUD APIKEY .................... ${COLOR_MAGENTA}${CIS_APIKEY:0:4}<snip>"
               echo "CIS subdomain ....................... ${COLOR_MAGENTA}${CIS_SUBDOMAIN}"
               echo "CIS proxy ........................... ${COLOR_MAGENTA}${CIS_PROXY}"
-              echo "OCP_INGRESS  ........................ ${COLOR_MAGENTA}${OCP_INGRESS}"
               echo "MAS Manual Certs YAML location ...... ${COLOR_MAGENTA}${MAS_MANUAL_CERTS_YAML}"
 
               echo ""

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
@@ -34,6 +34,9 @@ spec:
             - name: MAS_INSTANCE_ID
               value: "{{ .Values.instance_id }}"
 
+            - name: SECRETS_KEY_SEPERATOR
+              value: "/"
+
             # dns
             - name: DNS_PROVIDER
               value: "{{ .Values.dns_provider }}"
@@ -50,6 +53,8 @@ spec:
               value: "{{ .Values.cis_subdomain }}"
             - name: CIS_PROXY
               value: "{{ .Values.cis_proxy }}"
+            - name: SM_AWS_REGION
+              value: "{{ .Values.sm_aws_region }}"
 
             # Hard-coded for now:
             - name: AVP_TYPE
@@ -64,11 +69,20 @@ spec:
             - |
 
               set -e
+
+
               export MAS_CONFIG_DIR=${MAS_CONFIG_DIR:-"/tmp/suite_certs/configs"}
 
               export CIS_APIKEY=$(cat /etc/mas/creds/suite_certs/cis_apikey)
               MAS_MANUAL_CERTS_YAML=/etc/mas/creds/suite_certs/manual_certs.yaml
-
+              export SM_AWS_ACCESS_KEY_ID=$(cat /etc/mas/creds/suite_dns/sm_aws_access_key_id)
+              export SM_AWS_SECRET_ACCESS_KEY=$(cat /etc/mas/creds/suite_dns/sm_aws_secret_access_key)
+              source /mascli/functions/gitops_utils
+              sm_login
+              #if DNS name is set in AWS SM path account/cluster/public-elb#dns, set that name to OCP_INGRESS
+              export PUBLIC_ELB_DNS_NAME_FILE="/tmp/public-elb-dns-name-file.json"
+              sm_get_secret_file ${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}public-elb#dns ${PUBLIC_ELB_DNS_NAME_FILE}
+              export OCP_INGRESS=$(jq -r .name $PUBLIC_ELB_DNS_NAME_FILE)
               echo ""
               echo "================================================================================"
               echo "Settings"
@@ -82,7 +96,7 @@ spec:
               echo "IBM CLOUD APIKEY .................... ${COLOR_MAGENTA}${CIS_APIKEY:0:4}<snip>"
               echo "CIS subdomain ....................... ${COLOR_MAGENTA}${CIS_SUBDOMAIN}"
               echo "CIS proxy ........................... ${COLOR_MAGENTA}${CIS_PROXY}"
-
+              echo "OCP_INGRESS  ........................ ${COLOR_MAGENTA}${OCP_INGRESS}"
               echo "MAS Manual Certs YAML location ...... ${COLOR_MAGENTA}${MAS_MANUAL_CERTS_YAML}"
 
               echo ""

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
@@ -63,6 +63,7 @@ spec:
           volumeMounts:
             - name: "ibm-suite-certs"
               mountPath: /etc/mas/creds/suite_certs
+
           command:
             - /bin/sh
             - -c
@@ -75,10 +76,12 @@ spec:
 
               export CIS_APIKEY=$(cat /etc/mas/creds/suite_certs/cis_apikey)
               MAS_MANUAL_CERTS_YAML=/etc/mas/creds/suite_certs/manual_certs.yaml
-              export SM_AWS_ACCESS_KEY_ID=$(cat /etc/mas/creds/suite_dns/sm_aws_access_key_id)
-              export SM_AWS_SECRET_ACCESS_KEY=$(cat /etc/mas/creds/suite_dns/sm_aws_secret_access_key)
+              export SM_AWS_ACCESS_KEY_ID=$(cat /etc/mas/creds/suite_certs/sm_aws_access_key_id)
+              export SM_AWS_SECRET_ACCESS_KEY=$(cat /etc/mas/creds/suite_certs/sm_aws_secret_access_key)
+
               source /mascli/functions/gitops_utils
               sm_login
+
               #if DNS name is set in AWS SM path account/cluster/public-elb#dns, set that name to OCP_INGRESS
               export PUBLIC_ELB_DNS_NAME_FILE="/tmp/public-elb-dns-name-file.json"
               sm_get_secret_file ${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}public-elb#dns ${PUBLIC_ELB_DNS_NAME_FILE}
@@ -157,6 +160,7 @@ spec:
             secretName: "ibm-suite-certs"
             defaultMode: 420
             optional: false
+
 
   backoffLimit: 4
 

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
@@ -84,7 +84,9 @@ spec:
 
               #if DNS name is set in AWS SM path account/cluster/public-elb#dns, set that name to OCP_INGRESS
               export PUBLIC_ELB_DNS_NAME_FILE="/tmp/public-elb-dns-name-file.json"
-              sm_get_secret_file ${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}public-elb#dns ${PUBLIC_ELB_DNS_NAME_FILE}
+              sm_get_secret_file ${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}public-elb ${PUBLIC_ELB_DNS_NAME_FILE}
+              echo "cat file"
+              cat ${PUBLIC_ELB_DNS_NAME_FILE}
               export OCP_INGRESS=$(jq -r .dns $PUBLIC_ELB_DNS_NAME_FILE)
               echo ""
               echo "================================================================================"

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
@@ -53,8 +53,7 @@ spec:
               value: "{{ .Values.cis_subdomain }}"
             - name: CIS_PROXY
               value: "{{ .Values.cis_proxy }}"
-            - name: SM_AWS_REGION
-              value: "{{ .Values.sm_aws_region }}"
+
 
             # Hard-coded for now:
             - name: AVP_TYPE
@@ -76,18 +75,7 @@ spec:
 
               export CIS_APIKEY=$(cat /etc/mas/creds/suite_certs/cis_apikey)
               MAS_MANUAL_CERTS_YAML=/etc/mas/creds/suite_certs/manual_certs.yaml
-              export SM_AWS_ACCESS_KEY_ID=$(cat /etc/mas/creds/suite_certs/sm_aws_access_key_id)
-              export SM_AWS_SECRET_ACCESS_KEY=$(cat /etc/mas/creds/suite_certs/sm_aws_secret_access_key)
 
-              source /mascli/functions/gitops_utils
-              sm_login
-
-              #if DNS name is set in AWS SM path account/cluster/public-elb#dns, set that name to OCP_INGRESS
-              export PUBLIC_ELB_DNS_NAME_FILE="/tmp/public-elb-dns-name-file.json"
-              sm_get_secret_file ${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}public-elb ${PUBLIC_ELB_DNS_NAME_FILE}
-              echo "cat file"
-              cat ${PUBLIC_ELB_DNS_NAME_FILE}
-              export OCP_INGRESS=$(jq -r .dns $PUBLIC_ELB_DNS_NAME_FILE)
               echo ""
               echo "================================================================================"
               echo "Settings"

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
@@ -93,13 +93,13 @@ spec:
 
               set -e
 
-              source /mascli/functions/gitops_utils
-              sm_login
+
 
               export CIS_APIKEY=$(cat /etc/mas/creds/suite_dns/cis_apikey)
               export SM_AWS_ACCESS_KEY_ID=$(cat /etc/mas/creds/suite_dns/sm_aws_access_key_id)
               export SM_AWS_SECRET_ACCESS_KEY=$(cat /etc/mas/creds/suite_dns/sm_aws_secret_access_key)
-
+              source /mascli/functions/gitops_utils
+              sm_login
 
               #if DNS name is set in AWS SM path account/cluster/public-elb#dns, set that name to OCP_INGRESS
               export PUBLIC_ELB_DNS_NAME_FILE="/tmp/public-elb-dns-name-file.json"

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
@@ -33,6 +33,9 @@ spec:
             - name: MAS_INSTANCE_ID
               value: "{{ .Values.instance_id }}"
 
+            - name: SECRETS_KEY_SEPERATOR
+              value: "/"
+
             # dns
             - name: DNS_PROVIDER
               value: "{{ .Values.dns_provider }}"
@@ -91,11 +94,17 @@ spec:
               set -e
 
               source /mascli/functions/gitops_utils
+              sm_login
 
               export CIS_APIKEY=$(cat /etc/mas/creds/suite_dns/cis_apikey)
               export SM_AWS_ACCESS_KEY_ID=$(cat /etc/mas/creds/suite_dns/sm_aws_access_key_id)
               export SM_AWS_SECRET_ACCESS_KEY=$(cat /etc/mas/creds/suite_dns/sm_aws_secret_access_key)
 
+
+              #if DNS name is set in AWS SM path account/cluster/public-elb#dns, set that name to OCP_INGRESS
+              export PUBLIC_ELB_DNS_NAME_FILE="/tmp/public-elb-dns-name-file.json"
+              sm_get_secret_file ${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}/public-elb#dns ${PUBLIC_ELB_DNS_NAME_FILE}
+              export OCP_INGRESS=$(jq -r .name $PUBLIC_ELB_DNS_NAME_FILE)
 
               echo ""
               echo "================================================================================"
@@ -123,6 +132,7 @@ spec:
               echo "DELETE_WILDCARDS Flag ............... ${COLOR_MAGENTA}${DELETE_WILDCARDS}"
               echo "OVERRIDE_EDGE_CERTS Flag ............ ${COLOR_MAGENTA}${OVERRIDE_EDGE_CERTS}"
 
+              echo "OCP_INGRESS  ........................ ${COLOR_MAGENTA}${OCP_INGRESS}"
               echo "SM_AWS_REGION ....................... ${COLOR_MAGENTA}${SM_AWS_REGION}"
               echo "SM_AWS_ACCESS_KEY_ID ................ ${COLOR_MAGENTA}${SM_AWS_ACCESS_KEY_ID:0:4}<snip>"
               echo "SM_AWS_SECRET_ACCESS_KEY ............ ${COLOR_MAGENTA}${SM_AWS_SECRET_ACCESS_KEY:0:4}<snip>"

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
@@ -101,10 +101,10 @@ spec:
               source /mascli/functions/gitops_utils
               sm_login
 
-              #if DNS name is set in AWS SM path account/cluster/public-elb#dns, set that name to OCP_INGRESS
+              #if DNS name is set in AWS SM path account/cluster/public-elb (key=dns), set its value to OCP_INGRESS
               export PUBLIC_ELB_DNS_NAME_FILE="/tmp/public-elb-dns-name-file.json"
-              sm_get_secret_file ${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}public-elb#dns ${PUBLIC_ELB_DNS_NAME_FILE}
-              export OCP_INGRESS=$(jq -r .name $PUBLIC_ELB_DNS_NAME_FILE)
+              sm_get_secret_file ${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}public-elb ${PUBLIC_ELB_DNS_NAME_FILE}
+              export OCP_INGRESS=$(jq -r .dns $PUBLIC_ELB_DNS_NAME_FILE)
 
               echo ""
               echo "================================================================================"

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
@@ -103,7 +103,7 @@ spec:
 
               #if DNS name is set in AWS SM path account/cluster/public-elb#dns, set that name to OCP_INGRESS
               export PUBLIC_ELB_DNS_NAME_FILE="/tmp/public-elb-dns-name-file.json"
-              sm_get_secret_file ${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}/public-elb#dns ${PUBLIC_ELB_DNS_NAME_FILE}
+              sm_get_secret_file ${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}public-elb#dns ${PUBLIC_ELB_DNS_NAME_FILE}
               export OCP_INGRESS=$(jq -r .name $PUBLIC_ELB_DNS_NAME_FILE)
 
               echo ""

--- a/instance-applications/120-ibm-db2u-database/templates/04-tlsroute.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/04-tlsroute.yaml
@@ -8,6 +8,9 @@ metadata:
     argocd.argoproj.io/sync-wave: "123"
   labels:
     formation_id: "{{ .Values.db2_instance_name | lower }}"
+{{- if eq .Values.jdbc_route "public" }}
+    type: "external"
+{{- end }}
 {{- if .Values.custom_labels }}
 {{ .Values.custom_labels | toYaml | indent 4 }}
 {{- end }}

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -131,8 +131,8 @@ spec:
               done
 
               oc get routes -n ${SUITE_NAMESPACE}
-              export routes=$(oc get routes -n ${SUITE_NAMESPACE} -o jsonpath='{range .items[*]}{.metadata.name}{@}{"\n"}{end}')
-              echo "Add label to routes ${routes}"
+              export routes=$(oc get routes -n ${SUITE_NAMESPACE} -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
+              echo "Add label to routes updated ${routes}"
 
               for route in $routes do
                 echo "Adding -1"
@@ -141,7 +141,7 @@ spec:
                 echo "Adding -2"
               done
 
-              sleep 9000
+              sleep 90000
       restartPolicy: Never
       serviceAccountName: "mas-route-sa"
   backoffLimit: 4

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -132,7 +132,7 @@ spec:
 
               oc get routes -n ${SUITE_NAMESPACE}
 
-              export ROUTELIST=$(oc get routes -n ${SUITE_NAMESPACE} -o go-template --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+              export ROUTELIST=$(oc get routes -n ${SUITE_NAMESPACE} -o jsonpath='{range .items[*]}{.metadata.name} {end}')
               echo "Add label to routes ${ROUTELIST}"
 
               for ROUTE in $ROUTELIST do

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -75,35 +75,7 @@ rules:
       - core.mas.ibm.com
     resources:
       - suites
-  - verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-    apiGroups:
-      - apps.mas.ibm.com
-    resources:
-      - assistworkspaces
-      - healthextworkspaces
-      - healthworkspaces
-      - manageworkspaces
-      - visualinspectionappworkspaces
-      - workspaces
-  - verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-    apiGroups:
-      - iot.ibm.com
-    resources:
-      - iotworkspaces
+
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -43,6 +43,31 @@ rules:
       - "route.openshift.io"
     resources:
       - routes
+  - verbs:
+      - get
+      - list
+      - patch
+      - scale
+    apiGroups:
+      - ''
+      - apps
+      - zen.cpd.ibm.com
+      - operator.ibm.com
+    resources:
+      - deployments
+      - zenservices
+      - secrets
+      - commonservices
+      - deployments/scale
+  - verbs:
+      - get
+      - patch
+      - create
+      - update
+    apiGroups:
+      - ''
+    resources:
+      - serviceaccounts
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -63,7 +88,7 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: sync-mas-route-prereq-role-{{ .Values.instance_id }}
 
 ---
 apiVersion: batch/v1
@@ -112,6 +137,8 @@ spec:
               echo
 
               echo "Wait for Suite Routes to be ready"
+              echo "oc get Suite -n $SUITE_NAMESPACE -o NAME"
+              `oc get Suite -n $SUITE_NAMESPACE -o NAME`
               wait_period=0
               while true; do
                 wait_period=$(($wait_period+60))
@@ -119,11 +146,11 @@ spec:
                   echo "Suite Routes is not ready after 20 minutes of waiting. exiting..."
                   exit 1
                 else
-                  sleep 60
                   echo "sleep for 1 minute"
+                  sleep 60
                 fi
 
-                echo "oc get Suite -n $SUITE_NAMESPACE -o NAME"
+
                 SUITE_NAME=$(oc get Suite -n $SUITE_NAMESPACE -o NAME)
                 echo "SUITE_NAME == ${SUITE_NAME}"
 

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -68,7 +68,22 @@ rules:
       - "route.openshift.io"
     resources:
       - routes
-
+  - verbs:
+      - get
+      - list
+      - patch
+      - update
+    apiGroups:
+      - ''
+      - suites.core.mas.ibm.com
+      - assistworkspaces.apps.mas.ibm.com
+      - healthextworkspaces.apps.mas.ibm.com
+      - healthworkspaces.apps.mas.ibm.com
+      - iotworkspaces.iot.ibm.com
+      - manageworkspaces.apps.mas.ibm.com
+      - visualinspectionappworkspaces.apps.mas.ibm.com
+    resources:
+      - customresourcedefinitions
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -131,8 +131,7 @@ spec:
               done
 
               oc get routes -n ${SUITE_NAMESPACE}
-
-              export routes=$(oc get routes -n ${SUITE_NAMESPACE} -o jsonpath='{range .items[*]}{.metadata.name} {end}')
+              export routes=$(oc get routes -n ${SUITE_NAMESPACE} -o jsonpath='{range .items[*]}{.metadata.name}{@}{"\n"}{end}')
               echo "Add label to routes ${routes}"
 
               for route in $routes do
@@ -148,3 +147,4 @@ spec:
   backoffLimit: 4
 
 {{- end }}
+

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -1,5 +1,30 @@
 {{- if .Values.ingress }}
 
+{{ $job_label :=  "mas-route-patch" }}
+---
+# Permit outbound communication by the Job pods
+# (Needed to communicate with the K8S HTTP API and AWS SM)
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: mas-route-np
+  namespace: mas-{{ .Values.instance_id }}-core
+  annotations:
+    argocd.argoproj.io/sync-wave: "140"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $job_label }}
+  egress:
+    - {}
+  policyTypes:
+    - Egress
+
+
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -17,7 +42,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: sync-mas-route-prereq-role-{{ .Values.instance_id }}
+  name: mas-route-prereq-role-{{ .Values.instance_id }}
   annotations:
     argocd.argoproj.io/sync-wave: "140"
 {{- if .Values.custom_labels }}
@@ -43,31 +68,6 @@ rules:
       - "route.openshift.io"
     resources:
       - routes
-  - verbs:
-      - get
-      - list
-      - patch
-      - scale
-    apiGroups:
-      - ''
-      - apps
-      - zen.cpd.ibm.com
-      - operator.ibm.com
-    resources:
-      - deployments
-      - zenservices
-      - secrets
-      - commonservices
-      - deployments/scale
-  - verbs:
-      - get
-      - patch
-      - create
-      - update
-    apiGroups:
-      - ''
-    resources:
-      - serviceaccounts
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -88,7 +88,7 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: sync-mas-route-prereq-role-{{ .Values.instance_id }}
+  name: mas-route-prereq-role-{{ .Values.instance_id }}
 
 ---
 apiVersion: batch/v1
@@ -104,9 +104,10 @@ metadata:
 {{- end }}
 spec:
   template:
-{{- if .Values.custom_labels }}
     metadata:
       labels:
+        app: {{ $job_label }}
+{{- if .Values.custom_labels }}
 {{ .Values.custom_labels | toYaml | indent 8 }}
 {{- end }}
     spec:

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -52,25 +52,16 @@ metadata:
 {{- end }}
 rules:
   - verbs:
-      - create
-      - delete
       - get
       - list
       - patch
-      - update
-      - watch
     apiGroups:
       - "route.openshift.io"
     resources:
       - routes
   - verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
-      - update
-      - watch
     apiGroups:
       - core.mas.ibm.com
     resources:

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -120,9 +120,10 @@ spec:
                   exit 1
                 else
                   sleep 60
+                  echo "sleep for 1 minute"
                 fi
 
-
+                echo "oc get Suite -n $SUITE_NAMESPACE -o NAME"
                 SUITE_NAME=$(oc get Suite -n $SUITE_NAMESPACE -o NAME)
                 echo "SUITE_NAME == ${SUITE_NAME}"
 

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -52,10 +52,13 @@ metadata:
 {{- end }}
 rules:
   - verbs:
-      - get
-      - patch
       - create
+      - delete
+      - get
+      - list
+      - patch
       - update
+      - watch
     apiGroups:
       - "route.openshift.io"
     resources:

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -130,18 +130,13 @@ spec:
                 fi
               done
 
-              oc get routes -n ${SUITE_NAMESPACE}
               export routes=$(oc get routes -n ${SUITE_NAMESPACE} -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
               echo "Add label to routes updated ${routes}"
 
-              for route in $routes do
-                echo "Adding -1"
+              for route in $routes; do
                 echo "Adding label to route $route"
                 oc patch route/${route} -p '{"metadata":{"labels":{"type":"external"}}}'
-                echo "Adding -2"
               done
-
-              sleep 90000
       restartPolicy: Never
       serviceAccountName: "mas-route-sa"
   backoffLimit: 4

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -38,6 +38,70 @@ metadata:
 {{ .Values.custom_labels | toYaml | indent 4 }}
 {{- end }}
 
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: mas-route-prereq-role-{{ .Values.instance_id }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "140"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+rules:
+  - verbs:
+      - get
+      - patch
+      - create
+      - update
+    apiGroups:
+      - "route.openshift.io"
+    resources:
+      - routes
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - core.mas.ibm.com
+    resources:
+      - suites
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - apps.mas.ibm.com
+    resources:
+      - assistworkspaces
+      - healthextworkspaces
+      - healthworkspaces
+      - manageworkspaces
+      - visualinspectionappworkspaces
+      - workspaces
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - iot.ibm.com
+    resources:
+      - iotworkspaces
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -57,7 +121,7 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: mas-route-prereq-role-{{ .Values.instance_id }}
 
 ---
 apiVersion: batch/v1
@@ -134,7 +198,7 @@ spec:
               echo "Add label to routes updated ${routes}"
 
               for route in $routes; do
-                echo "Adding label to route $route"
+                echo "Adding label to route - ${route}"
                 oc patch route/${route} -p '{"metadata":{"labels":{"type":"external"}}}'
               done
       restartPolicy: Never

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -130,7 +130,9 @@ spec:
                 fi
               done
 
-              export ROUTELIST=$(oc get routes -n $SUITE_NAMESPACE -o go-template --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+              oc get routes -n ${SUITE_NAMESPACE}
+
+              export ROUTELIST=$(oc get routes -n ${SUITE_NAMESPACE} -o go-template --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
               echo "Add label to routes ${ROUTELIST}"
 
               for ROUTE in $ROUTELIST do
@@ -138,6 +140,7 @@ spec:
                 oc patch route/${ROUTE} -p '{"metadata":{"labels":{"type":"external"}}}'
               done
 
+              sleep 9000
       restartPolicy: Never
       serviceAccountName: "mas-route-sa"
   backoffLimit: 4

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -132,12 +132,14 @@ spec:
 
               oc get routes -n ${SUITE_NAMESPACE}
 
-              export ROUTELIST=$(oc get routes -n ${SUITE_NAMESPACE} -o jsonpath='{range .items[*]}{.metadata.name} {end}')
-              echo "Add label to routes ${ROUTELIST}"
+              export routes=$(oc get routes -n ${SUITE_NAMESPACE} -o jsonpath='{range .items[*]}{.metadata.name} {end}')
+              echo "Add label to routes ${routes}"
 
-              for ROUTE in $ROUTELIST do
-                echo "Adding label to route - ${ROUTE}"
-                oc patch route/${ROUTE} -p '{"metadata":{"labels":{"type":"external"}}}'
+              for route in $routes do
+                echo "Adding -1"
+                echo "Adding label to route $route"
+                oc patch route/${route} -p '{"metadata":{"labels":{"type":"external"}}}'
+                echo "Adding -2"
               done
 
               sleep 9000

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -1,0 +1,150 @@
+{{- if .Values.ingress }}
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mas-route-sa
+  namespace: mas-{{ .Values.instance_id }}-core
+  annotations:
+    argocd.argoproj.io/sync-wave: "140"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: sync-mas-route-prereq-role-{{ .Values.instance_id }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "140"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+rules:
+  - verbs:
+      - get
+      - patch
+      - create
+      - update
+    apiGroups:
+      - ""
+    resources:
+      - secrets
+  - verbs:
+      - get
+      - patch
+      - create
+      - update
+    apiGroups:
+      - "route.openshift.io"
+    resources:
+      - routes
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sync-mas-route-prereq-rb-{{ .Values.instance_id }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "141"
+
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+subjects:
+  - kind: ServiceAccount
+    name: mas-route-sa
+    namespace: mas-{{ .Values.instance_id }}-core
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sync-mas-route-prereq-role-{{ .Values.instance_id }}
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "mas-route-patch-v1-{{ .Values | toYaml | adler32sum }}"
+  namespace: mas-{{ .Values.instance_id }}-core
+  annotations:
+    argocd.argoproj.io/sync-wave: "142"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+spec:
+  template:
+{{- if .Values.custom_labels }}
+    metadata:
+      labels:
+{{ .Values.custom_labels | toYaml | indent 8 }}
+{{- end }}
+    spec:
+      containers:
+        - name: run
+          image: quay.io/ibmmas/cli:latest
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 10m
+              memory: 64Mi
+          env:
+            - name: SUITE_NAMESPACE
+              value: mas-{{ .Values.instance_id }}-core
+          command:
+            - /bin/sh
+            - -c
+            - |
+
+              set -e
+              echo
+              echo "================================================================================"
+              echo "Wait for Suite Routes to be ready and add label type=external to routes"
+              echo "================================================================================"
+              echo
+
+              echo "Wait for Suite Routes to be ready"
+              wait_period=0
+              while true; do
+                wait_period=$(($wait_period+60))
+                if [ $wait_period -gt 3600 ]; then
+                  echo "Suite Routes is not ready after 20 minutes of waiting. exiting..."
+                  exit 1
+                else
+                  sleep 60
+                fi
+
+
+                SUITE_NAME=$(oc get Suite -n $SUITE_NAMESPACE -o NAME)
+                echo "SUITE_NAME == ${SUITE_NAME}"
+
+                export ROUTES_READY=$(oc get ${SUITE_NAME} -n ${SUITE_NAMESPACE} -o=jsonpath="{.status.conditions[?(@.type=='RoutesReady')].status}")
+                echo "ROUTES_READY == ${ROUTES_READY}"
+
+                if [[ "${ROUTES_READY}" == "True" ]]; then
+                  echo "Suite Routes are now in ready status"
+                  break
+                fi
+              done
+
+              export ROUTELIST=$(oc get routes -n $SUITE_NAMESPACE -o go-template --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+              echo "Add label to routes ${ROUTELIST}"
+
+              for ROUTE in $ROUTELIST do
+                echo "Adding label to route - ${ROUTE}"
+                oc patch route/${ROUTE} -p '{"metadata":{"labels":{"type":"external"}}}'
+              done
+
+      restartPolicy: Never
+      serviceAccountName: "mas-route-sa"
+  backoffLimit: 4
+
+{{- end }}

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -40,55 +40,9 @@ metadata:
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: mas-route-prereq-role-{{ .Values.instance_id }}
-  annotations:
-    argocd.argoproj.io/sync-wave: "140"
-{{- if .Values.custom_labels }}
-  labels:
-{{ .Values.custom_labels | toYaml | indent 4 }}
-{{- end }}
-rules:
-  - verbs:
-      - get
-      - patch
-      - create
-      - update
-    apiGroups:
-      - ""
-    resources:
-      - secrets
-  - verbs:
-      - get
-      - patch
-      - create
-      - update
-    apiGroups:
-      - "route.openshift.io"
-    resources:
-      - routes
-  - verbs:
-      - get
-      - list
-      - patch
-      - update
-    apiGroups:
-      - ''
-      - suites.core.mas.ibm.com
-      - assistworkspaces.apps.mas.ibm.com
-      - healthextworkspaces.apps.mas.ibm.com
-      - healthworkspaces.apps.mas.ibm.com
-      - iotworkspaces.iot.ibm.com
-      - manageworkspaces.apps.mas.ibm.com
-      - visualinspectionappworkspaces.apps.mas.ibm.com
-    resources:
-      - customresourcedefinitions
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: sync-mas-route-prereq-rb-{{ .Values.instance_id }}
+  name: mas-route-prereq-rb-{{ .Values.instance_id }}
   annotations:
     argocd.argoproj.io/sync-wave: "141"
 
@@ -103,7 +57,7 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: mas-route-prereq-role-{{ .Values.instance_id }}
+  name: cluster-admin
 
 ---
 apiVersion: batch/v1
@@ -153,8 +107,6 @@ spec:
               echo
 
               echo "Wait for Suite Routes to be ready"
-              echo "oc get Suite -n $SUITE_NAMESPACE -o NAME"
-              `oc get Suite -n $SUITE_NAMESPACE -o NAME`
               wait_period=0
               while true; do
                 wait_period=$(($wait_period+60))
@@ -162,7 +114,6 @@ spec:
                   echo "Suite Routes is not ready after 20 minutes of waiting. exiting..."
                   exit 1
                 else
-                  echo "sleep for 1 minute"
                   sleep 60
                 fi
 

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -63,7 +63,7 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: sync-mas-route-prereq-role-{{ .Values.instance_id }}
+  name: cluster-admin
 
 ---
 apiVersion: batch/v1

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
@@ -47,7 +47,7 @@ kind: ClusterRole
 metadata:
   name: mas-app-route-prereq-role-{{ .Values.instance_id }}-{{ .Values.mas_app_id }}
   annotations:
-    argocd.argoproj.io/sync-wave: "140"
+    argocd.argoproj.io/sync-wave: "100"
 {{- if .Values.custom_labels }}
   labels:
 {{ .Values.custom_labels | toYaml | indent 4 }}
@@ -107,7 +107,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: mas-route-prereq-rb-{{ .Values.instance_id }}-{{ .Values.mas_app_id }}
+  name: mas-app-route-prereq-rb-{{ .Values.instance_id }}-{{ .Values.mas_app_id }}
   annotations:
     argocd.argoproj.io/sync-wave: "101"
 

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
@@ -65,18 +65,7 @@ rules:
       - "route.openshift.io"
     resources:
       - routes
-  - verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-    apiGroups:
-      - core.mas.ibm.com
-    resources:
-      - suites
+
   - verbs:
       - create
       - delete

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
@@ -1,16 +1,41 @@
 {{- if .Values.ingress }}
 
 {{ $ns               :=  .Values.mas_app_namespace }}
+
+{{ $job_label :=  "mas-app-route-patch" }}
+---
+# Permit outbound communication by the Job pods
+# (Needed to communicate with the K8S HTTP API and AWS SM)
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: mas-app-route-np
+  namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "100"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $job_label }}
+  egress:
+    - {}
+  policyTypes:
+    - Egress
+
+
 ---
 # Service account that is authorized to read k8s secrets (needed by the job)
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: mas-route-sa-{{ .Values.instance_id }}-{{ .Values.mas_app_id }}
+  name: mas-app-route-sa
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "100"
-    argocd.argoproj.io/hook: PostSync
 {{- if .Values.custom_labels }}
   labels:
 {{ .Values.custom_labels | toYaml | indent 4 }}
@@ -18,43 +43,11 @@ metadata:
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: sync-mas-route-prereq-role-{{ .Values.instance_id }}-{{ .Values.mas_app_id }}
-  annotations:
-    argocd.argoproj.io/sync-wave: "100"
-    argocd.argoproj.io/hook: PostSync
-{{- if .Values.custom_labels }}
-  labels:
-{{ .Values.custom_labels | toYaml | indent 4 }}
-{{- end }}
-rules:
-  - verbs:
-      - get
-      - patch
-      - create
-      - update
-    apiGroups:
-      - ""
-    resources:
-      - secrets
-  - verbs:
-      - get
-      - patch
-      - create
-      - update
-    apiGroups:
-      - "route.openshift.io"
-    resources:
-      - routes
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: sync-mas-route-prereq-rb-{{ .Values.instance_id }}-{{ .Values.mas_app_id }}
+  name: mas-route-prereq-rb-{{ .Values.instance_id }}-{{ .Values.mas_app_id }}
   annotations:
     argocd.argoproj.io/sync-wave: "101"
-    argocd.argoproj.io/hook: PostSync
 
 {{- if .Values.custom_labels }}
   labels:
@@ -62,7 +55,7 @@ metadata:
 {{- end }}
 subjects:
   - kind: ServiceAccount
-    name: mas-route-sa-{{ .Values.instance_id }}-{{ .Values.mas_app_id }}
+    name: mas-app-route-sa
     namespace: {{ $ns }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -73,20 +66,20 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "mas-route-patch-{{ .Values.instance_id }}-{{ .Values.mas_app_id }}-v1-{{ .Values | toYaml | adler32sum }}"
+  name: "mas-app-route-patch-v1-{{ .Values | toYaml | adler32sum }}"
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "102"
-    argocd.argoproj.io/hook: PostSync
 {{- if .Values.custom_labels }}
   labels:
 {{ .Values.custom_labels | toYaml | indent 4 }}
 {{- end }}
 spec:
   template:
-{{- if .Values.custom_labels }}
     metadata:
       labels:
+        app: {{ $job_label }}
+{{- if .Values.custom_labels }}
 {{ .Values.custom_labels | toYaml | indent 8 }}
 {{- end }}
     spec:
@@ -164,7 +157,7 @@ spec:
               fi
 
       restartPolicy: Never
-      serviceAccountName: "mas-route-sa-{{ .Values.instance_id }}-{{ .Values.mas_app_id }}"
+      serviceAccountName: "mas-app-route-sa"
   backoffLimit: 4
 
 {{- end }}

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
@@ -54,26 +54,17 @@ metadata:
 {{- end }}
 rules:
   - verbs:
-      - create
-      - delete
       - get
       - list
       - patch
-      - update
-      - watch
     apiGroups:
       - "route.openshift.io"
     resources:
       - routes
 
   - verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
-      - update
-      - watch
     apiGroups:
       - apps.mas.ibm.com
     resources:
@@ -84,13 +75,8 @@ rules:
       - visualinspectionappworkspaces
       - workspaces
   - verbs:
-      - create
-      - delete
       - get
       - list
-      - patch
-      - update
-      - watch
     apiGroups:
       - iot.ibm.com
     resources:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
@@ -54,10 +54,13 @@ metadata:
 {{- end }}
 rules:
   - verbs:
-      - get
-      - patch
       - create
+      - delete
+      - get
+      - list
+      - patch
       - update
+      - watch
     apiGroups:
       - "route.openshift.io"
     resources:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
@@ -1,0 +1,170 @@
+{{- if .Values.ingress }}
+
+{{ $ns               :=  .Values.mas_app_namespace }}
+---
+# Service account that is authorized to read k8s secrets (needed by the job)
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mas-route-sa-{{ .Values.instance_id }}-{{ .Values.mas_app_id }}
+  namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "100"
+    argocd.argoproj.io/hook: PostSync
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: sync-mas-route-prereq-role-{{ .Values.instance_id }}-{{ .Values.mas_app_id }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "100"
+    argocd.argoproj.io/hook: PostSync
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+rules:
+  - verbs:
+      - get
+      - patch
+      - create
+      - update
+    apiGroups:
+      - ""
+    resources:
+      - secrets
+  - verbs:
+      - get
+      - patch
+      - create
+      - update
+    apiGroups:
+      - "route.openshift.io"
+    resources:
+      - routes
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sync-mas-route-prereq-rb-{{ .Values.instance_id }}-{{ .Values.mas_app_id }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "101"
+    argocd.argoproj.io/hook: PostSync
+
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+subjects:
+  - kind: ServiceAccount
+    name: mas-route-sa-{{ .Values.instance_id }}-{{ .Values.mas_app_id }}
+    namespace: {{ $ns }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sync-mas-route-prereq-role-{{ .Values.instance_id }}-{{ .Values.mas_app_id }}
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "mas-route-patch-{{ .Values.instance_id }}-{{ .Values.mas_app_id }}-v1-{{ .Values | toYaml | adler32sum }}"
+  namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "102"
+    argocd.argoproj.io/hook: PostSync
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+spec:
+  template:
+{{- if .Values.custom_labels }}
+    metadata:
+      labels:
+{{ .Values.custom_labels | toYaml | indent 8 }}
+{{- end }}
+    spec:
+      containers:
+        - name: run
+          image: quay.io/ibmmas/cli:latest
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 10m
+              memory: 64Mi
+          env:
+            - name: MAS_APP_NAMESPACE
+              value: {{ .Values.mas_app_namespace }}
+            - name: MAS_APP_ID
+              value: {{ .Values.mas_app_id }}
+
+          command:
+            - /bin/sh
+            - -c
+            - |
+
+              set -e
+              echo
+              echo "================================================================================"
+              echo "Wait for App workspaces to be ready and add label type=external to routes"
+              echo "================================================================================"
+              echo
+
+              declare -A mas_app_workspace_name
+              mas_app_workspace_name['iot']="IoTWorkspace"
+              mas_app_workspace_name['manage']="ManageWorkspace"
+              mas_app_workspace_name['monitor']="MonitorWorkspace"
+              mas_app_workspace_name['assist']="AssistWorkspace"
+              mas_app_workspace_name['optimizer']="OptimizerWorkspace"
+              mas_app_workspace_name['predict']="PredictWorkspace"
+              mas_app_workspace_name['visualinspection']="VisualInspectionAppWorkspace"
+
+              if [[ -n "${mas_app_workspace_name[$MAS_APP_ID]}" ]]; then
+
+                echo "Wait for App Workspaces to be ready"
+                wait_period=0
+                while true; do
+                  wait_period=$(($wait_period+60))
+                  if [ $wait_period -gt 21600 ]; then
+                    echo "App workspaces is not ready after 6 hours of waiting. exiting..."
+                    exit 1
+                  else
+                    sleep 60
+                  fi
+
+                  MAS_APP_WORKSPACE_NAME=${mas_app_workspace_name[$MAS_APP_ID]}
+                  MAS_APP_NAME=$(oc get $MAS_APP_WORKSPACE_NAME -n $MAS_APP_NAMESPACE -o NAME)
+                  echo "MAS_APP_NAME == ${MAS_APP_NAME}"
+
+                  export MAS_APP_READY=$(oc get ${MAS_APP_NAME} -n ${MAS_APP_NAMESPACE} -o=jsonpath="{.status.conditions[?(@.type=='Ready')].status}")
+                  echo "MAS_APP_READY == ${MAS_APP_READY}"
+
+                  if [[ "${MAS_APP_READY}" == "True" ]]; then
+                    echo "${MAS_APP_NAME} is in ready status"
+                    break
+                  fi
+                done
+
+                export ROUTELIST=$(oc get routes -n $MAS_APP_NAMESPACE -o go-template --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+                echo "Add label to routes ${ROUTELIST}"
+
+                for ROUTE in $ROUTELIST do
+                  echo "Adding label to route - ${ROUTE}"
+                  oc patch route/${ROUTE} -p '{"metadata":{"labels":{"type":"external"}}}'
+                done
+              fi
+
+      restartPolicy: Never
+      serviceAccountName: "mas-route-sa-{{ .Values.instance_id }}-{{ .Values.mas_app_id }}"
+  backoffLimit: 4
+
+{{- end }}

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
@@ -67,7 +67,7 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: sync-mas-route-prereq-role-{{ .Values.instance_id }}-{{ .Values.mas_app_id }}
+  name: cluster-admin
 
 ---
 apiVersion: batch/v1

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
@@ -147,12 +147,12 @@ spec:
                   fi
                 done
 
-                export ROUTELIST=$(oc get routes -n $MAS_APP_NAMESPACE -o go-template --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
-                echo "Add label to routes ${ROUTELIST}"
+                export routes=$(oc get routes -n ${MAS_APP_NAMESPACE} -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
+                echo "Add label to routes ${routes}"
 
-                for ROUTE in $ROUTELIST do
-                  echo "Adding label to route - ${ROUTE}"
-                  oc patch route/${ROUTE} -p '{"metadata":{"labels":{"type":"external"}}}'
+                for route in $routes; do
+                  echo "Adding label to route - ${route}"
+                  oc patch route/${route} -p '{"metadata":{"labels":{"type":"external"}}}'
                 done
               fi
 

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
@@ -1,8 +1,8 @@
 {{- if .Values.ingress }}
 
-{{ $ns               :=  .Values.mas_app_namespace }}
-
+{{ $ns        :=  .Values.mas_app_namespace }}
 {{ $job_label :=  "mas-app-route-patch" }}
+
 ---
 # Permit outbound communication by the Job pods
 # (Needed to communicate with the K8S HTTP API and AWS SM)
@@ -26,7 +26,6 @@ spec:
   policyTypes:
     - Egress
 
-
 ---
 # Service account that is authorized to read k8s secrets (needed by the job)
 apiVersion: v1
@@ -41,6 +40,69 @@ metadata:
 {{ .Values.custom_labels | toYaml | indent 4 }}
 {{- end }}
 
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: mas-app-route-prereq-role-{{ .Values.instance_id }}-{{ .Values.mas_app_id }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "140"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+rules:
+  - verbs:
+      - get
+      - patch
+      - create
+      - update
+    apiGroups:
+      - "route.openshift.io"
+    resources:
+      - routes
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - core.mas.ibm.com
+    resources:
+      - suites
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - apps.mas.ibm.com
+    resources:
+      - assistworkspaces
+      - healthextworkspaces
+      - healthworkspaces
+      - manageworkspaces
+      - visualinspectionappworkspaces
+      - workspaces
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - iot.ibm.com
+    resources:
+      - iotworkspaces
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -60,7 +122,7 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: mas-app-route-prereq-role-{{ .Values.instance_id }}-{{ .Values.mas_app_id }}
 
 ---
 apiVersion: batch/v1

--- a/root-applications/ibm-mas-cluster-root/templates/030-ibm-cis-cert-manager.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/030-ibm-cis-cert-manager.yaml
@@ -43,7 +43,7 @@ spec:
             ocp_cluster_domain: "{{ .Values.ibm_cis_cert_manager.ocp_cluster_domain }}"
             cis_apikey: "{{ .Values.ibm_cis_cert_manager.cis_apikey }}"
             ocp_public_cluster_domain: "{{ .Values.ibm_cis_cert_manager.ocp_public_cluster_domain }}"
-            cluster_ingress: "{{ .Values.ibm_cis_cert_manager.cluster_ingress }}"
+            ingress: {{ .Values.ibm_cis_cert_manager.ingress }}
 
         - name: ARGOCD_APP_NAME
           value: ibmciscertmanagerapp

--- a/root-applications/ibm-mas-cluster-root/templates/030-ibm-cis-cert-manager.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/030-ibm-cis-cert-manager.yaml
@@ -42,6 +42,8 @@ spec:
             dns_provider: "{{ .Values.ibm_cis_cert_manager.dns_provider }}"
             ocp_cluster_domain: "{{ .Values.ibm_cis_cert_manager.ocp_cluster_domain }}"
             cis_apikey: "{{ .Values.ibm_cis_cert_manager.cis_apikey }}"
+            ocp_public_cluster_domain: "{{ .Values.ibm_cis_cert_manager.ocp_public_cluster_domain }}"
+            cluster_ingress: "{{ .Values.ibm_cis_cert_manager.cluster_ingress }}"
 
         - name: ARGOCD_APP_NAME
           value: ibmciscertmanagerapp

--- a/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-app.yaml
@@ -56,6 +56,7 @@ spec:
             dns_provider: "{{ .Values.ibm_mas_suite.dns_provider }}"
             icr_cp: "{{ .Values.ibm_mas_suite.icr_cp }}"
             icr_cp_open: "{{ .Values.ibm_mas_suite.icr_cp_open }}"
+            ingress: "{{ .Values.ibm_mas_suite.ingress }}"
 
             {{- if .Values.ibm_mas_suite.mas_annotations }}
             mas_annotations: {{ .Values.ibm_mas_suite.mas_annotations | toYaml | nindent 14 }}

--- a/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
@@ -63,6 +63,7 @@ spec:
             mas_appws_spec: {{ $value.mas_appws_spec | toYaml | nindent 14 }}
 
             mas_manual_cert_mgmt: {{ $value.mas_manual_cert_mgmt   }}
+            ingress: {{ $value.ingress }}
             {{- if $value.mas_manual_cert_mgmt  }}
             public_tls_secret_name: "{{ $value.public_tls_secret_name }}"
             ca_cert: |


### PR DESCRIPTION


Issue https://jsw.ibm.com/browse/MASCORE-3232

As part of this changes below are achieved:
1. Gitops creates a public IngressController controlled via ingress flag present in cluster params file
2. Gitops adds type: "external" label to mas core  & apps controlled via ingress flag
3. Gitops adds type: "external" label to db2 route controlled via jdbc_route flag, if set to public in cluster params file
