### PR TITLE
[patch] MAS instance Mongo data wipe job to sync-jobs application

### DIFF
--- a/instance-applications/010-ibm-sync-jobs/templates/PostDelete-aws-docdb-remove-user_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/PostDelete-aws-docdb-remove-user_Job.yaml
@@ -68,18 +68,60 @@ spec:
                   name: aws
                   key: aws_secret_access_key
 
+            - name: MAS_WIPE_MONGO_DATA
+              value: "{{ .Values.mas_wipe_mongo_data }}"
+
           command:
             - /bin/sh
             - -c
             - |
+
+
+              if [[ "${MAS_WIPE_MONGO_DATA}" == "true" ]]; then
+                echo
+                echo "================================================================================"
+                echo "Wiping data from Mongo for MAS instance ${MAS_INSTANCE_ID}"
+                echo "================================================================================"
+
+                export ROLE_NAME=mongodb
+                export MONGODB_ACTION=destroy-data
+                export MONGODB_PROVIDER=aws
+
+                # Map DOCDB_MASTER_INFO YAML into structure expected by destroy-data role
+                # Just need to remove the top-level key
+                export CONFIG=$(echo "${DOCDB_MASTER_INFO}" | yq '.config')
+
+                # We seem to permit the "info" attribute of the mongo secret in AWS (DOCDB_MASTER_INFO here) provide certificates either as "certificates" (at the top level), or "config.certificate".
+                # There is existing code elsewhere to cope with both alternatives;
+                # e.g. https://github.com/ibm-mas/cli/blob/03a9499e6bb433d28ed3f928f92fd0b8ce7f4e73/image/cli/mascli/templates/gitops/appset-configs/cluster/instance/configs/ibm-mas-mongo-config.yaml.j2#L32
+                # So this script will also have to allow either to be used
+                export CERTIFICATES=$(echo "${DOCDB_MASTER_INFO}" | yq '.certificates // .config.certificate')
+
+                export MONGO_USERNAME="${DOCDB_MASTER_USERNAME}"
+                export MONGO_PASSWORD="${DOCDB_INSTANCE_PASSWORD}"
+
+                echo "Params:"
+                echo "    - MAS_INSTANCE_ID         ................... ${MAS_INSTANCE_ID}"
+                echo "    - ROLE_NAME               ................... ${ROLE_NAME}"
+                echo "    - MONGODB_ACTION          ................... ${MONGODB_ACTION}"
+                echo "    - MONGODB_PROVIDER        ................... ${MONGODB_PROVIDER}"
+                echo "    - MONGO_USERNAME          ................... ${MONGO_USERNAME:0:2}<snip>"
+                echo "    - MONGO_PASSWORD          ................... ${MONGO_PASSWORD:0:2}<snip>"
+                echo "    - CONFIG                  ................... ${CONFIG}"
+                echo "    - CERTIFICATES            ................... ${CERTIFICATES}"
+
+                ansible-playbook ibm.mas_devops.run_role
+                rc=$?
+                echo "Role mongodb with action destroy-data completed with rc=${rc}"
+                [ $rc -ne 0 ] && exit $rc
+              fi
+
 
               echo
               echo "================================================================================"
               echo "/opt/app-root/src/run-role.sh aws_documentdb_user"
               echo "================================================================================"
 
-              export MAS_CONFIG_DIR="/tmp/${MAS_INSTANCE_ID}/aws_documentdb_user"
-              export USER_ACTION="remove"
 
               DOCDB_HOST_COUNT=$(echo "${DOCDB_MASTER_INFO}" | sed 's/\\n/\n/g' | sed 's/\\"//g' | yq '.config.hosts  | length')
               while [ ${DOCDB_HOST_COUNT} -gt 0 ]; do
@@ -103,6 +145,10 @@ spec:
               echo "    - DOCDB_INSTANCE_PASSWORD ................... ${DOCDB_INSTANCE_PASSWORD:0:2}<snip>"
               echo "    - USER_ACTION             ................... ${USER_ACTION}"
               echo
+
+
+              export MAS_CONFIG_DIR="/tmp/${MAS_INSTANCE_ID}/aws_documentdb_user"
+              export USER_ACTION="remove"
 
               mkdir -p ${MAS_CONFIG_DIR}
               /opt/app-root/src/run-role.sh aws_documentdb_user || exit $?

--- a/instance-applications/010-ibm-sync-jobs/templates/PostDelete-aws-docdb-remove-user_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/PostDelete-aws-docdb-remove-user_Job.yaml
@@ -81,15 +81,23 @@ spec:
               export MAS_CONFIG_DIR="/tmp/${MAS_INSTANCE_ID}/aws_documentdb_user"
               export USER_ACTION="remove"
 
