### PR TITLE
[patch] Add unlimited retries and fix suite cert/dns sync

### DIFF
--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
@@ -7,7 +7,7 @@ metadata:
   name: "ibm-suite-certs-v1-{{ .Values | toYaml | adler32sum }}"
   namespace: mas-{{ .Values.instance_id }}-syncres
   annotations:
-    argocd.argoproj.io/sync-wave: "00"
+    argocd.argoproj.io/sync-wave: "003"
 {{- if .Values.custom_labels }}
   labels:
 {{ .Values.custom_labels | toYaml | indent 4 }}

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "ibm-suite-dns-v1-{{ .Values | toYaml | adler32sum }}"
   namespace: mas-{{ .Values.instance_id }}-syncres
   annotations:
-    argocd.argoproj.io/sync-wave: "00"
+    argocd.argoproj.io/sync-wave: "003"
 {{- if .Values.custom_labels }}
   labels:
 {{ .Values.custom_labels | toYaml | indent 4 }}

--- a/root-applications/ibm-mas-account-root/templates/000-cluster-appset.yaml
+++ b/root-applications/ibm-mas-account-root/templates/000-cluster-appset.yaml
@@ -117,6 +117,8 @@ spec:
           prune: true
           {{- end }}
           selfHeal: true
+        retry:
+          limit: 0
         syncOptions:
           - CreateNamespace=false
           - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-account-root/templates/000-cluster-appset.yaml
+++ b/root-applications/ibm-mas-account-root/templates/000-cluster-appset.yaml
@@ -118,7 +118,7 @@ spec:
           {{- end }}
           selfHeal: true
         retry:
-          limit: 0
+          limit: -1
         syncOptions:
           - CreateNamespace=false
           - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-cluster-root/templates/099-instance-appset.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/099-instance-appset.yaml
@@ -210,7 +210,7 @@ spec:
           - CreateNamespace=false
           - RespectIgnoreDifferences=true
         retry:
-          limit: 0
+          limit: -1
       ignoreDifferences:
         - group: '*'
           kind: ServiceAccount

--- a/root-applications/ibm-mas-cluster-root/templates/099-instance-appset.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/099-instance-appset.yaml
@@ -209,6 +209,8 @@ spec:
         syncOptions:
           - CreateNamespace=false
           - RespectIgnoreDifferences=true
+        retry:
+          limit: 0
       ignoreDifferences:
         - group: '*'
           kind: ServiceAccount


### PR DESCRIPTION
Adds the `retry.limit` for the ArgoCD instance and cluster appsets, and sets it to unlimited (-1). This means that argocd will continue to sync until it is ready and won't fail when the default (5) failures are reached. This is needed as we see many temporal failures in each app that is just a failure until another app is ready. 

This change also changes the syncwave of the suite certs and dns jobs so it runs at the same time as the olm job, as these jobs can take 15 minutes, and was blocking the olm job from running when it could have run at the same time.

Tested in fvtsaas and it all works