### PR TITLE
[patch] Redo Manage Attachment configuration support in SaaS/gitops 

### DIFF
--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/01-ibm-manage_encryption_secret.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/01-ibm-manage_encryption_secret.yaml
@@ -1,5 +1,5 @@
 {{- if (or (eq .Values.mas_app_id "manage") (eq .Values.mas_app_id "health")) }}
-{{- if .Values.manage_attachments_secret_name }}
+{{- if (and .Values.global_secrets .Values.mas_appws_spec .Values.mas_appws_spec.db .Values.mas_appws_spec.db.encryptionSecret) }}
 ---
 kind: Secret
 apiVersion: v1
@@ -11,10 +11,12 @@ metadata:
   labels:
 {{ .Values.custom_labels | toYaml | indent 4 }}
 {{- end }}
-  name: {{ .Values.manage_attachments_secret_name }}
+  name: {{ .Values.mas_appws_spec.db.encryptionSecret }}
   namespace: {{ .Values.mas_app_namespace }}
 stringData:
-  accessSecretKey: {{ .Values.manage_attachments_access_secret_key }}
+  {{- range $key, $value := $.Values.global_secrets }}
+  {{ $key }}: {{ $value }}
+  {{- end }}
 type: Opaque
 {{- end }}
 {{- end }}

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/01-ibm-manage_encryption_secret.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/01-ibm-manage_encryption_secret.yaml
@@ -1,5 +1,6 @@
 {{- if (or (eq .Values.mas_app_id "manage") (eq .Values.mas_app_id "health")) }}
-{{- if (and .Values.global_secrets .Values.mas_appws_spec .Values.mas_appws_spec.db .Values.mas_appws_spec.db.encryptionSecret) }}
+{{- if hasKey .Values "global_secrets" }}
+{{- if and (hasKey .Values "mas_appws_spec") (hasKey .Values.mas_appws_spec "settings") (hasKey .Values.mas_appws_spec.settings "db") (hasKey .Values.mas_appws_spec.settings.db "encryptionSecret") }}
 ---
 kind: Secret
 apiVersion: v1
@@ -11,12 +12,13 @@ metadata:
   labels:
 {{ .Values.custom_labels | toYaml | indent 4 }}
 {{- end }}
-  name: {{ .Values.mas_appws_spec.db.encryptionSecret }}
+  name: {{ .Values.mas_appws_spec.settings.db.encryptionSecret }}
   namespace: {{ .Values.mas_app_namespace }}
 stringData:
   {{- range $key, $value := $.Values.global_secrets }}
   {{ $key }}: {{ $value }}
   {{- end }}
 type: Opaque
+{{- end }}
 {{- end }}
 {{- end }}

--- a/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
@@ -82,8 +82,9 @@ spec:
             manage_logging_secret_name: {{ $value.manage_logging_secret_name }}
             manage_logging_access_secret_key: {{ $value.manage_logging_access_secret_key }}
 
-            manage_attachments_secret_name: {{ $value.manage_attachments_secret_name }}
-            manage_attachments_access_secret_key: {{ $value.manage_attachments_access_secret_key }}
+            {{- if $value.global_secrets  }}
+            global_secrets: {{ $value.global_secrets | toYaml | nindent 14 }}
+            {{- end }}
 
             {{- end }}
 


### PR DESCRIPTION
Adds new manage encryption secret. This contains the key/values defined under the new `manage.global_secrets_yaml` property. See [saas-envs PR](https://github.ibm.com/maximoappsuite/saas-envs/pull/183/files).
 
Removes deprecated `manage_attachments_secret`

https://jsw.ibm.com/browse/MASCORE-3747


Tested in `noble5`:

![image](https://github.com/user-attachments/assets/16f69aac-df13-4086-9779-0377c25ea9c9)

![image](https://github.com/user-attachments/assets/2c2ae65b-3164-4f20-b676-51e09754bbca)

![image](https://github.com/user-attachments/assets/731f7cc5-1b8c-4c3a-8c35-53b871e9d114)
