### PR TITLE
[minor] [MASCORE-3232] suport ingress controller and expose routes to…

### DIFF
--- a/cluster-applications/030-ibm-cis-cert-manager/templates/00-8-ibm-cis-webhook_cis-ingress-controller.yaml
+++ b/cluster-applications/030-ibm-cis-cert-manager/templates/00-8-ibm-cis-webhook_cis-ingress-controller.yaml
@@ -1,0 +1,24 @@
+{{- if and (eq .Values.dns_provider "cis") (.Values.ingress) }}
+---
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: public
+  namespace: openshift-ingress-operator
+spec:
+  domain: "{{ .Values.ocp_public_cluster_domain }}"
+  routeSelector:
+    matchLabels:
+      type: external
+  tuningOptions: {}
+  unsupportedConfigOverrides: null
+  httpErrorCodePages:
+    name: ''
+  replicas: 3
+  httpEmptyRequestsPolicy: Respond
+  endpointPublishingStrategy:
+    loadBalancer:
+      dnsManagementPolicy: Managed
+      scope: Internal
+    type: LoadBalancerService
+{{- end }}

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
@@ -33,6 +33,9 @@ spec:
             - name: MAS_INSTANCE_ID
               value: "{{ .Values.instance_id }}"
 
+            - name: SECRETS_KEY_SEPERATOR
+              value: "/"
+
             # dns
             - name: DNS_PROVIDER
               value: "{{ .Values.dns_provider }}"
@@ -90,12 +93,18 @@ spec:
 
               set -e
 
-              source /mascli/functions/gitops_utils
+
 
               export CIS_APIKEY=$(cat /etc/mas/creds/suite_dns/cis_apikey)
               export SM_AWS_ACCESS_KEY_ID=$(cat /etc/mas/creds/suite_dns/sm_aws_access_key_id)
               export SM_AWS_SECRET_ACCESS_KEY=$(cat /etc/mas/creds/suite_dns/sm_aws_secret_access_key)
+              source /mascli/functions/gitops_utils
+              sm_login
 
+              #if DNS name is set in AWS SM path account/cluster/public-elb (key=dns), set its value to OCP_INGRESS
+              export PUBLIC_ELB_DNS_NAME_FILE="/tmp/public-elb-dns-name-file.json"
+              sm_get_secret_file ${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}public-elb ${PUBLIC_ELB_DNS_NAME_FILE}
+              export OCP_INGRESS=$(jq -r .dns $PUBLIC_ELB_DNS_NAME_FILE)
 
               echo ""
               echo "================================================================================"
@@ -123,6 +132,7 @@ spec:
               echo "DELETE_WILDCARDS Flag ............... ${COLOR_MAGENTA}${DELETE_WILDCARDS}"
               echo "OVERRIDE_EDGE_CERTS Flag ............ ${COLOR_MAGENTA}${OVERRIDE_EDGE_CERTS}"
 
+              echo "OCP_INGRESS  ........................ ${COLOR_MAGENTA}${OCP_INGRESS}"
               echo "SM_AWS_REGION ....................... ${COLOR_MAGENTA}${SM_AWS_REGION}"
               echo "SM_AWS_ACCESS_KEY_ID ................ ${COLOR_MAGENTA}${SM_AWS_ACCESS_KEY_ID:0:4}<snip>"
               echo "SM_AWS_SECRET_ACCESS_KEY ............ ${COLOR_MAGENTA}${SM_AWS_SECRET_ACCESS_KEY:0:4}<snip>"

--- a/instance-applications/120-ibm-db2u-database/templates/04-tlsroute.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/04-tlsroute.yaml
@@ -8,6 +8,9 @@ metadata:
     argocd.argoproj.io/sync-wave: "123"
   labels:
     formation_id: "{{ .Values.db2_instance_name | lower }}"