-              # Grab one of the hosts/ports out of docdb master info
-              export DOCDB_HOST=$(echo "${DOCDB_MASTER_INFO}" | sed 's/\\n/\n/g' | sed 's/\\"//g' | yq '.config.hosts[0].host')
-              export DOCDB_PORT=$(echo "${DOCDB_MASTER_INFO}" | sed 's/\\n/\n/g' | yq '.config.hosts[0].port')
+              DOCDB_HOST_COUNT=$(echo "${DOCDB_MASTER_INFO}" | sed 's/\\n/\n/g' | sed 's/\\"//g' | yq '.config.hosts  | length')
+              while [ ${DOCDB_HOST_COUNT} -gt 0 ]; do
+                DOCDB_HOST_COUNT=$((DOCDB_HOST_COUNT-1))
+                # Grab hosts/ports from docdb master info
+                DOCDB_HOST=$(echo "${DOCDB_MASTER_INFO}" | sed 's/\\n/\n/g' | sed 's/\\"//g' | yq ".config.hosts[$DOCDB_HOST_COUNT].host")
+                DOCDB_PORT=$(echo "${DOCDB_MASTER_INFO}" | sed 's/\\n/\n/g' | yq ".config.hosts[$DOCDB_HOST_COUNT].port")
+                DOCDB_HOSTS="$DOCDB_HOSTS$DOCDB_HOST:$DOCDB_PORT,"
+              done
+              # remove trailing comma
+              export DOCDB_HOSTS=${DOCDB_HOSTS%,}
 
               echo "Params:"
               echo "    - MAS_INSTANCE_ID         ................... ${MAS_INSTANCE_ID}"
               echo "    - MAS_CONFIG_DIR          ................... ${MAS_CONFIG_DIR}"
               echo "    - DOCDB_HOST              ................... ${DOCDB_HOST}"
               echo "    - DOCDB_PORT              ................... ${DOCDB_PORT}"
+              echo "    - DOCDB_HOSTS             ................... ${DOCDB_HOSTS}"
               echo "    - DOCDB_MASTER_USERNAME   ................... ${DOCDB_MASTER_USERNAME:0:2}<snip>"
               echo "    - DOCDB_MASTER_PASSWORD   ................... ${DOCDB_MASTER_PASSWORD:0:2}<snip>"
               echo "    - DOCDB_INSTANCE_PASSWORD ................... ${DOCDB_INSTANCE_PASSWORD:0:2}<snip>"

--- a/instance-applications/130-ibm-mas-mongo-config/templates/01-mongo-credentials_Secret.yaml
+++ b/instance-applications/130-ibm-mas-mongo-config/templates/01-mongo-credentials_Secret.yaml
@@ -14,26 +14,3 @@ type: Opaque
 stringData:
   username: "{{ .Values.username }}"
   password: "{{ .Values.password }}"
-
----
-kind: Secret
-apiVersion: v1
-metadata:
-  name: mongo-db
-  namespace: mas-{{ .Values.instance_id }}-core
-  annotations:
-    argocd.argoproj.io/hook: PostDelete
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
-{{- if .Values.custom_labels }}
-  labels:
-{{ .Values.custom_labels | toYaml | indent 4 }}
-{{- end }}
-stringData:
-  mongo_username: {{ .Values.username }}
-  mongo_password: {{ .Values.password }}
-  mas_wipe_mongo_data: "{{ .Values.mas_wipe_mongo_data }}"
-  config.yaml: |
-{{ .Values.config | toYaml | indent 4 }}
-  certificates.yaml: |
-{{ .Values.certificates | toYaml | indent 4 }}
-type: Opaque

--- a/instance-applications/130-ibm-mas-mongo-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-mas-mongo-config/templates/postdelete-delete-cr.yaml
@@ -140,33 +140,6 @@ spec:
                 
               }
 