+{{- if eq .Values.jdbc_route "public" }}
+    type: "external"
+{{- end }}
 {{- if .Values.custom_labels }}
 {{ .Values.custom_labels | toYaml | indent 4 }}
 {{- end }}

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -1,0 +1,175 @@
+{{- if .Values.ingress }}
+
+{{ $job_label :=  "mas-route-patch" }}
+---
+# Permit outbound communication by the Job pods
+# (Needed to communicate with the K8S HTTP API and AWS SM)
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: mas-route-np
+  namespace: mas-{{ .Values.instance_id }}-core
+  annotations:
+    argocd.argoproj.io/sync-wave: "140"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $job_label }}
+  egress:
+    - {}
+  policyTypes:
+    - Egress
+
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mas-route-sa
+  namespace: mas-{{ .Values.instance_id }}-core
+  annotations:
+    argocd.argoproj.io/sync-wave: "140"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: mas-route-prereq-role-{{ .Values.instance_id }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "140"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+rules:
+  - verbs:
+      - get
+      - list
+      - patch
+    apiGroups:
+      - "route.openshift.io"
+    resources:
+      - routes
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - core.mas.ibm.com
+    resources:
+      - suites
+
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: mas-route-prereq-rb-{{ .Values.instance_id }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "141"
+
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+subjects:
+  - kind: ServiceAccount
+    name: mas-route-sa
+    namespace: mas-{{ .Values.instance_id }}-core
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: mas-route-prereq-role-{{ .Values.instance_id }}
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "mas-route-patch-v1-{{ .Values | toYaml | adler32sum }}"
+  namespace: mas-{{ .Values.instance_id }}-core
+  annotations:
+    argocd.argoproj.io/sync-wave: "142"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ $job_label }}
+{{- if .Values.custom_labels }}
+{{ .Values.custom_labels | toYaml | indent 8 }}
+{{- end }}
+    spec:
+      containers:
+        - name: run
+          image: quay.io/ibmmas/cli:latest
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 10m
+              memory: 64Mi
+          env:
+            - name: SUITE_NAMESPACE
+              value: mas-{{ .Values.instance_id }}-core
+          command:
+            - /bin/sh
+            - -c
+            - |
+
+              set -e
+              echo
+              echo "================================================================================"
+              echo "Wait for Suite Routes to be ready and add label type=external to routes"
+              echo "================================================================================"
+              echo
+
+              echo "Wait for Suite Routes to be ready"
+              wait_period=0
+              while true; do
+                wait_period=$(($wait_period+60))
+                if [ $wait_period -gt 3600 ]; then
+                  echo "Suite Routes is not ready after 20 minutes of waiting. exiting..."
+                  exit 1
+                else
+                  sleep 60
+                fi
+
+
+                SUITE_NAME=$(oc get Suite -n $SUITE_NAMESPACE -o NAME)
+                echo "SUITE_NAME == ${SUITE_NAME}"
+
+                export ROUTES_READY=$(oc get ${SUITE_NAME} -n ${SUITE_NAMESPACE} -o=jsonpath="{.status.conditions[?(@.type=='RoutesReady')].status}")
+                echo "ROUTES_READY == ${ROUTES_READY}"
+
+                if [[ "${ROUTES_READY}" == "True" ]]; then
+                  echo "Suite Routes are now in ready status"
+                  break
+                fi
+              done
+
+              export routes=$(oc get routes -n ${SUITE_NAMESPACE} -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
+              echo "Add label to routes updated ${routes}"
+
+              for route in $routes; do
+                echo "Adding label to route - ${route}"
+                oc patch route/${route} -p '{"metadata":{"labels":{"type":"external"}}}'
+              done
+      restartPolicy: Never
+      serviceAccountName: "mas-route-sa"
+  backoffLimit: 4
+
+{{- end }}
+

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
@@ -1,0 +1,203 @@
+{{- if .Values.ingress }}
+
+{{ $ns        :=  .Values.mas_app_namespace }}
+{{ $job_label :=  "mas-app-route-patch" }}
+
+---
+# Permit outbound communication by the Job pods
+# (Needed to communicate with the K8S HTTP API and AWS SM)
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: mas-app-route-np
+  namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "100"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $job_label }}
+  egress:
+    - {}
+  policyTypes:
+    - Egress
+
+---
+# Service account that is authorized to read k8s secrets (needed by the job)
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mas-app-route-sa
+  namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "100"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: mas-app-route-prereq-role-{{ .Values.instance_id }}-{{ .Values.mas_app_id }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "100"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+rules:
+  - verbs:
+      - get
+      - list
+      - patch
+    apiGroups:
+      - "route.openshift.io"
+    resources:
+      - routes
+
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - apps.mas.ibm.com
+    resources:
+      - assistworkspaces
+      - healthextworkspaces
+      - healthworkspaces
+      - manageworkspaces
+      - visualinspectionappworkspaces
+      - workspaces
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - iot.ibm.com
+    resources:
+      - iotworkspaces
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: mas-app-route-prereq-rb-{{ .Values.instance_id }}-{{ .Values.mas_app_id }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "101"
+
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+subjects:
+  - kind: ServiceAccount
+    name: mas-app-route-sa
+    namespace: {{ $ns }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: mas-app-route-prereq-role-{{ .Values.instance_id }}-{{ .Values.mas_app_id }}
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "mas-app-route-patch-v1-{{ .Values | toYaml | adler32sum }}"
+  namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "102"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ $job_label }}
+{{- if .Values.custom_labels }}
+{{ .Values.custom_labels | toYaml | indent 8 }}
+{{- end }}
+    spec:
+      containers:
+        - name: run
+          image: quay.io/ibmmas/cli:latest
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 10m
+              memory: 64Mi
+          env:
+            - name: MAS_APP_NAMESPACE
+              value: {{ .Values.mas_app_namespace }}
+            - name: MAS_APP_ID
+              value: {{ .Values.mas_app_id }}
+
+          command:
+            - /bin/sh
+            - -c
+            - |
+
+              set -e
+              echo
+              echo "================================================================================"
+              echo "Wait for App workspaces to be ready and add label type=external to routes"
+              echo "================================================================================"
+              echo
+
+              declare -A mas_app_workspace_name
+              mas_app_workspace_name['iot']="IoTWorkspace"
+              mas_app_workspace_name['manage']="ManageWorkspace"
+              mas_app_workspace_name['monitor']="MonitorWorkspace"
+              mas_app_workspace_name['assist']="AssistWorkspace"
+              mas_app_workspace_name['optimizer']="OptimizerWorkspace"
+              mas_app_workspace_name['predict']="PredictWorkspace"
+              mas_app_workspace_name['visualinspection']="VisualInspectionAppWorkspace"
+
+              if [[ -n "${mas_app_workspace_name[$MAS_APP_ID]}" ]]; then
+
+                echo "Wait for App Workspaces to be ready"
+                wait_period=0
+                while true; do
+                  wait_period=$(($wait_period+60))
+                  if [ $wait_period -gt 21600 ]; then
+                    echo "App workspaces is not ready after 6 hours of waiting. exiting..."
+                    exit 1
+                  else
+                    sleep 60
+                  fi
+
+                  MAS_APP_WORKSPACE_NAME=${mas_app_workspace_name[$MAS_APP_ID]}
+                  MAS_APP_NAME=$(oc get $MAS_APP_WORKSPACE_NAME -n $MAS_APP_NAMESPACE -o NAME)
+                  echo "MAS_APP_NAME == ${MAS_APP_NAME}"
+
+                  export MAS_APP_READY=$(oc get ${MAS_APP_NAME} -n ${MAS_APP_NAMESPACE} -o=jsonpath="{.status.conditions[?(@.type=='Ready')].status}")
+                  echo "MAS_APP_READY == ${MAS_APP_READY}"
+
+                  if [[ "${MAS_APP_READY}" == "True" ]]; then
+                    echo "${MAS_APP_NAME} is in ready status"
+                    break
+                  fi
+                done
+
+                export routes=$(oc get routes -n ${MAS_APP_NAMESPACE} -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
+                echo "Add label to routes ${routes}"
+
+                for route in $routes; do
+                  echo "Adding label to route - ${route}"
+                  oc patch route/${route} -p '{"metadata":{"labels":{"type":"external"}}}'
+                done
+              fi
+
+      restartPolicy: Never
+      serviceAccountName: "mas-app-route-sa"
+  backoffLimit: 4
+
+{{- end }}

--- a/root-applications/ibm-mas-cluster-root/templates/030-ibm-cis-cert-manager.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/030-ibm-cis-cert-manager.yaml
@@ -42,6 +42,8 @@ spec:
             dns_provider: "{{ .Values.ibm_cis_cert_manager.dns_provider }}"
             ocp_cluster_domain: "{{ .Values.ibm_cis_cert_manager.ocp_cluster_domain }}"
             cis_apikey: "{{ .Values.ibm_cis_cert_manager.cis_apikey }}"
+            ocp_public_cluster_domain: "{{ .Values.ibm_cis_cert_manager.ocp_public_cluster_domain }}"
+            ingress: {{ .Values.ibm_cis_cert_manager.ingress }}
 
         - name: ARGOCD_APP_NAME
           value: ibmciscertmanagerapp

--- a/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-app.yaml
@@ -56,6 +56,7 @@ spec:
             dns_provider: "{{ .Values.ibm_mas_suite.dns_provider }}"
             icr_cp: "{{ .Values.ibm_mas_suite.icr_cp }}"
             icr_cp_open: "{{ .Values.ibm_mas_suite.icr_cp_open }}"
+            ingress: "{{ .Values.ibm_mas_suite.ingress }}"
 
             {{- if .Values.ibm_mas_suite.mas_annotations }}
             mas_annotations: {{ .Values.ibm_mas_suite.mas_annotations | toYaml | nindent 14 }}

--- a/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
@@ -63,6 +63,7 @@ spec:
             mas_appws_spec: {{ $value.mas_appws_spec | toYaml | nindent 14 }}
 
             mas_manual_cert_mgmt: {{ $value.mas_manual_cert_mgmt   }}
+            ingress: {{ $value.ingress }}
             {{- if $value.mas_manual_cert_mgmt  }}
             public_tls_secret_name: "{{ $value.public_tls_secret_name }}"
             ca_cert: |


### PR DESCRIPTION

Issue https://jsw.ibm.com/browse/MASCORE-3232

As part of this changes below are achieved:
1. Gitops creates a public IngressController controlled via ingress flag present in cluster params file
2. Gitops adds type: "external" label to mas core  & apps controlled via ingress flag
3. Gitops adds type: "external" label to db2 route controlled via jdbc_route flag, if set to public in cluster params file