-              echo -e "Silently wipe Mongo data"
-
-              
-              echo ""
-              echo "================================================================================"
-              echo "Settings - wipe_mongo"
-              echo "================================================================================"
-              echo "MAS Instance ID ....................... ${COLOR_MAGENTA}${MAS_INSTANCE_ID}"
-              echo "Mongo username ........................ ${COLOR_MAGENTA}${MONGO_USERNAME}"
-              echo "Mongo password ........................ ${COLOR_MAGENTA}${MONGO_PASSWORD:0:6}<snip>"
-              echo "Mongo config .......................... ${COLOR_MAGENTA}${CONFIG}"
-              echo "Mongo certificates .................... ${COLOR_MAGENTA}${CERTIFICATES}"
-              echo "MAS_WIPE_MONGO_DATA ................... ${COLOR_MAGENTA}${MAS_WIPE_MONGO_DATA}"
-              echo ""
-              echo "================================================================================"
-
-              if [[ "${MAS_WIPE_MONGO_DATA}" == "true" ]]; then
-
-                export ROLE_NAME=mongodb
-                export MONGODB_ACTION=destroy-data
-                export MONGODB_PROVIDER=aws
-                ansible-playbook ibm.mas_devops.run_role
-                rc=$?
-                echo "Role mongodb with action destroy-data completes with rc=${rc}"
-                [ $rc -ne 0 ] && exit $rc
-              fi
-
               delete_oc_resource "${CR_KIND}.${CR_API_VERSION}/${CR_NAME}" "${CR_NAMESPACE}"
 
 

--- a/instance-applications/130-ibm-mas-mongo-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-mas-mongo-config/templates/postdelete-delete-cr.yaml
@@ -66,28 +66,6 @@ spec:
             - name: MAS_INSTANCE_ID
               value: {{ $mas_instance_id }}
 
-            - name: MONGO_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: mongo-db
-                  key: mongo_username
-
-            - name: MONGO_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: mongo-db
-                  key: mongo_password
-
-            - name: MAS_WIPE_MONGO_DATA
-              valueFrom:
-                secretKeyRef:
-                  name: mongo-db
-                  key: mas_wipe_mongo_data
-
-          volumeMounts:
-            - name: "mongo-db"
-              mountPath: /etc/mas/secrets/mongo_db
-
           command:
             - /bin/sh
             - -c
@@ -95,8 +73,6 @@ spec:
 
               set -e
 
-              export CONFIG=$(cat /etc/mas/secrets/mongo_db/config.yaml | yq '.' )
-              export CERTIFICATES=$(cat /etc/mas/secrets/mongo_db/certificates.yaml | yq '.' )
 
               function delete_oc_resource(){
                 RESOURCE=$1
@@ -146,11 +122,5 @@ spec:
       restartPolicy: Never
       serviceAccountName: {{ $sa_name }}
 
-      volumes:
-        - name: "mongo-db"
-          secret:
-            secretName: "mongo-db"
-            defaultMode: 420
-            optional: false
   backoffLimit: 4
 {{- end }}

--- a/root-applications/ibm-mas-instance-root/templates/010-ibm-sync-jobs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/010-ibm-sync-jobs.yaml
@@ -86,11 +86,11 @@ spec:
 
             {{- end }}
 
-
-
             {{- if .Values.custom_labels }}
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}
+
+            mas_wipe_mongo_data: {{ .Values.mas_wipe_mongo_data }}
 
         - name: ARGOCD_APP_NAME
           value: syncres


### PR DESCRIPTION
https://jsw.ibm.com/browse/MASCORE-3100

The PostDelete annotated secret necessary for running this Job in the mongocfg application was causing deprovisioning to hang due to a [known issue](https://github.com/argoproj/argo-cd/issues/17191) in ArgoCD.

The approach we've taken for PostDelete jobs that depend on other resources (e.g. secrets) is to move them to the `sync-jobs` application. This has a supporting application `sync-res` that contains the secret needed by this job. Since `sync-res` is in an earlier syncwave than `sync-jobs`, the resources will persist until after any PostDelete hooks in `sync-jobs` have completed.

This approach seemed appropriate here. In fact, the existing [PostDelete-aws-docdb-remove-user_Job](https://github.com/ibm-mas/gitops/blob/main/instance-applications/010-ibm-sync-jobs/templates/PostDelete-aws-docdb-remove-user_Job.yaml) seems like a good fit for performing the mongo data wipe.

The PR also fixes an additional issue in [PostDelete-aws-docdb-remove-user_Job](https://github.com/ibm-mas/gitops/blob/main/instance-applications/010-ibm-sync-jobs/templates/PostDelete-aws-docdb-remove-user_Job.yaml) where only the first Mongo host was being passed into the aws_documentdb_user role. If this host did not happen to be the primary, the role would fail to execute. With these changes, all known hosts are passed to the role.

NOTE: The code in this PR is built on top of the mascore3340 branch (since I wanted to test everything together in a single deployment). This PR currently targets mascore3340. mascore3340 should be merged into master first, then this PR should be updated to target master before being merged.