### PR TITLE
[minor] Make install plan configurable for all subscriptions in gitops

### DIFF
--- a/cluster-applications/010-redhat-cert-manager/templates/02-cert-manager_Subscription.yaml
+++ b/cluster-applications/010-redhat-cert-manager/templates/02-cert-manager_Subscription.yaml
@@ -14,7 +14,7 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   channel: {{ .Values.channel }}
-  installPlanApproval: {{ .Values.redhat_cert_manager.cert_manager_install_plan }}
+  installPlanApproval: {{ .Values.cert_manager_install_plan }}
   name: openshift-cert-manager-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-applications/010-redhat-cert-manager/templates/02-cert-manager_Subscription.yaml
+++ b/cluster-applications/010-redhat-cert-manager/templates/02-cert-manager_Subscription.yaml
@@ -14,7 +14,7 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   channel: {{ .Values.channel }}
-  installPlanApproval: "{{ .Values.cert_manager_install_plan | default('Automatic', True) }}"
+  installPlanApproval: "{{ .Values.cert_manager_install_plan | default "Automatic" | quote }}"
   name: openshift-cert-manager-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-applications/010-redhat-cert-manager/templates/02-cert-manager_Subscription.yaml
+++ b/cluster-applications/010-redhat-cert-manager/templates/02-cert-manager_Subscription.yaml
@@ -14,7 +14,7 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   channel: {{ .Values.channel }}
-  installPlanApproval: "{{ .Values.cert_manager_install_plan | default('Automatic') }}"
+  installPlanApproval: "{{ .Values.cert_manager_install_plan | default('Automatic', True) }}"
   name: openshift-cert-manager-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-applications/010-redhat-cert-manager/templates/02-cert-manager_Subscription.yaml
+++ b/cluster-applications/010-redhat-cert-manager/templates/02-cert-manager_Subscription.yaml
@@ -14,7 +14,7 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   channel: {{ .Values.channel }}
-  installPlanApproval: Automatic
+  installPlanApproval: {{ .Values.cert_manager_install_plan_approval }}
   name: openshift-cert-manager-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-applications/010-redhat-cert-manager/templates/02-cert-manager_Subscription.yaml
+++ b/cluster-applications/010-redhat-cert-manager/templates/02-cert-manager_Subscription.yaml
@@ -14,7 +14,7 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   channel: {{ .Values.channel }}
-  installPlanApproval: {{ .Values.cert_manager_install_plan_approval }}
+  installPlanApproval: {{ .Values.redhat_cert_manager.cert_manager_install_plan }}
   name: openshift-cert-manager-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-applications/010-redhat-cert-manager/templates/02-cert-manager_Subscription.yaml
+++ b/cluster-applications/010-redhat-cert-manager/templates/02-cert-manager_Subscription.yaml
@@ -14,7 +14,7 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   channel: {{ .Values.channel }}
-  installPlanApproval: {{ .Values.cert_manager_install_plan | default "Automatic" | quote }}
+  installPlanApproval: {{ .Values.redhat_cert_manager_install_plan | default "Automatic" | quote }}
   name: openshift-cert-manager-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-applications/010-redhat-cert-manager/templates/02-cert-manager_Subscription.yaml
+++ b/cluster-applications/010-redhat-cert-manager/templates/02-cert-manager_Subscription.yaml
@@ -14,7 +14,7 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   channel: {{ .Values.channel }}
-  installPlanApproval: "{{ .Values.cert_manager_install_plan | default "Automatic" | quote }}"
+  installPlanApproval: {{ .Values.cert_manager_install_plan | default "Automatic" | quote }}
   name: openshift-cert-manager-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-applications/010-redhat-cert-manager/templates/02-cert-manager_Subscription.yaml
+++ b/cluster-applications/010-redhat-cert-manager/templates/02-cert-manager_Subscription.yaml
@@ -14,7 +14,7 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   channel: {{ .Values.channel }}
-  installPlanApproval: {{ .Values.cert_manager_install_plan }}
+  installPlanApproval: "{{ .Values.cert_manager_install_plan | default('Automatic') }}"
   name: openshift-cert-manager-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-applications/020-ibm-dro/templates/03-imo_Subscription.yaml
+++ b/cluster-applications/020-ibm-dro/templates/03-imo_Subscription.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- end }}
 spec:
   channel: stable
-  installPlanApproval: "{{ .Values.imo_install_plan | default "Automatic" | quote }}"
+  installPlanApproval: {{ .Values.imo_install_plan | default "Automatic" | quote }}
   name: ibm-metrics-operator
   source: certified-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-applications/020-ibm-dro/templates/03-imo_Subscription.yaml
+++ b/cluster-applications/020-ibm-dro/templates/03-imo_Subscription.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- end }}
 spec:
   channel: stable
-  installPlanApproval: Automatic
+  installPlanApproval: {{ .Values.imo_install_plan }}
   name: ibm-metrics-operator
   source: certified-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-applications/020-ibm-dro/templates/03-imo_Subscription.yaml
+++ b/cluster-applications/020-ibm-dro/templates/03-imo_Subscription.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- end }}
 spec:
   channel: stable
-  installPlanApproval: "{{ .Values.imo_install_plan | default('Automatic', True) }}"
+  installPlanApproval: "{{ .Values.imo_install_plan | default "Automatic" | quote }}"
   name: ibm-metrics-operator
   source: certified-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-applications/020-ibm-dro/templates/03-imo_Subscription.yaml
+++ b/cluster-applications/020-ibm-dro/templates/03-imo_Subscription.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- end }}
 spec:
   channel: stable
-  installPlanApproval: "{{ .Values.imo_install_plan | default('Automatic') }}"
+  installPlanApproval: "{{ .Values.imo_install_plan | default('Automatic', True) }}"
   name: ibm-metrics-operator
   source: certified-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-applications/020-ibm-dro/templates/03-imo_Subscription.yaml
+++ b/cluster-applications/020-ibm-dro/templates/03-imo_Subscription.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- end }}
 spec:
   channel: stable
-  installPlanApproval: {{ .Values.imo_install_plan }}
+  installPlanApproval: "{{ .Values.imo_install_plan | default('Automatic') }}"
   name: ibm-metrics-operator
   source: certified-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-applications/020-ibm-dro/templates/04-dro_Subscription.yaml
+++ b/cluster-applications/020-ibm-dro/templates/04-dro_Subscription.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- end }}
 spec:
   channel: stable
-  installPlanApproval: "{{ .Values.dro_install_plan | default('Automatic') }}"
+  installPlanApproval: "{{ .Values.dro_install_plan | default('Automatic', True) }}"
   name: ibm-data-reporter-operator
   source: certified-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-applications/020-ibm-dro/templates/04-dro_Subscription.yaml
+++ b/cluster-applications/020-ibm-dro/templates/04-dro_Subscription.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- end }}
 spec:
   channel: stable
-  installPlanApproval: "{{ .Values.dro_install_plan | default('Automatic', True) }}"
+  installPlanApproval: "{{ .Values.dro_install_plan | default "Automatic" | quote }}"
   name: ibm-data-reporter-operator
   source: certified-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-applications/020-ibm-dro/templates/04-dro_Subscription.yaml
+++ b/cluster-applications/020-ibm-dro/templates/04-dro_Subscription.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- end }}
 spec:
   channel: stable
-  installPlanApproval: "{{ .Values.dro_install_plan | default "Automatic" | quote }}"
+  installPlanApproval: {{ .Values.dro_install_plan | default "Automatic" | quote }}
   name: ibm-data-reporter-operator
   source: certified-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-applications/020-ibm-dro/templates/04-dro_Subscription.yaml
+++ b/cluster-applications/020-ibm-dro/templates/04-dro_Subscription.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- end }}
 spec:
   channel: stable
-  installPlanApproval: {{ .Values.dro_install_plan }}
+  installPlanApproval: "{{ .Values.dro_install_plan | default('Automatic') }}"
   name: ibm-data-reporter-operator
   source: certified-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-applications/020-ibm-dro/templates/04-dro_Subscription.yaml
+++ b/cluster-applications/020-ibm-dro/templates/04-dro_Subscription.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- end }}
 spec:
   channel: stable
-  installPlanApproval: Automatic
+  installPlanApproval: {{ .Values.dro_install_plan }}
   name: ibm-data-reporter-operator
   source: certified-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-applications/040-cis-compliance/templates/03-cis-compliance_Subscription.yaml
+++ b/cluster-applications/040-cis-compliance/templates/03-cis-compliance_Subscription.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   channel: stable
   name: compliance-operator
-  installPlanApproval: "{{ .Values.cis_install_plan | default('Automatic', True) }}"
+  installPlanApproval: "{{ .Values.cis_install_plan | default "Automatic" | quote }}"
   source: redhat-operators
   sourceNamespace: openshift-marketplace
   config:

--- a/cluster-applications/040-cis-compliance/templates/03-cis-compliance_Subscription.yaml
+++ b/cluster-applications/040-cis-compliance/templates/03-cis-compliance_Subscription.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   channel: stable
   name: compliance-operator
-  installPlanApproval: "{{ .Values.cis_install_plan | default "Automatic" | quote }}"
+  installPlanApproval: {{ .Values.cis_install_plan | default "Automatic" | quote }}
   source: redhat-operators
   sourceNamespace: openshift-marketplace
   config:

--- a/cluster-applications/040-cis-compliance/templates/03-cis-compliance_Subscription.yaml
+++ b/cluster-applications/040-cis-compliance/templates/03-cis-compliance_Subscription.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   channel: stable
   name: compliance-operator
-  installPlanApproval: {{ .Values.cis_install_plan }}
+  installPlanApproval: "{{ .Values.cis_install_plan | default('Automatic') }}"
   source: redhat-operators
   sourceNamespace: openshift-marketplace
   config:

--- a/cluster-applications/040-cis-compliance/templates/03-cis-compliance_Subscription.yaml
+++ b/cluster-applications/040-cis-compliance/templates/03-cis-compliance_Subscription.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   channel: stable
   name: compliance-operator
-  installPlanApproval: Automatic
+  installPlanApproval: {{ .Values.cis_install_plan }}
   source: redhat-operators
   sourceNamespace: openshift-marketplace
   config:

--- a/cluster-applications/040-cis-compliance/templates/03-cis-compliance_Subscription.yaml
+++ b/cluster-applications/040-cis-compliance/templates/03-cis-compliance_Subscription.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   channel: stable
   name: compliance-operator
-  installPlanApproval: "{{ .Values.cis_install_plan | default('Automatic') }}"
+  installPlanApproval: "{{ .Values.cis_install_plan | default('Automatic', True) }}"
   source: redhat-operators
   sourceNamespace: openshift-marketplace
   config:

--- a/cluster-applications/050-nfd-operator/templates/02-nfd_Subcription.yaml
+++ b/cluster-applications/050-nfd-operator/templates/02-nfd_Subcription.yaml
@@ -12,7 +12,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.nfd_channel }}"
-  installPlanApproval: Automatic
+  installPlanApproval: {{ .Values.nfd_install_plan }}
   name: nfd
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-applications/050-nfd-operator/templates/02-nfd_Subcription.yaml
+++ b/cluster-applications/050-nfd-operator/templates/02-nfd_Subcription.yaml
@@ -12,7 +12,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.nfd_channel }}"
-  installPlanApproval: "{{ .Values.nfd_install_plan | default('Automatic') }}"
+  installPlanApproval: "{{ .Values.nfd_install_plan | default('Automatic', True) }}"
   name: nfd
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-applications/050-nfd-operator/templates/02-nfd_Subcription.yaml
+++ b/cluster-applications/050-nfd-operator/templates/02-nfd_Subcription.yaml
@@ -12,7 +12,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.nfd_channel }}"
-  installPlanApproval: {{ .Values.nfd_install_plan }}
+  installPlanApproval: "{{ .Values.nfd_install_plan | default('Automatic') }}"
   name: nfd
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-applications/050-nfd-operator/templates/02-nfd_Subcription.yaml
+++ b/cluster-applications/050-nfd-operator/templates/02-nfd_Subcription.yaml
@@ -12,7 +12,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.nfd_channel }}"
-  installPlanApproval: "{{ .Values.nfd_install_plan | default "Automatic" | quote }}"
+  installPlanApproval: {{ .Values.nfd_install_plan | default "Automatic" | quote }}
   name: nfd
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-applications/050-nfd-operator/templates/02-nfd_Subcription.yaml
+++ b/cluster-applications/050-nfd-operator/templates/02-nfd_Subcription.yaml
@@ -12,7 +12,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.nfd_channel }}"
-  installPlanApproval: "{{ .Values.nfd_install_plan | default('Automatic', True) }}"
+  installPlanApproval: "{{ .Values.nfd_install_plan | default "Automatic" | quote }}"
   name: nfd
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-applications/051-nvidia-gpu-operator/templates/02-gpu_Subcription.yaml
+++ b/cluster-applications/051-nvidia-gpu-operator/templates/02-gpu_Subcription.yaml
@@ -12,7 +12,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.gpu_channel }}"
-  installPlanApproval: "{{ .Values.gpu_install_plan | default "Automatic" | quote }}"
+  installPlanApproval: {{ .Values.gpu_install_plan | default "Automatic" | quote }}
   name: gpu-operator-certified
   source: certified-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-applications/051-nvidia-gpu-operator/templates/02-gpu_Subcription.yaml
+++ b/cluster-applications/051-nvidia-gpu-operator/templates/02-gpu_Subcription.yaml
@@ -12,7 +12,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.gpu_channel }}"
-  installPlanApproval: "{{ .Values.gpu_install_plan | default('Automatic') }}"
+  installPlanApproval: "{{ .Values.gpu_install_plan | default('Automatic', True) }}"
   name: gpu-operator-certified
   source: certified-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-applications/051-nvidia-gpu-operator/templates/02-gpu_Subcription.yaml
+++ b/cluster-applications/051-nvidia-gpu-operator/templates/02-gpu_Subcription.yaml
@@ -12,7 +12,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.gpu_channel }}"
-  installPlanApproval: {{ .Values.gpu_install_plan }}
+  installPlanApproval: "{{ .Values.gpu_install_plan | default('Automatic') }}"
   name: gpu-operator-certified
   source: certified-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-applications/051-nvidia-gpu-operator/templates/02-gpu_Subcription.yaml
+++ b/cluster-applications/051-nvidia-gpu-operator/templates/02-gpu_Subcription.yaml
@@ -12,7 +12,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.gpu_channel }}"
-  installPlanApproval: Automatic
+  installPlanApproval: {{ .Values.gpu_install_plan }}
   name: gpu-operator-certified
   source: certified-operators
   sourceNamespace: openshift-marketplace

--- a/cluster-applications/051-nvidia-gpu-operator/templates/02-gpu_Subcription.yaml
+++ b/cluster-applications/051-nvidia-gpu-operator/templates/02-gpu_Subcription.yaml
@@ -12,7 +12,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.gpu_channel }}"
-  installPlanApproval: "{{ .Values.gpu_install_plan | default('Automatic', True) }}"
+  installPlanApproval: "{{ .Values.gpu_install_plan | default "Automatic" | quote }}"
   name: gpu-operator-certified
   source: certified-operators
   sourceNamespace: openshift-marketplace

--- a/example-config/dev/cluster1/ibm-dro.yaml
+++ b/example-config/dev/cluster1/ibm-dro.yaml
@@ -4,3 +4,5 @@ ibm_dro:
     dro_namespace: ibm-software-central
     ibm_entitlement_key: "<path:arn:aws:secretsmanager:us-east-1:xxxxxxxxxxxx:secret:dev/cluster1/ibm_entitlement#entitlement_key>"
     run_sync_hooks: true
+    imo_install_plan: Automatic
+    dro_install_plan: Automatic

--- a/example-config/dev/cluster1/instance1/ibm-db2u.yaml
+++ b/example-config/dev/cluster1/instance1/ibm-db2u.yaml
@@ -2,6 +2,7 @@ merge-key: "dev/cluster1/instance1"
 
 ibm_db2u:
   db2_namespace: db2u-instance1
+  db2_install_plan: Automatic
 
   db2_channel: <path:arn:aws:secretsmanager:us-east-1:xxxxxxxxxxxx:secret:dev/cluster1/db2_default_channel#db2_default_channel>
 

--- a/example-config/dev/cluster1/instance1/ibm-mas-suite.yaml
+++ b/example-config/dev/cluster1/instance1/ibm-mas-suite.yaml
@@ -10,3 +10,4 @@ ibm_mas_suite:
   icr_cp_open: "icr.io/cpopen"
 
   mas_manual_cert_mgmt: false
+  mas_install_plan: Automatic

--- a/example-config/dev/cluster1/instance1/ibm-sls.yaml
+++ b/example-config/dev/cluster1/instance1/ibm-sls.yaml
@@ -4,6 +4,7 @@ ibm_sls:
   sls_channel: 3.x
   sls_entitlement_file: <path:arn:aws:secretsmanager:us-east-1:xxxxxxxxxxxx:secret:dev/cluster1/instance1/license#license_file>
   ibm_entitlement_key: <path:arn:aws:secretsmanager:us-east-1:xxxxxxxxxxxx:secret:dev/cluster1/ibm_entitlement#image_pull_secret_b64>
+  sls_install_plan: Automatic
 
   # aws docdb
   mongodb_provider: "aws"

--- a/example-config/dev/cluster1/redhat-cert-manager.yaml
+++ b/example-config/dev/cluster1/redhat-cert-manager.yaml
@@ -3,4 +3,4 @@ merge-key: "dev/cluster1"
 redhat_cert_manager:
    run_sync_hooks: true
    channel: stable-v1
-   cert_manager_install_plan_approval: Automatic
+   cert_manager_install_plan: Automatic

--- a/example-config/dev/cluster1/redhat-cert-manager.yaml
+++ b/example-config/dev/cluster1/redhat-cert-manager.yaml
@@ -3,4 +3,4 @@ merge-key: "dev/cluster1"
 redhat_cert_manager:
    run_sync_hooks: true
    channel: stable-v1
-   cert_manager_install_plan: Automatic
+   redhat_cert_manager_install_plan: Automatic

--- a/example-config/dev/cluster1/redhat-cert-manager.yaml
+++ b/example-config/dev/cluster1/redhat-cert-manager.yaml
@@ -3,3 +3,4 @@ merge-key: "dev/cluster1"
 redhat_cert_manager:
    run_sync_hooks: true
    channel: stable-v1
+   cert_manager_install_plan_approval: Automatic

--- a/instance-applications/100-ibm-sls/templates/02-ibm-sls_Subscription.yaml
+++ b/instance-applications/100-ibm-sls/templates/02-ibm-sls_Subscription.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.sls_channel }}"
-  installPlanApproval: "{{ .Values.sls_install_plan | default('Automatic') }}"
+  installPlanApproval: "{{ .Values.sls_install_plan | default('Automatic', True) }}"
   name: ibm-sls
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace

--- a/instance-applications/100-ibm-sls/templates/02-ibm-sls_Subscription.yaml
+++ b/instance-applications/100-ibm-sls/templates/02-ibm-sls_Subscription.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.sls_channel }}"
-  installPlanApproval: Automatic
+  installPlanApproval: {{ .Values.sls_install_plan }}
   name: ibm-sls
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace

--- a/instance-applications/100-ibm-sls/templates/02-ibm-sls_Subscription.yaml
+++ b/instance-applications/100-ibm-sls/templates/02-ibm-sls_Subscription.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.sls_channel }}"
-  installPlanApproval: "{{ .Values.sls_install_plan | default('Automatic', True) }}"
+  installPlanApproval: "{{ .Values.sls_install_plan | default "Automatic" | quote }}"
   name: ibm-sls
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace

--- a/instance-applications/100-ibm-sls/templates/02-ibm-sls_Subscription.yaml
+++ b/instance-applications/100-ibm-sls/templates/02-ibm-sls_Subscription.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.sls_channel }}"
-  installPlanApproval: "{{ .Values.sls_install_plan | default "Automatic" | quote }}"
+  installPlanApproval: {{ .Values.sls_install_plan | default "Automatic" | quote }}
   name: ibm-sls
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace

--- a/instance-applications/100-ibm-sls/templates/02-ibm-sls_Subscription.yaml
+++ b/instance-applications/100-ibm-sls/templates/02-ibm-sls_Subscription.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.sls_channel }}"
-  installPlanApproval: {{ .Values.sls_install_plan }}
+  installPlanApproval: "{{ .Values.sls_install_plan | default('Automatic') }}"
   name: ibm-sls
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace

--- a/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_prereqs_ops.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_prereqs_ops.yaml
@@ -14,7 +14,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.namespace_scope_channel }}"
-  installPlanApproval: Automatic
+  installPlanApproval: "{{ .Values.namespace_scope_install_plan }}"
   name: ibm-namespace-scope-operator
   source: opencloud-operators
   sourceNamespace: "{{ .Values.cpd_operators_namespace }}"
@@ -60,7 +60,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.cpfs_channel }}"
-  installPlanApproval: Automatic
+  installPlanApproval: "{{ .Values.cpfs_install_plan }}"
   name: ibm-common-service-operator
   source: opencloud-operators
   sourceNamespace: "{{ .Values.cpd_operators_namespace }}"

--- a/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_prereqs_ops.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_prereqs_ops.yaml
@@ -14,7 +14,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.namespace_scope_channel }}"
-  installPlanApproval: "{{ .Values.namespace_scope_install_plan | default('Automatic') }}"
+  installPlanApproval: "{{ .Values.namespace_scope_install_plan | default('Automatic', True) }}"
   name: ibm-namespace-scope-operator
   source: opencloud-operators
   sourceNamespace: "{{ .Values.cpd_operators_namespace }}"
@@ -60,7 +60,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.cpfs_channel }}"
-  installPlanApproval: "{{ .Values.cpfs_install_plan | default('Automatic') }}"
+  installPlanApproval: "{{ .Values.cpfs_install_plan | default('Automatic', True) }}"
   name: ibm-common-service-operator
   source: opencloud-operators
   sourceNamespace: "{{ .Values.cpd_operators_namespace }}"

--- a/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_prereqs_ops.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_prereqs_ops.yaml
@@ -14,7 +14,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.namespace_scope_channel }}"
-  installPlanApproval: "{{ .Values.namespace_scope_install_plan | default "Automatic" | quote }}"
+  installPlanApproval: {{ .Values.namespace_scope_install_plan | default "Automatic" | quote }}
   name: ibm-namespace-scope-operator
   source: opencloud-operators
   sourceNamespace: "{{ .Values.cpd_operators_namespace }}"
@@ -60,7 +60,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.cpfs_channel }}"
-  installPlanApproval: "{{ .Values.cpfs_install_plan | default "Automatic" | quote }}"
+  installPlanApproval: {{ .Values.cpfs_install_plan | default "Automatic" | quote }}
   name: ibm-common-service-operator
   source: opencloud-operators
   sourceNamespace: "{{ .Values.cpd_operators_namespace }}"

--- a/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_prereqs_ops.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_prereqs_ops.yaml
@@ -14,7 +14,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.namespace_scope_channel }}"
-  installPlanApproval: "{{ .Values.namespace_scope_install_plan | default('Automatic', True) }}"
+  installPlanApproval: "{{ .Values.namespace_scope_install_plan | default "Automatic" | quote }}"
   name: ibm-namespace-scope-operator
   source: opencloud-operators
   sourceNamespace: "{{ .Values.cpd_operators_namespace }}"
@@ -60,7 +60,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.cpfs_channel }}"
-  installPlanApproval: "{{ .Values.cpfs_install_plan | default('Automatic', True) }}"
+  installPlanApproval: "{{ .Values.cpfs_install_plan | default "Automatic" | quote }}"
   name: ibm-common-service-operator
   source: opencloud-operators
   sourceNamespace: "{{ .Values.cpd_operators_namespace }}"

--- a/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_prereqs_ops.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_prereqs_ops.yaml
@@ -14,7 +14,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.namespace_scope_channel }}"
-  installPlanApproval: "{{ .Values.namespace_scope_install_plan }}"
+  installPlanApproval: "{{ .Values.namespace_scope_install_plan | default('Automatic') }}"
   name: ibm-namespace-scope-operator
   source: opencloud-operators
   sourceNamespace: "{{ .Values.cpd_operators_namespace }}"
@@ -60,7 +60,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.cpfs_channel }}"
-  installPlanApproval: "{{ .Values.cpfs_install_plan }}"
+  installPlanApproval: "{{ .Values.cpfs_install_plan | default('Automatic') }}"
   name: ibm-common-service-operator
   source: opencloud-operators
   sourceNamespace: "{{ .Values.cpd_operators_namespace }}"

--- a/instance-applications/110-ibm-cp4d-operators/templates/06-ibm-cp4d_Subscription.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/06-ibm-cp4d_Subscription.yaml
@@ -12,7 +12,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.cpd_platform_channel }}"
-  installPlanApproval: "{{ .Values.cpd_platform_install_plan | default('Automatic') }}"
+  installPlanApproval: "{{ .Values.cpd_platform_install_plan | default('Automatic', True) }}"
   name: cpd-platform-operator
   source: cpd-platform
   sourceNamespace: "{{ .Values.cpd_operators_namespace }}"

--- a/instance-applications/110-ibm-cp4d-operators/templates/06-ibm-cp4d_Subscription.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/06-ibm-cp4d_Subscription.yaml
@@ -12,7 +12,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.cpd_platform_channel }}"
-  installPlanApproval: "{{ .Values.cpd_platform_install_plan | default('Automatic', True) }}"
+  installPlanApproval: "{{ .Values.cpd_platform_install_plan | default "Automatic" | quote }}"
   name: cpd-platform-operator
   source: cpd-platform
   sourceNamespace: "{{ .Values.cpd_operators_namespace }}"

--- a/instance-applications/110-ibm-cp4d-operators/templates/06-ibm-cp4d_Subscription.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/06-ibm-cp4d_Subscription.yaml
@@ -12,7 +12,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.cpd_platform_channel }}"
-  installPlanApproval: "{{ .Values.cpd_platform_install_plan | default "Automatic" | quote }}"
+  installPlanApproval: {{ .Values.cpd_platform_install_plan | default "Automatic" | quote }}
   name: cpd-platform-operator
   source: cpd-platform
   sourceNamespace: "{{ .Values.cpd_operators_namespace }}"

--- a/instance-applications/110-ibm-cp4d-operators/templates/06-ibm-cp4d_Subscription.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/06-ibm-cp4d_Subscription.yaml
@@ -12,7 +12,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.cpd_platform_channel }}"
-  installPlanApproval: Automatic
+  installPlanApproval: "{{ .Values.cpd_platform_install_plan }}"
   name: cpd-platform-operator
   source: cpd-platform
   sourceNamespace: "{{ .Values.cpd_operators_namespace }}"

--- a/instance-applications/110-ibm-cp4d-operators/templates/06-ibm-cp4d_Subscription.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/06-ibm-cp4d_Subscription.yaml
@@ -12,7 +12,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.cpd_platform_channel }}"
-  installPlanApproval: "{{ .Values.cpd_platform_install_plan }}"
+  installPlanApproval: "{{ .Values.cpd_platform_install_plan | default('Automatic') }}"
   name: cpd-platform-operator
   source: cpd-platform
   sourceNamespace: "{{ .Values.cpd_operators_namespace }}"

--- a/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
@@ -102,7 +102,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.ccs_channel }}"
-  installPlanApproval: "{{ .Values.cpd_ccs_install_plan }}"
+  installPlanApproval: "{{ .Values.cpd_ccs_install_plan | default('Automatic') }}"
   name: ibm-cpd-ccs
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
@@ -121,7 +121,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.datarefinery_channel }}"
-  installPlanApproval: "{{ .Values.cpd_datarefinery_install_plan }}"
+  installPlanApproval: "{{ .Values.cpd_datarefinery_install_plan | default('Automatic') }}"
   name: ibm-cpd-datarefinery
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
@@ -140,7 +140,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.ws_runtimes_channel }}"
-  installPlanApproval: "{{ .Values.cpd_ws_install_plan }}"
+  installPlanApproval: "{{ .Values.cpd_ws_install_plan | default('Automatic') }}"
   name: ibm-cpd-ws-runtimes
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
@@ -159,7 +159,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.opencontent_elasticsearch_channel }}"
-  installPlanApproval: "{{ .Values.elasticsearch_install_plan }}"
+  installPlanApproval: "{{ .Values.elasticsearch_install_plan | default('Automatic') }}"
   name: ibm-elasticsearch-operator
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace

--- a/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
@@ -102,7 +102,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.ccs_channel }}"
-  installPlanApproval: "{{ .Values.cpd_ccs_install_plan | default('Automatic') }}"
+  installPlanApproval: "{{ .Values.cpd_ccs_install_plan | default('Automatic', True) }}"
   name: ibm-cpd-ccs
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
@@ -121,7 +121,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.datarefinery_channel }}"
-  installPlanApproval: "{{ .Values.cpd_datarefinery_install_plan | default('Automatic') }}"
+  installPlanApproval: "{{ .Values.cpd_datarefinery_install_plan | default('Automatic', True) }}"
   name: ibm-cpd-datarefinery
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
@@ -140,7 +140,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.ws_runtimes_channel }}"
-  installPlanApproval: "{{ .Values.cpd_ws_install_plan | default('Automatic') }}"
+  installPlanApproval: "{{ .Values.cpd_ws_install_plan | default('Automatic', True) }}"
   name: ibm-cpd-ws-runtimes
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
@@ -159,7 +159,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.opencontent_elasticsearch_channel }}"
-  installPlanApproval: "{{ .Values.elasticsearch_install_plan | default('Automatic') }}"
+  installPlanApproval: "{{ .Values.elasticsearch_install_plan | default('Automatic', True) }}"
   name: ibm-elasticsearch-operator
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace

--- a/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
@@ -102,7 +102,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.ccs_channel }}"
-  installPlanApproval: "{{ .Values.cpd_ccs_install_plan | default('Automatic', True) }}"
+  installPlanApproval: "{{ .Values.cpd_ccs_install_plan | default "Automatic" | quote }}"
   name: ibm-cpd-ccs
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
@@ -121,7 +121,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.datarefinery_channel }}"
-  installPlanApproval: "{{ .Values.cpd_datarefinery_install_plan | default('Automatic', True) }}"
+  installPlanApproval: "{{ .Values.cpd_datarefinery_install_plan | default "Automatic" | quote }}"
   name: ibm-cpd-datarefinery
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
@@ -140,7 +140,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.ws_runtimes_channel }}"
-  installPlanApproval: "{{ .Values.cpd_ws_install_plan | default('Automatic', True) }}"
+  installPlanApproval: "{{ .Values.cpd_ws_install_plan | default "Automatic" | quote }}"
   name: ibm-cpd-ws-runtimes
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
@@ -159,7 +159,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.opencontent_elasticsearch_channel }}"
-  installPlanApproval: "{{ .Values.elasticsearch_install_plan | default('Automatic', True) }}"
+  installPlanApproval: "{{ .Values.elasticsearch_install_plan | default "Automatic" | quote }}"
   name: ibm-elasticsearch-operator
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace

--- a/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
@@ -102,7 +102,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.ccs_channel }}"
-  installPlanApproval: "{{ .Values.cpd_ccs_install_plan | default "Automatic" | quote }}"
+  installPlanApproval: {{ .Values.cpd_ccs_install_plan | default "Automatic" | quote }}
   name: ibm-cpd-ccs
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
@@ -121,7 +121,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.datarefinery_channel }}"
-  installPlanApproval: "{{ .Values.cpd_datarefinery_install_plan | default "Automatic" | quote }}"
+  installPlanApproval: {{ .Values.cpd_datarefinery_install_plan | default "Automatic" | quote }}
   name: ibm-cpd-datarefinery
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
@@ -140,7 +140,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.ws_runtimes_channel }}"
-  installPlanApproval: "{{ .Values.cpd_ws_install_plan | default "Automatic" | quote }}"
+  installPlanApproval: {{ .Values.cpd_ws_install_plan | default "Automatic" | quote }}
   name: ibm-cpd-ws-runtimes
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
@@ -159,7 +159,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.opencontent_elasticsearch_channel }}"
-  installPlanApproval: "{{ .Values.elasticsearch_install_plan | default "Automatic" | quote }}"
+  installPlanApproval: {{ .Values.elasticsearch_install_plan | default "Automatic" | quote }}
   name: ibm-elasticsearch-operator
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace

--- a/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
@@ -102,7 +102,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.ccs_channel }}"
-  installPlanApproval: Automatic
+  installPlanApproval: "{{ .Values.cpd_ccs_install_plan }}"
   name: ibm-cpd-ccs
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
@@ -121,7 +121,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.datarefinery_channel }}"
-  installPlanApproval: Automatic
+  installPlanApproval: "{{ .Values.cpd_datarefinery_install_plan }}"
   name: ibm-cpd-datarefinery
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
@@ -140,7 +140,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.ws_runtimes_channel }}"
-  installPlanApproval: Automatic
+  installPlanApproval: "{{ .Values.cpd_ws_install_plan }}"
   name: ibm-cpd-ws-runtimes
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
@@ -159,7 +159,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.opencontent_elasticsearch_channel }}"
-  installPlanApproval: Automatic
+  installPlanApproval: "{{ .Values.elasticsearch_install_plan }}"
   name: ibm-elasticsearch-operator
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace

--- a/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_dependencies.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_dependencies.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   operators:
     - channel: "{{ .Values.ccs_channel }}"
-      installPlanApproval: "{{ .Values.cpd_ccs_install_plan | default('Automatic') }}"
+      installPlanApproval: "{{ .Values.cpd_ccs_install_plan | default('Automatic', True) }}"
       name: ibm-cpd-ccs-operator
       namespace: "{{ .Values.cpd_operators_namespace }}"
       packageName: ibm-cpd-ccs
@@ -40,7 +40,7 @@ metadata:
 spec:
   operators:
     - channel: "{{ .Values.datarefinery_channel }}"
-      installPlanApproval: "{{ .Values.cpd_datarefinery_install_plan | default('Automatic') }}"
+      installPlanApproval: "{{ .Values.cpd_datarefinery_install_plan | default('Automatic', True) }}"
       name: ibm-cpd-datarefinery-operator
       namespace: "{{ .Values.cpd_operators_namespace }}"
       packageName: ibm-cpd-datarefinery
@@ -63,7 +63,7 @@ metadata:
 spec:
   operators:
     - channel: "{{ .Values.ws_runtimes_channel }}"
-      installPlanApproval: "{{ .Values.cpd_ws_install_plan | default('Automatic') }}"
+      installPlanApproval: "{{ .Values.cpd_ws_install_plan | default('Automatic', True) }}"
       name: ibm-cpd-ws-runtimes-operator
       namespace: "{{ .Values.cpd_operators_namespace }}"
       packageName: ibm-cpd-ws-runtimes
@@ -86,7 +86,7 @@ metadata:
 spec:
   operators:
     - channel: "{{ .Values.opencontent_rabbitmq_channel }}"
-      installPlanApproval: "{{ .Values.rabbitmq_install_plan | default('Automatic') }}"
+      installPlanApproval: "{{ .Values.rabbitmq_install_plan | default('Automatic', True) }}"
       name: rabbitmq-operator
       namespace: "{{ .Values.cpd_operators_namespace }}"
       packageName: ibm-rabbitmq-operator
@@ -109,7 +109,7 @@ metadata:
 spec:
   operators:
     - channel: "{{ .Values.opencontent_elasticsearch_channel }}"
-      installPlanApproval: "{{ .Values.elasticsearch_install_plan | default('Automatic') }}"
+      installPlanApproval: "{{ .Values.elasticsearch_install_plan | default('Automatic', True) }}"
       name: elasticsearch-operator
       namespace: "{{ .Values.cpd_operators_namespace }}"
       packageName: ibm-elasticsearch-operator

--- a/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_dependencies.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_dependencies.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   operators:
     - channel: "{{ .Values.ccs_channel }}"
-      installPlanApproval: Automatic
+      installPlanApproval: "{{ .Values.cpd_ccs_install_plan }}"
       name: ibm-cpd-ccs-operator
       namespace: "{{ .Values.cpd_operators_namespace }}"
       packageName: ibm-cpd-ccs
@@ -40,7 +40,7 @@ metadata:
 spec:
   operators:
     - channel: "{{ .Values.datarefinery_channel }}"
-      installPlanApproval: Automatic
+      installPlanApproval: "{{ .Values.cpd_datarefinery_install_plan }}"
       name: ibm-cpd-datarefinery-operator
       namespace: "{{ .Values.cpd_operators_namespace }}"
       packageName: ibm-cpd-datarefinery
@@ -63,7 +63,7 @@ metadata:
 spec:
   operators:
     - channel: "{{ .Values.ws_runtimes_channel }}"
-      installPlanApproval: Automatic
+      installPlanApproval: "{{ .Values.cpd_ws_install_plan }}"
       name: ibm-cpd-ws-runtimes-operator
       namespace: "{{ .Values.cpd_operators_namespace }}"
       packageName: ibm-cpd-ws-runtimes
@@ -86,7 +86,7 @@ metadata:
 spec:
   operators:
     - channel: "{{ .Values.opencontent_rabbitmq_channel }}"
-      installPlanApproval: Automatic
+      installPlanApproval: "{{ .Values.rabbitmq_install_plan }}"
       name: rabbitmq-operator
       namespace: "{{ .Values.cpd_operators_namespace }}"
       packageName: ibm-rabbitmq-operator
@@ -109,7 +109,7 @@ metadata:
 spec:
   operators:
     - channel: "{{ .Values.opencontent_elasticsearch_channel }}"
-      installPlanApproval: Automatic
+      installPlanApproval: "{{ .Values.elasticsearch_install_plan }}"
       name: elasticsearch-operator
       namespace: "{{ .Values.cpd_operators_namespace }}"
       packageName: ibm-elasticsearch-operator

--- a/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_dependencies.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_dependencies.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   operators:
     - channel: "{{ .Values.ccs_channel }}"
-      installPlanApproval: "{{ .Values.cpd_ccs_install_plan | default "Automatic" | quote }}"
+      installPlanApproval: {{ .Values.cpd_ccs_install_plan | default "Automatic" | quote }}
       name: ibm-cpd-ccs-operator
       namespace: "{{ .Values.cpd_operators_namespace }}"
       packageName: ibm-cpd-ccs
@@ -40,7 +40,7 @@ metadata:
 spec:
   operators:
     - channel: "{{ .Values.datarefinery_channel }}"
-      installPlanApproval: "{{ .Values.cpd_datarefinery_install_plan | default "Automatic" | quote }}"
+      installPlanApproval: {{ .Values.cpd_datarefinery_install_plan | default "Automatic" | quote }}
       name: ibm-cpd-datarefinery-operator
       namespace: "{{ .Values.cpd_operators_namespace }}"
       packageName: ibm-cpd-datarefinery
@@ -63,7 +63,7 @@ metadata:
 spec:
   operators:
     - channel: "{{ .Values.ws_runtimes_channel }}"
-      installPlanApproval: "{{ .Values.cpd_ws_install_plan | default "Automatic" | quote }}"
+      installPlanApproval: {{ .Values.cpd_ws_install_plan | default "Automatic" | quote }}
       name: ibm-cpd-ws-runtimes-operator
       namespace: "{{ .Values.cpd_operators_namespace }}"
       packageName: ibm-cpd-ws-runtimes
@@ -86,7 +86,7 @@ metadata:
 spec:
   operators:
     - channel: "{{ .Values.opencontent_rabbitmq_channel }}"
-      installPlanApproval: "{{ .Values.rabbitmq_install_plan | default "Automatic" | quote }}"
+      installPlanApproval: {{ .Values.rabbitmq_install_plan | default "Automatic" | quote }}
       name: rabbitmq-operator
       namespace: "{{ .Values.cpd_operators_namespace }}"
       packageName: ibm-rabbitmq-operator
@@ -109,7 +109,7 @@ metadata:
 spec:
   operators:
     - channel: "{{ .Values.opencontent_elasticsearch_channel }}"
-      installPlanApproval: "{{ .Values.elasticsearch_install_plan | default "Automatic" | quote }}"
+      installPlanApproval: {{ .Values.elasticsearch_install_plan | default "Automatic" | quote }}
       name: elasticsearch-operator
       namespace: "{{ .Values.cpd_operators_namespace }}"
       packageName: ibm-elasticsearch-operator

--- a/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_dependencies.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_dependencies.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   operators:
     - channel: "{{ .Values.ccs_channel }}"
-      installPlanApproval: "{{ .Values.cpd_ccs_install_plan | default('Automatic', True) }}"
+      installPlanApproval: "{{ .Values.cpd_ccs_install_plan | default "Automatic" | quote }}"
       name: ibm-cpd-ccs-operator
       namespace: "{{ .Values.cpd_operators_namespace }}"
       packageName: ibm-cpd-ccs
@@ -40,7 +40,7 @@ metadata:
 spec:
   operators:
     - channel: "{{ .Values.datarefinery_channel }}"
-      installPlanApproval: "{{ .Values.cpd_datarefinery_install_plan | default('Automatic', True) }}"
+      installPlanApproval: "{{ .Values.cpd_datarefinery_install_plan | default "Automatic" | quote }}"
       name: ibm-cpd-datarefinery-operator
       namespace: "{{ .Values.cpd_operators_namespace }}"
       packageName: ibm-cpd-datarefinery
@@ -63,7 +63,7 @@ metadata:
 spec:
   operators:
     - channel: "{{ .Values.ws_runtimes_channel }}"
-      installPlanApproval: "{{ .Values.cpd_ws_install_plan | default('Automatic', True) }}"
+      installPlanApproval: "{{ .Values.cpd_ws_install_plan | default "Automatic" | quote }}"
       name: ibm-cpd-ws-runtimes-operator
       namespace: "{{ .Values.cpd_operators_namespace }}"
       packageName: ibm-cpd-ws-runtimes
@@ -86,7 +86,7 @@ metadata:
 spec:
   operators:
     - channel: "{{ .Values.opencontent_rabbitmq_channel }}"
-      installPlanApproval: "{{ .Values.rabbitmq_install_plan | default('Automatic', True) }}"
+      installPlanApproval: "{{ .Values.rabbitmq_install_plan | default "Automatic" | quote }}"
       name: rabbitmq-operator
       namespace: "{{ .Values.cpd_operators_namespace }}"
       packageName: ibm-rabbitmq-operator
@@ -109,7 +109,7 @@ metadata:
 spec:
   operators:
     - channel: "{{ .Values.opencontent_elasticsearch_channel }}"
-      installPlanApproval: "{{ .Values.elasticsearch_install_plan | default('Automatic', True) }}"
+      installPlanApproval: "{{ .Values.elasticsearch_install_plan | default "Automatic" | quote }}"
       name: elasticsearch-operator
       namespace: "{{ .Values.cpd_operators_namespace }}"
       packageName: ibm-elasticsearch-operator

--- a/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_dependencies.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_dependencies.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   operators:
     - channel: "{{ .Values.ccs_channel }}"
-      installPlanApproval: "{{ .Values.cpd_ccs_install_plan }}"
+      installPlanApproval: "{{ .Values.cpd_ccs_install_plan | default('Automatic') }}"
       name: ibm-cpd-ccs-operator
       namespace: "{{ .Values.cpd_operators_namespace }}"
       packageName: ibm-cpd-ccs
@@ -40,7 +40,7 @@ metadata:
 spec:
   operators:
     - channel: "{{ .Values.datarefinery_channel }}"
-      installPlanApproval: "{{ .Values.cpd_datarefinery_install_plan }}"
+      installPlanApproval: "{{ .Values.cpd_datarefinery_install_plan | default('Automatic') }}"
       name: ibm-cpd-datarefinery-operator
       namespace: "{{ .Values.cpd_operators_namespace }}"
       packageName: ibm-cpd-datarefinery
@@ -63,7 +63,7 @@ metadata:
 spec:
   operators:
     - channel: "{{ .Values.ws_runtimes_channel }}"
-      installPlanApproval: "{{ .Values.cpd_ws_install_plan }}"
+      installPlanApproval: "{{ .Values.cpd_ws_install_plan | default('Automatic') }}"
       name: ibm-cpd-ws-runtimes-operator
       namespace: "{{ .Values.cpd_operators_namespace }}"
       packageName: ibm-cpd-ws-runtimes
@@ -86,7 +86,7 @@ metadata:
 spec:
   operators:
     - channel: "{{ .Values.opencontent_rabbitmq_channel }}"
-      installPlanApproval: "{{ .Values.rabbitmq_install_plan }}"
+      installPlanApproval: "{{ .Values.rabbitmq_install_plan | default('Automatic') }}"
       name: rabbitmq-operator
       namespace: "{{ .Values.cpd_operators_namespace }}"
       packageName: ibm-rabbitmq-operator
@@ -109,7 +109,7 @@ metadata:
 spec:
   operators:
     - channel: "{{ .Values.opencontent_elasticsearch_channel }}"
-      installPlanApproval: "{{ .Values.elasticsearch_install_plan }}"
+      installPlanApproval: "{{ .Values.elasticsearch_install_plan | default('Automatic') }}"
       name: elasticsearch-operator
       namespace: "{{ .Values.cpd_operators_namespace }}"
       packageName: ibm-elasticsearch-operator

--- a/instance-applications/110-ibm-cs-control/templates/04-ibm-cs-control_prereqs_ops.yaml
+++ b/instance-applications/110-ibm-cs-control/templates/04-ibm-cs-control_prereqs_ops.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.cpd_ibm_licensing_channel }}"
-  installPlanApproval: "{{ .Values.cpd_licensing_install_plan | default "Automatic" | quote }}"
+  installPlanApproval: {{ .Values.cpd_licensing_install_plan | default "Automatic" | quote }}
   name: ibm-licensing-operator-app
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace

--- a/instance-applications/110-ibm-cs-control/templates/04-ibm-cs-control_prereqs_ops.yaml
+++ b/instance-applications/110-ibm-cs-control/templates/04-ibm-cs-control_prereqs_ops.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.cpd_ibm_licensing_channel }}"
-  installPlanApproval: Automatic
+  installPlanApproval: "{{ .Values.cpd_licensing_install_plan }}"
   name: ibm-licensing-operator-app
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace

--- a/instance-applications/110-ibm-cs-control/templates/04-ibm-cs-control_prereqs_ops.yaml
+++ b/instance-applications/110-ibm-cs-control/templates/04-ibm-cs-control_prereqs_ops.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.cpd_ibm_licensing_channel }}"
-  installPlanApproval: "{{ .Values.cpd_licensing_install_plan }}"
+  installPlanApproval: "{{ .Values.cpd_licensing_install_plan | default('Automatic') }}"
   name: ibm-licensing-operator-app
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace

--- a/instance-applications/110-ibm-cs-control/templates/04-ibm-cs-control_prereqs_ops.yaml
+++ b/instance-applications/110-ibm-cs-control/templates/04-ibm-cs-control_prereqs_ops.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.cpd_ibm_licensing_channel }}"
-  installPlanApproval: "{{ .Values.cpd_licensing_install_plan | default('Automatic') }}"
+  installPlanApproval: "{{ .Values.cpd_licensing_install_plan | default('Automatic', True) }}"
   name: ibm-licensing-operator-app
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace

--- a/instance-applications/110-ibm-cs-control/templates/04-ibm-cs-control_prereqs_ops.yaml
+++ b/instance-applications/110-ibm-cs-control/templates/04-ibm-cs-control_prereqs_ops.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.cpd_ibm_licensing_channel }}"
-  installPlanApproval: "{{ .Values.cpd_licensing_install_plan | default('Automatic', True) }}"
+  installPlanApproval: "{{ .Values.cpd_licensing_install_plan | default "Automatic" | quote }}"
   name: ibm-licensing-operator-app
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace

--- a/instance-applications/110-ibm-db2u/templates/03-db2_Subscription.yaml
+++ b/instance-applications/110-ibm-db2u/templates/03-db2_Subscription.yaml
@@ -12,7 +12,7 @@ metadata:
 {{- end }}
 spec:
   channel: {{ .Values.db2_channel }}
-  installPlanApproval: Automatic
+  installPlanApproval: {{ .Values.db2_install_plan }}
   name: db2u-operator
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace

--- a/instance-applications/110-ibm-db2u/templates/03-db2_Subscription.yaml
+++ b/instance-applications/110-ibm-db2u/templates/03-db2_Subscription.yaml
@@ -12,7 +12,7 @@ metadata:
 {{- end }}
 spec:
   channel: {{ .Values.db2_channel }}
-  installPlanApproval: {{ .Values.db2_install_plan }}
+  installPlanApproval: "{{ .Values.db2_install_plan | default('Automatic') }}"
   name: db2u-operator
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace

--- a/instance-applications/110-ibm-db2u/templates/03-db2_Subscription.yaml
+++ b/instance-applications/110-ibm-db2u/templates/03-db2_Subscription.yaml
@@ -12,7 +12,7 @@ metadata:
 {{- end }}
 spec:
   channel: {{ .Values.db2_channel }}
-  installPlanApproval: "{{ .Values.db2_install_plan | default('Automatic') }}"
+  installPlanApproval: "{{ .Values.db2_install_plan | default('Automatic', True) }}"
   name: db2u-operator
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace

--- a/instance-applications/110-ibm-db2u/templates/03-db2_Subscription.yaml
+++ b/instance-applications/110-ibm-db2u/templates/03-db2_Subscription.yaml
@@ -12,7 +12,7 @@ metadata:
 {{- end }}
 spec:
   channel: {{ .Values.db2_channel }}
-  installPlanApproval: "{{ .Values.db2_install_plan | default('Automatic', True) }}"
+  installPlanApproval: "{{ .Values.db2_install_plan | default "Automatic" | quote }}"
   name: db2u-operator
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace

--- a/instance-applications/110-ibm-db2u/templates/03-db2_Subscription.yaml
+++ b/instance-applications/110-ibm-db2u/templates/03-db2_Subscription.yaml
@@ -12,7 +12,7 @@ metadata:
 {{- end }}
 spec:
   channel: {{ .Values.db2_channel }}
-  installPlanApproval: "{{ .Values.db2_install_plan | default "Automatic" | quote }}"
+  installPlanApproval: {{ .Values.db2_install_plan | default "Automatic" | quote }}
   name: db2u-operator
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace

--- a/instance-applications/120-ibm-aiopenscale/templates/00-ibm-aiopenscale_Subscription.yaml
+++ b/instance-applications/120-ibm-aiopenscale/templates/00-ibm-aiopenscale_Subscription.yaml
@@ -15,4 +15,4 @@ spec:
   channel: "{{ .Values.aiopenscale_channel }}"
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  installPlanApproval: {{ .Values.aiopenscale_install_plan }}
+  installPlanApproval: "{{ .Values.aiopenscale_install_plan | default('Automatic') }}"

--- a/instance-applications/120-ibm-aiopenscale/templates/00-ibm-aiopenscale_Subscription.yaml
+++ b/instance-applications/120-ibm-aiopenscale/templates/00-ibm-aiopenscale_Subscription.yaml
@@ -15,4 +15,4 @@ spec:
   channel: "{{ .Values.aiopenscale_channel }}"
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  installPlanApproval: "{{ .Values.aiopenscale_install_plan | default('Automatic') }}"
+  installPlanApproval: "{{ .Values.aiopenscale_install_plan | default('Automatic', True) }}"

--- a/instance-applications/120-ibm-aiopenscale/templates/00-ibm-aiopenscale_Subscription.yaml
+++ b/instance-applications/120-ibm-aiopenscale/templates/00-ibm-aiopenscale_Subscription.yaml
@@ -15,4 +15,4 @@ spec:
   channel: "{{ .Values.aiopenscale_channel }}"
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  installPlanApproval: Automatic
+  installPlanApproval: {{ .Values.aiopenscale_install_plan }}

--- a/instance-applications/120-ibm-aiopenscale/templates/00-ibm-aiopenscale_Subscription.yaml
+++ b/instance-applications/120-ibm-aiopenscale/templates/00-ibm-aiopenscale_Subscription.yaml
@@ -15,4 +15,4 @@ spec:
   channel: "{{ .Values.aiopenscale_channel }}"
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  installPlanApproval: "{{ .Values.aiopenscale_install_plan | default('Automatic', True) }}"
+  installPlanApproval: "{{ .Values.aiopenscale_install_plan | default "Automatic" | quote }}"

--- a/instance-applications/120-ibm-aiopenscale/templates/00-ibm-aiopenscale_Subscription.yaml
+++ b/instance-applications/120-ibm-aiopenscale/templates/00-ibm-aiopenscale_Subscription.yaml
@@ -15,4 +15,4 @@ spec:
   channel: "{{ .Values.aiopenscale_channel }}"
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  installPlanApproval: "{{ .Values.aiopenscale_install_plan | default "Automatic" | quote }}"
+  installPlanApproval: {{ .Values.aiopenscale_install_plan | default "Automatic" | quote }}

--- a/instance-applications/120-ibm-spark/templates/01-ibm-spark_Subscription.yaml
+++ b/instance-applications/120-ibm-spark/templates/01-ibm-spark_Subscription.yaml
@@ -15,5 +15,5 @@ spec:
   channel: "{{ .Values.spark_channel }}"
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  installPlanApproval: {{ .Values.spark_install_plan }}
+  installPlanApproval: "{{ .Values.spark_install_plan | default('Automatic') }}"
 

--- a/instance-applications/120-ibm-spark/templates/01-ibm-spark_Subscription.yaml
+++ b/instance-applications/120-ibm-spark/templates/01-ibm-spark_Subscription.yaml
@@ -15,5 +15,5 @@ spec:
   channel: "{{ .Values.spark_channel }}"
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  installPlanApproval: "{{ .Values.spark_install_plan | default('Automatic', True) }}"
+  installPlanApproval: "{{ .Values.spark_install_plan | default "Automatic" | quote }}"
 

--- a/instance-applications/120-ibm-spark/templates/01-ibm-spark_Subscription.yaml
+++ b/instance-applications/120-ibm-spark/templates/01-ibm-spark_Subscription.yaml
@@ -15,5 +15,5 @@ spec:
   channel: "{{ .Values.spark_channel }}"
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  installPlanApproval: "{{ .Values.spark_install_plan | default('Automatic') }}"
+  installPlanApproval: "{{ .Values.spark_install_plan | default('Automatic', True) }}"
 

--- a/instance-applications/120-ibm-spark/templates/01-ibm-spark_Subscription.yaml
+++ b/instance-applications/120-ibm-spark/templates/01-ibm-spark_Subscription.yaml
@@ -15,5 +15,5 @@ spec:
   channel: "{{ .Values.spark_channel }}"
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  installPlanApproval: "{{ .Values.spark_install_plan | default "Automatic" | quote }}"
+  installPlanApproval: {{ .Values.spark_install_plan | default "Automatic" | quote }}
 

--- a/instance-applications/120-ibm-spark/templates/01-ibm-spark_Subscription.yaml
+++ b/instance-applications/120-ibm-spark/templates/01-ibm-spark_Subscription.yaml
@@ -15,5 +15,5 @@ spec:
   channel: "{{ .Values.spark_channel }}"
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  installPlanApproval: Automatic
+  installPlanApproval: {{ .Values.spark_install_plan }}
 

--- a/instance-applications/120-ibm-spss/templates/00-ibm-spss_Subscription.yaml
+++ b/instance-applications/120-ibm-spss/templates/00-ibm-spss_Subscription.yaml
@@ -15,7 +15,7 @@ spec:
   channel: "{{ .Values.spss_channel }}"
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  installPlanApproval: Automatic
+  installPlanApproval: {{ .Values.spss_install_plan }}
 
 ---
 apiVersion: operators.coreos.com/v1alpha1
@@ -34,4 +34,4 @@ spec:
   channel: "{{ .Values.canvasbase_channel }}"
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  installPlanApproval: Automatic
+  installPlanApproval: {{ .Values.canvasbase_install_plan }}

--- a/instance-applications/120-ibm-spss/templates/00-ibm-spss_Subscription.yaml
+++ b/instance-applications/120-ibm-spss/templates/00-ibm-spss_Subscription.yaml
@@ -15,7 +15,7 @@ spec:
   channel: "{{ .Values.spss_channel }}"
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  installPlanApproval: {{ .Values.spss_install_plan }}
+  installPlanApproval: "{{ .Values.spss_install_plan | default('Automatic') }}"
 
 ---
 apiVersion: operators.coreos.com/v1alpha1
@@ -34,4 +34,4 @@ spec:
   channel: "{{ .Values.canvasbase_channel }}"
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  installPlanApproval: {{ .Values.canvasbase_install_plan }}
+  installPlanApproval: "{{ .Values.canvasbase_install_plan | default('Automatic') }}"

--- a/instance-applications/120-ibm-spss/templates/00-ibm-spss_Subscription.yaml
+++ b/instance-applications/120-ibm-spss/templates/00-ibm-spss_Subscription.yaml
@@ -15,7 +15,7 @@ spec:
   channel: "{{ .Values.spss_channel }}"
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  installPlanApproval: "{{ .Values.spss_install_plan | default "Automatic" | quote }}"
+  installPlanApproval: {{ .Values.spss_install_plan | default "Automatic" | quote }}
 
 ---
 apiVersion: operators.coreos.com/v1alpha1
@@ -34,4 +34,4 @@ spec:
   channel: "{{ .Values.canvasbase_channel }}"
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  installPlanApproval: "{{ .Values.canvasbase_install_plan | default "Automatic" | quote }}"
+  installPlanApproval: {{ .Values.canvasbase_install_plan | default "Automatic" | quote }}

--- a/instance-applications/120-ibm-spss/templates/00-ibm-spss_Subscription.yaml
+++ b/instance-applications/120-ibm-spss/templates/00-ibm-spss_Subscription.yaml
@@ -15,7 +15,7 @@ spec:
   channel: "{{ .Values.spss_channel }}"
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  installPlanApproval: "{{ .Values.spss_install_plan | default('Automatic', True) }}"
+  installPlanApproval: "{{ .Values.spss_install_plan | default "Automatic" | quote }}"
 
 ---
 apiVersion: operators.coreos.com/v1alpha1
@@ -34,4 +34,4 @@ spec:
   channel: "{{ .Values.canvasbase_channel }}"
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  installPlanApproval: "{{ .Values.canvasbase_install_plan | default('Automatic', True) }}"
+  installPlanApproval: "{{ .Values.canvasbase_install_plan | default "Automatic" | quote }}"

--- a/instance-applications/120-ibm-spss/templates/00-ibm-spss_Subscription.yaml
+++ b/instance-applications/120-ibm-spss/templates/00-ibm-spss_Subscription.yaml
@@ -15,7 +15,7 @@ spec:
   channel: "{{ .Values.spss_channel }}"
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  installPlanApproval: "{{ .Values.spss_install_plan | default('Automatic') }}"
+  installPlanApproval: "{{ .Values.spss_install_plan | default('Automatic', True) }}"
 
 ---
 apiVersion: operators.coreos.com/v1alpha1
@@ -34,4 +34,4 @@ spec:
   channel: "{{ .Values.canvasbase_channel }}"
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  installPlanApproval: "{{ .Values.canvasbase_install_plan | default('Automatic') }}"
+  installPlanApproval: "{{ .Values.canvasbase_install_plan | default('Automatic', True) }}"

--- a/instance-applications/120-ibm-wml/templates/01-ibm-wml_Subscription.yaml
+++ b/instance-applications/120-ibm-wml/templates/01-ibm-wml_Subscription.yaml
@@ -15,4 +15,4 @@ spec:
   channel: "{{ .Values.wml_channel }}"
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  installPlanApproval: "{{ .Values.wml_install_plan | default('Automatic') }}"
+  installPlanApproval: "{{ .Values.wml_install_plan | default('Automatic', True) }}"

--- a/instance-applications/120-ibm-wml/templates/01-ibm-wml_Subscription.yaml
+++ b/instance-applications/120-ibm-wml/templates/01-ibm-wml_Subscription.yaml
@@ -15,4 +15,4 @@ spec:
   channel: "{{ .Values.wml_channel }}"
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  installPlanApproval: "{{ .Values.wml_install_plan | default "Automatic" | quote }}"
+  installPlanApproval: {{ .Values.wml_install_plan | default "Automatic" | quote }}

--- a/instance-applications/120-ibm-wml/templates/01-ibm-wml_Subscription.yaml
+++ b/instance-applications/120-ibm-wml/templates/01-ibm-wml_Subscription.yaml
@@ -15,4 +15,4 @@ spec:
   channel: "{{ .Values.wml_channel }}"
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  installPlanApproval: Automatic
+  installPlanApproval: {{ .Values.wml_install_plan }}

--- a/instance-applications/120-ibm-wml/templates/01-ibm-wml_Subscription.yaml
+++ b/instance-applications/120-ibm-wml/templates/01-ibm-wml_Subscription.yaml
@@ -15,4 +15,4 @@ spec:
   channel: "{{ .Values.wml_channel }}"
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  installPlanApproval: {{ .Values.wml_install_plan }}
+  installPlanApproval: "{{ .Values.wml_install_plan | default('Automatic') }}"

--- a/instance-applications/120-ibm-wml/templates/01-ibm-wml_Subscription.yaml
+++ b/instance-applications/120-ibm-wml/templates/01-ibm-wml_Subscription.yaml
@@ -15,4 +15,4 @@ spec:
   channel: "{{ .Values.wml_channel }}"
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  installPlanApproval: "{{ .Values.wml_install_plan | default('Automatic', True) }}"
+  installPlanApproval: "{{ .Values.wml_install_plan | default "Automatic" | quote }}"

--- a/instance-applications/120-ibm-wsl/templates/00-ibm-wsl_Subscription.yaml
+++ b/instance-applications/120-ibm-wsl/templates/00-ibm-wsl_Subscription.yaml
@@ -15,4 +15,4 @@ spec:
   channel: "{{ .Values.wsl_channel }}"
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  installPlanApproval: "{{ .Values.wsl_install_plan | default "Automatic" | quote }}"
+  installPlanApproval: {{ .Values.wsl_install_plan | default "Automatic" | quote }}

--- a/instance-applications/120-ibm-wsl/templates/00-ibm-wsl_Subscription.yaml
+++ b/instance-applications/120-ibm-wsl/templates/00-ibm-wsl_Subscription.yaml
@@ -15,4 +15,4 @@ spec:
   channel: "{{ .Values.wsl_channel }}"
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  installPlanApproval: Automatic
+  installPlanApproval: {{ .Values.wsl_install_plan }}

--- a/instance-applications/120-ibm-wsl/templates/00-ibm-wsl_Subscription.yaml
+++ b/instance-applications/120-ibm-wsl/templates/00-ibm-wsl_Subscription.yaml
@@ -15,4 +15,4 @@ spec:
   channel: "{{ .Values.wsl_channel }}"
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  installPlanApproval: {{ .Values.wsl_install_plan }}
+  installPlanApproval: "{{ .Values.wsl_install_plan | default('Automatic') }}"

--- a/instance-applications/120-ibm-wsl/templates/00-ibm-wsl_Subscription.yaml
+++ b/instance-applications/120-ibm-wsl/templates/00-ibm-wsl_Subscription.yaml
@@ -15,4 +15,4 @@ spec:
   channel: "{{ .Values.wsl_channel }}"
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  installPlanApproval: "{{ .Values.wsl_install_plan | default('Automatic') }}"
+  installPlanApproval: "{{ .Values.wsl_install_plan | default('Automatic', True) }}"

--- a/instance-applications/120-ibm-wsl/templates/00-ibm-wsl_Subscription.yaml
+++ b/instance-applications/120-ibm-wsl/templates/00-ibm-wsl_Subscription.yaml
@@ -15,4 +15,4 @@ spec:
   channel: "{{ .Values.wsl_channel }}"
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace
-  installPlanApproval: "{{ .Values.wsl_install_plan | default('Automatic', True) }}"
+  installPlanApproval: "{{ .Values.wsl_install_plan | default "Automatic" | quote }}"

--- a/instance-applications/130-ibm-mas-suite/templates/02-ibm-mas_Subscription.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/02-ibm-mas_Subscription.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.mas_channel }}"
-  installPlanApproval: "{{ .Values.mas_install_plan | default('Automatic') }}"
+  installPlanApproval: "{{ .Values.mas_install_plan | default('Automatic', True) }}"
   name: ibm-mas
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace

--- a/instance-applications/130-ibm-mas-suite/templates/02-ibm-mas_Subscription.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/02-ibm-mas_Subscription.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.mas_channel }}"
-  installPlanApproval: {{ .Values.mas_install_plan }}
+  installPlanApproval: "{{ .Values.mas_install_plan | default('Automatic') }}"
   name: ibm-mas
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace

--- a/instance-applications/130-ibm-mas-suite/templates/02-ibm-mas_Subscription.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/02-ibm-mas_Subscription.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.mas_channel }}"
-  installPlanApproval: "{{ .Values.mas_install_plan | default "Automatic" | quote }}"
+  installPlanApproval: {{ .Values.mas_install_plan | default "Automatic" | quote }}
   name: ibm-mas
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace

--- a/instance-applications/130-ibm-mas-suite/templates/02-ibm-mas_Subscription.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/02-ibm-mas_Subscription.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.mas_channel }}"
-  installPlanApproval: "{{ .Values.mas_install_plan | default('Automatic', True) }}"
+  installPlanApproval: "{{ .Values.mas_install_plan | default "Automatic" | quote }}"
   name: ibm-mas
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace

--- a/instance-applications/130-ibm-mas-suite/templates/02-ibm-mas_Subscription.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/02-ibm-mas_Subscription.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.mas_channel }}"
-  installPlanApproval: Automatic
+  installPlanApproval: {{ .Values.mas_install_plan }}
   name: ibm-mas
   source: ibm-operator-catalog
   sourceNamespace: openshift-marketplace

--- a/instance-applications/500-540-ibm-mas-suite-app-install/templates/04-ibm-mas_Subscription.yaml
+++ b/instance-applications/500-540-ibm-mas-suite-app-install/templates/04-ibm-mas_Subscription.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.mas_app_channel }}"
-  installPlanApproval: Automatic
+  installPlanApproval: "{{ .Values.mas_app_install_plan }}"
 {{- if eq .Values.mas_app_id "health" }}
   name: ibm-mas-manage
 {{- else }}

--- a/instance-applications/500-540-ibm-mas-suite-app-install/templates/04-ibm-mas_Subscription.yaml
+++ b/instance-applications/500-540-ibm-mas-suite-app-install/templates/04-ibm-mas_Subscription.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.mas_app_channel }}"
-  installPlanApproval: "{{ .Values.mas_app_install_plan }}"
+  installPlanApproval: "{{ .Values.mas_app_install_plan | default('Automatic') }}"
 {{- if eq .Values.mas_app_id "health" }}
   name: ibm-mas-manage
 {{- else }}

--- a/instance-applications/500-540-ibm-mas-suite-app-install/templates/04-ibm-mas_Subscription.yaml
+++ b/instance-applications/500-540-ibm-mas-suite-app-install/templates/04-ibm-mas_Subscription.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.mas_app_channel }}"
-  installPlanApproval: "{{ .Values.mas_app_install_plan | default('Automatic', True) }}"
+  installPlanApproval: "{{ .Values.mas_app_install_plan | default "Automatic" | quote }}"
 {{- if eq .Values.mas_app_id "health" }}
   name: ibm-mas-manage
 {{- else }}

--- a/instance-applications/500-540-ibm-mas-suite-app-install/templates/04-ibm-mas_Subscription.yaml
+++ b/instance-applications/500-540-ibm-mas-suite-app-install/templates/04-ibm-mas_Subscription.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.mas_app_channel }}"
-  installPlanApproval: "{{ .Values.mas_app_install_plan | default "Automatic" | quote }}"
+  installPlanApproval: {{ .Values.mas_app_install_plan | default "Automatic" | quote }}
 {{- if eq .Values.mas_app_id "health" }}
   name: ibm-mas-manage
 {{- else }}

--- a/instance-applications/500-540-ibm-mas-suite-app-install/templates/04-ibm-mas_Subscription.yaml
+++ b/instance-applications/500-540-ibm-mas-suite-app-install/templates/04-ibm-mas_Subscription.yaml
@@ -13,7 +13,7 @@ metadata:
 {{- end }}
 spec:
   channel: "{{ .Values.mas_app_channel }}"
-  installPlanApproval: "{{ .Values.mas_app_install_plan | default('Automatic') }}"
+  installPlanApproval: "{{ .Values.mas_app_install_plan | default('Automatic', True) }}"
 {{- if eq .Values.mas_app_id "health" }}
   name: ibm-mas-manage
 {{- else }}

--- a/root-applications/ibm-mas-cluster-root/templates/010-ibm-redhat-cert-manager-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/010-ibm-redhat-cert-manager-app.yaml
@@ -41,7 +41,7 @@ spec:
             sm_aws_secret_access_key: "{{ .Values.sm.aws_secret_access_key }}"
             channel: "{{ .Values.redhat_cert_manager.channel }}"
             run_sync_hooks: {{ .Values.redhat_cert_manager.run_sync_hooks }}
-            cert_manager_install_plan_approval: {{ .Values.redhat_cert_manager.cert_manager_install_plan_approval | default('Automatic') }}
+            cert_manager_install_plan: {{ .Values.redhat_cert_manager.cert_manager_install_plan | default('Automatic') }}
             {{- if .Values.custom_labels }}
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}

--- a/root-applications/ibm-mas-cluster-root/templates/010-ibm-redhat-cert-manager-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/010-ibm-redhat-cert-manager-app.yaml
@@ -41,7 +41,7 @@ spec:
             sm_aws_secret_access_key: "{{ .Values.sm.aws_secret_access_key }}"
             channel: "{{ .Values.redhat_cert_manager.channel }}"
             run_sync_hooks: {{ .Values.redhat_cert_manager.run_sync_hooks }}
-            cert_manager_install_plan: "{{ .Values.redhat_cert_manager.cert_manager_install_plan }}"
+            redhat_cert_manager_install_plan: "{{ .Values.redhat_cert_manager.redhat_cert_manager_install_plan }}"
             junitreporter:
               reporter_name: "redhat-cert-manager"
               cluster_id: "{{ .Values.cluster.id }}"

--- a/root-applications/ibm-mas-cluster-root/templates/010-ibm-redhat-cert-manager-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/010-ibm-redhat-cert-manager-app.yaml
@@ -41,6 +41,7 @@ spec:
             sm_aws_secret_access_key: "{{ .Values.sm.aws_secret_access_key }}"
             channel: "{{ .Values.redhat_cert_manager.channel }}"
             run_sync_hooks: {{ .Values.redhat_cert_manager.run_sync_hooks }}
+            cert_manager_install_plan_approval: {{ .Values.redhat_cert_manager.cert_manager_install_plan_approval | default('Automatic') }}
             {{- if .Values.custom_labels }}
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}

--- a/root-applications/ibm-mas-cluster-root/templates/010-ibm-redhat-cert-manager-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/010-ibm-redhat-cert-manager-app.yaml
@@ -41,7 +41,7 @@ spec:
             sm_aws_secret_access_key: "{{ .Values.sm.aws_secret_access_key }}"
             channel: "{{ .Values.redhat_cert_manager.channel }}"
             run_sync_hooks: {{ .Values.redhat_cert_manager.run_sync_hooks }}
-            cert_manager_install_plan: "{{ .Values.redhat_cert_manager.cert_manager_install_plan | default('Automatic') }}"
+            cert_manager_install_plan: "{{ .Values.redhat_cert_manager.cert_manager_install_plan | default('Automatic', True) }}"
             {{- if .Values.custom_labels }}
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}

--- a/root-applications/ibm-mas-cluster-root/templates/010-ibm-redhat-cert-manager-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/010-ibm-redhat-cert-manager-app.yaml
@@ -41,7 +41,7 @@ spec:
             sm_aws_secret_access_key: "{{ .Values.sm.aws_secret_access_key }}"
             channel: "{{ .Values.redhat_cert_manager.channel }}"
             run_sync_hooks: {{ .Values.redhat_cert_manager.run_sync_hooks }}
-            cert_manager_install_plan: {{ .Values.redhat_cert_manager.cert_manager_install_plan | default('Automatic') }}
+            cert_manager_install_plan: "{{ .Values.redhat_cert_manager.cert_manager_install_plan | default('Automatic') }}"
             {{- if .Values.custom_labels }}
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}

--- a/root-applications/ibm-mas-cluster-root/templates/010-ibm-redhat-cert-manager-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/010-ibm-redhat-cert-manager-app.yaml
@@ -41,7 +41,7 @@ spec:
             sm_aws_secret_access_key: "{{ .Values.sm.aws_secret_access_key }}"
             channel: "{{ .Values.redhat_cert_manager.channel }}"
             run_sync_hooks: {{ .Values.redhat_cert_manager.run_sync_hooks }}
-            cert_manager_install_plan: "{{ .Values.redhat_cert_manager.cert_manager_install_plan | default('Automatic', True) }}"
+            cert_manager_install_plan: "{{ .Values.redhat_cert_manager.cert_manager_install_plan }}"
             {{- if .Values.custom_labels }}
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}

--- a/root-applications/ibm-mas-cluster-root/templates/020-ibm-dro-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/020-ibm-dro-app.yaml
@@ -48,6 +48,8 @@ spec:
             dro_namespace: "{{ .Values.ibm_dro.dro_namespace }}"
             ibm_entitlement_key: "{{ .Values.ibm_dro.ibm_entitlement_key }}"
             dro_cmm_setup: "{{ .Values.ibm_dro.dro_cmm_setup }}"
+            dro_install_plan: "{{ .Values.ibm_dro.dro_install_plan }}"
+            imo_install_plan: "{{ .Values.ibm_dro.imo_install_plan }}"
             {{- if .Values.ibm_dro.dro_cmm_setup  }}
             dro_cmm:
               auth_apikey: "{{ .Values.ibm_dro.dro_cmm.auth_apikey }}"

--- a/root-applications/ibm-mas-cluster-root/templates/040-cis-compliance-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/040-cis-compliance-app.yaml
@@ -34,6 +34,7 @@ spec:
         - name: {{ .Values.avp.values_varname }}
           value: |
             argo_namespace: "{{ .Values.argo.namespace }}"
+            cis_install_plan: "{{ .Values.cis_compliance.cis_install_plan }}"
             {{- if .Values.custom_labels }}
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}

--- a/root-applications/ibm-mas-cluster-root/templates/050-nfd-operator-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/050-nfd-operator-app.yaml
@@ -36,6 +36,7 @@ spec:
             argo_namespace: "{{ .Values.argo.namespace }}"
             nfd_namespace: "{{ .Values.nvidia_gpu_operator.nfd_namespace }}"
             nfd_channel: "{{ .Values.nvidia_gpu_operator.nfd_channel }}"
+            nfd_install_plan: "{{ .Values.nvidia_gpu_operator.nfd_install_plan }}"
             {{- if .Values.custom_labels }}
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}

--- a/root-applications/ibm-mas-cluster-root/templates/051-nvidia-gpu-operator-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/051-nvidia-gpu-operator-app.yaml
@@ -37,6 +37,7 @@ spec:
             gpu_channel: "{{ .Values.nvidia_gpu_operator.gpu_channel }}"
             gpu_driver_repository_path: "{{ .Values.nvidia_gpu_operator.gpu_driver_repository_path }}"
             gpu_driver_version: "{{ .Values.nvidia_gpu_operator.gpu_driver_version }}"
+            gpu_install_plan: "{{ .Values.nvidia_gpu_operator.gpu_install_plan }}"
             {{- if .Values.custom_labels }}
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}

--- a/root-applications/ibm-mas-instance-root/templates/100-ibm-sls-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/100-ibm-sls-app.yaml
@@ -53,6 +53,7 @@ spec:
             sls_mongo_password: "{{ .Values.ibm_sls.sls_mongo_password }}"
             sls_entitlement_file: "{{ .Values.ibm_sls.sls_entitlement_file }}"
             icr_cp_open: "{{ .Values.ibm_sls.icr_cp_open }}"
+            sls_install_plan: "{{ .Values.ibm_sls.sls_install_plan }}"
             mongo_spec: {{ .Values.ibm_sls.mongo_spec | toYaml | nindent 14}}
             {{- if .Values.custom_labels }}
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}

--- a/root-applications/ibm-mas-instance-root/templates/110-ibm-cp4d-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/110-ibm-cp4d-app.yaml
@@ -54,13 +54,17 @@ spec:
             cpd_cs_control_namespace: "{{ .Values.ibm_cp4d.cpd_cs_control_namespace }}"
             cpd_admin_login_sa: "{{ .Values.ibm_cp4d.cpd_admin_login_sa }}"
             namespace_scope_channel: "{{ .Values.ibm_cp4d.namespace_scope_channel }}"
+            namespace_scope_install_plan: "{{ .Values.ibm_cp4d.namespace_scope_install_plan }}"
             cpd_ibm_licensing_channel: "{{ .Values.ibm_cp4d.cpd_ibm_licensing_channel }}"
             cpd_ibm_licensing_version: "{{ .Values.ibm_cp4d.cpd_ibm_licensing_version }}"
+            cpd_licensing_install_plan: "{{ .Values.ibm_cp4d.cpd_licensing_install_plan }}"
             cpfs_channel: "{{ .Values.ibm_cp4d.cpfs_channel }}"
             cpfs_size: "{{ .Values.ibm_cp4d.cpfs_size }}"
+            cpfs_install_plan: "{{ .Values.ibm_cp4d.cpfs_install_plan }}"
             cpd_scale_config: "{{ .Values.ibm_cp4d.cpd_scale_config }}"
             cpd_platform_channel: "{{ .Values.ibm_cp4d.cpd_platform_channel }}"
             cpd_platform_cr_name: "{{ .Values.ibm_cp4d.cpd_platform_cr_name }}"
+            cpd_platform_install_plan: "{{ .Values.ibm_cp4d.cpd_platform_install_plan }}"
             cpd_product_version: "{{ .Values.ibm_cp4d.cpd_product_version }}"
             cpd_iam_integration: "{{ .Values.ibm_cp4d.cpd_iam_integration }}"
             cpd_primary_storage_class: "{{ .Values.ibm_cp4d.cpd_primary_storage_class }}"
@@ -79,10 +83,15 @@ spec:
             {{- end }}
             {{- if not (empty .Values.ibm_cp4d_services_base) }}
             ccs_channel: "{{ .Values.ibm_cp4d_services_base.ccs_channel }}"
+            cpd_ccs_install_plan: "{{ .Values.ibm_cp4d_services_base.cpd_ccs_install_plan }}"
             datarefinery_channel: "{{ .Values.ibm_cp4d_services_base.datarefinery_channel }}"
+            cpd_datarefinery_install_plan: "{{ .Values.ibm_cp4d_services_base.cpd_datarefinery_install_plan }}"
             ws_runtimes_channel: "{{ .Values.ibm_cp4d_services_base.ws_runtimes_channel }}"
+            cpd_ws_install_plan: "{{ .Values.ibm_cp4d_services_base.cpd_ws_install_plan }}"
             opencontent_rabbitmq_channel: "{{ .Values.ibm_cp4d_services_base.opencontent_rabbitmq_channel }}"
+            rabbitmq_install_plan: "{{ .Values.ibm_cp4d_services_base.rabbitmq_install_plan }}"
             opencontent_elasticsearch_channel: "{{ .Values.ibm_cp4d_services_base.opencontent_elasticsearch_channel }}"
+            elasticsearch_install_plan: "{{ .Values.ibm_cp4d_services_base.elasticsearch_install_plan }}"
             {{- end }}
             {{- if .Values.custom_labels }}
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}

--- a/root-applications/ibm-mas-instance-root/templates/110-ibm-cp4d-operator-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/110-ibm-cp4d-operator-app.yaml
@@ -46,13 +46,17 @@ spec:
             cpd_cs_control_namespace: "{{ .Values.ibm_cp4d.cpd_cs_control_namespace }}"
             cpd_admin_login_sa: "{{ .Values.ibm_cp4d.cpd_admin_login_sa }}"
             namespace_scope_channel: "{{ .Values.ibm_cp4d.namespace_scope_channel }}"
+            namespace_scope_install_plan: "{{ .Values.ibm_cp4d.namespace_scope_install_plan }}"
             cpd_ibm_licensing_channel: "{{ .Values.ibm_cp4d.cpd_ibm_licensing_channel }}"
             cpd_ibm_licensing_version: "{{ .Values.ibm_cp4d.cpd_ibm_licensing_version }}"
+            cpd_licensing_install_plan: "{{ .Values.ibm_cp4d.cpd_licensing_install_plan }}"
             cpfs_channel: "{{ .Values.ibm_cp4d.cpfs_channel }}"
             cpfs_size: "{{ .Values.ibm_cp4d.cpfs_size }}"
+            cpfs_install_plan: "{{ .Values.ibm_cp4d.cpfs_install_plan }}"
             cpd_scale_config: "{{ .Values.ibm_cp4d.cpd_scale_config }}"
             cpd_platform_channel: "{{ .Values.ibm_cp4d.cpd_platform_channel }}"
             cpd_platform_cr_name: "{{ .Values.ibm_cp4d.cpd_platform_cr_name }}"
+            cpd_platform_install_plan: "{{ .Values.ibm_cp4d.cpd_platform_install_plan }}"
             cpd_product_version: "{{ .Values.ibm_cp4d.cpd_product_version }}"
             cpd_iam_integration: "{{ .Values.ibm_cp4d.cpd_iam_integration }}"
             cpd_primary_storage_class: "{{ .Values.ibm_cp4d.cpd_primary_storage_class }}"
@@ -71,10 +75,15 @@ spec:
             {{- end }}
             {{- if not (empty .Values.ibm_cp4d_services_base) }}
             ccs_channel: "{{ .Values.ibm_cp4d_services_base.ccs_channel }}"
+            cpd_ccs_install_plan: "{{ .Values.ibm_cp4d_services_base.cpd_ccs_install_plan }}"
             datarefinery_channel: "{{ .Values.ibm_cp4d_services_base.datarefinery_channel }}"
+            cpd_datarefinery_install_plan: "{{ .Values.ibm_cp4d_services_base.cpd_datarefinery_install_plan }}"
             ws_runtimes_channel: "{{ .Values.ibm_cp4d_services_base.ws_runtimes_channel }}"
+            cpd_ws_install_plan: "{{ .Values.ibm_cp4d_services_base.cpd_ws_install_plan }}"
             opencontent_rabbitmq_channel: "{{ .Values.ibm_cp4d_services_base.opencontent_rabbitmq_channel }}"
+            rabbitmq_install_plan: "{{ .Values.ibm_cp4d_services_base.rabbitmq_install_plan }}"
             opencontent_elasticsearch_channel: "{{ .Values.ibm_cp4d_services_base.opencontent_elasticsearch_channel }}"
+            elasticsearch_install_plan: "{{ .Values.ibm_cp4d_services_base.elasticsearch_install_plan }}"
             {{- end }}
             {{- if .Values.custom_labels }}
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}

--- a/root-applications/ibm-mas-instance-root/templates/110-ibm-cs-control-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/110-ibm-cs-control-app.yaml
@@ -46,13 +46,17 @@ spec:
             cpd_cs_control_namespace: "{{ .Values.ibm_cp4d.cpd_cs_control_namespace }}"
             cpd_admin_login_sa: "{{ .Values.ibm_cp4d.cpd_admin_login_sa }}"
             namespace_scope_channel: "{{ .Values.ibm_cp4d.namespace_scope_channel }}"
+            namespace_scope_install_plan: "{{ .Values.ibm_cp4d.namespace_scope_install_plan }}"
             cpd_ibm_licensing_channel: "{{ .Values.ibm_cp4d.cpd_ibm_licensing_channel }}"
             cpd_ibm_licensing_version: "{{ .Values.ibm_cp4d.cpd_ibm_licensing_version }}"
+            cpd_licensing_install_plan: "{{ .Values.ibm_cp4d.cpd_licensing_install_plan }}"
             cpfs_channel: "{{ .Values.ibm_cp4d.cpfs_channel }}"
             cpfs_size: "{{ .Values.ibm_cp4d.cpfs_size }}"
+            cpfs_install_plan: "{{ .Values.ibm_cp4d.cpfs_install_plan }}"
             cpd_scale_config: "{{ .Values.ibm_cp4d.cpd_scale_config }}"
             cpd_platform_channel: "{{ .Values.ibm_cp4d.cpd_platform_channel }}"
             cpd_platform_cr_name: "{{ .Values.ibm_cp4d.cpd_platform_cr_name }}"
+            cpd_platform_install_plan: "{{ .Values.ibm_cp4d.cpd_platform_install_plan }}"
             cpd_product_version: "{{ .Values.ibm_cp4d.cpd_product_version }}"
             cpd_iam_integration: "{{ .Values.ibm_cp4d.cpd_iam_integration }}"
             cpd_primary_storage_class: "{{ .Values.ibm_cp4d.cpd_primary_storage_class }}"
@@ -71,10 +75,14 @@ spec:
             {{- end }}
             {{- if not (empty .Values.ibm_cp4d_services_base) }}
             ccs_channel: "{{ .Values.ibm_cp4d_services_base.ccs_channel }}"
+            cpd_ccs_install_plan: "{{ .Values.ibm_cp4d_services_base.cpd_ccs_install_plan }}"
             datarefinery_channel: "{{ .Values.ibm_cp4d_services_base.datarefinery_channel }}"
+            cpd_datarefinery_install_plan: "{{ .Values.ibm_cp4d_services_base.cpd_datarefinery_install_plan }}"
             ws_runtimes_channel: "{{ .Values.ibm_cp4d_services_base.ws_runtimes_channel }}"
+            cpd_ws_install_plan: "{{ .Values.ibm_cp4d_services_base.cpd_ws_install_plan }}"
             opencontent_rabbitmq_channel: "{{ .Values.ibm_cp4d_services_base.opencontent_rabbitmq_channel }}"
             opencontent_elasticsearch_channel: "{{ .Values.ibm_cp4d_services_base.opencontent_elasticsearch_channel }}"
+            elasticsearch_install_plan: "{{ .Values.ibm_cp4d_services_base.elasticsearch_install_plan }}"
             {{- end }}
             {{- if .Values.custom_labels }}
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}

--- a/root-applications/ibm-mas-instance-root/templates/110-ibm-db2u-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/110-ibm-db2u-app.yaml
@@ -38,6 +38,7 @@ spec:
             db2_namespace: "{{ .Values.ibm_db2u.db2_namespace }}"
             ibm_entitlement_key: "{{ .Values.ibm_db2u.ibm_entitlement_key }}"
             db2_channel: "{{ .Values.ibm_db2u.db2_channel }}"
+            db2_install_plan: "{{ .Values.ibm_db2u.db2_install_plan }}"
             {{- if .Values.custom_labels }}
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}

--- a/root-applications/ibm-mas-instance-root/templates/120-ibm-aiopenscale-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-ibm-aiopenscale-app.yaml
@@ -41,6 +41,7 @@ spec:
             cpd_service_scale_config: "{{ .Values.ibm_aiopenscale.cpd_service_scale_config }}"
             aiopenscale_version: "{{ .Values.ibm_aiopenscale.aiopenscale_version }}"
             aiopenscale_channel: "{{ .Values.ibm_aiopenscale.aiopenscale_channel }}"
+            aiopenscale_install_plan: "{{ .Values.ibm_aiopenscale.aiopenscale_install_plan }}"
             ccs_version: "{{ .Values.ibm_aiopenscale.ccs_version }}"
             {{- if .Values.custom_labels }}
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}

--- a/root-applications/ibm-mas-instance-root/templates/120-ibm-spark-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-ibm-spark-app.yaml
@@ -45,7 +45,8 @@ spec:
             cpd_service_scale_config: "{{ .Values.ibm_spark.cpd_service_scale_config }}"
             cpd_service_storage_class: "{{ .Values.ibm_spark.cpd_service_storage_class }}"
             spark_channel: "{{ .Values.ibm_spark.spark_channel }}"
-            spark_version: "{{ .Values.ibm_spark.spark_version }}"                                                            
+            spark_version: "{{ .Values.ibm_spark.spark_version }}"
+            spark_install_plan: "{{ .Values.ibm_spark.spark_install_plan }}"
             {{- if .Values.custom_labels }}
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}

--- a/root-applications/ibm-mas-instance-root/templates/120-ibm-spss-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-ibm-spss-app.yaml
@@ -47,8 +47,10 @@ spec:
             cpd_service_scale_config: "{{ .Values.ibm_spss.cpd_service_scale_config }}"
             spss_version: "{{ .Values.ibm_spss.spss_version }}"
             spss_channel: "{{ .Values.ibm_spss.spss_channel }}"
+            spss_install_plan: "{{ .Values.ibm_spss.spss_install_plan }}"
             ccs_version: "{{ .Values.ibm_spss.ccs_version }}"
             canvasbase_channel: "{{ .Values.ibm_spss.canvasbase_channel }}"
+            canvasbase_install_plan: "{{ .Values.ibm_spss.canvasbase_install_plan }}"
             {{- if .Values.custom_labels }}
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}

--- a/root-applications/ibm-mas-instance-root/templates/120-ibm-wml-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-ibm-wml-app.yaml
@@ -47,6 +47,7 @@ spec:
             cpd_service_storage_class: "{{ .Values.ibm_wml.cpd_service_storage_class }}"
             wml_channel: "{{ .Values.ibm_wml.wml_channel }}"
             wml_version: "{{ .Values.ibm_wml.wml_version }}"
+            wml_install_plan: "{{ .Values.ibm_wml.wml_install_plan }}"
             {{- if .Values.custom_labels }}
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}

--- a/root-applications/ibm-mas-instance-root/templates/120-ibm-wsl-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-ibm-wsl-app.yaml
@@ -47,6 +47,7 @@ spec:
             cpd_service_scale_config: "{{ .Values.ibm_wsl.cpd_service_scale_config }}"
             wsl_version: "{{ .Values.ibm_wsl.wsl_version }}"
             wsl_channel: "{{ .Values.ibm_wsl.wsl_channel }}"
+            wsl_install_plan: "{{ .Values.ibm_wsl.wsl_install_plan }}"
             ccs_version: "{{ .Values.ibm_wsl.ccs_version }}"
             datarefinery_version: "{{ .Values.ibm_wsl.datarefinery_version }}"
             ws_runtimes_version: "{{ .Values.ibm_wsl.ws_runtimes_version }}"

--- a/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-app.yaml
@@ -49,6 +49,7 @@ spec:
             mas_domain: "{{ .Values.ibm_mas_suite.mas_domain }}"
             mas_config_dir: "{{ .Values.ibm_mas_suite.mas_config_dir }}"
             mas_channel: "{{ .Values.ibm_mas_suite.mas_channel }}"
+            mas_install_plan: "{{ .Values.ibm_mas_suite.mas_install_plan }}"
             ibm_entitlement_key: "{{ .Values.ibm_mas_suite.ibm_entitlement_key }}"
             domain: "{{ .Values.ibm_mas_suite.domain }}"
             cert_manager_namespace: "{{ .Values.ibm_mas_suite.cert_manager_namespace }}"

--- a/root-applications/ibm-mas-instance-root/templates/500-ibm-mas-masapp-manage-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/500-ibm-mas-masapp-manage-install.yaml
@@ -43,6 +43,7 @@ spec:
             mas_app_id: "{{ .Values.ibm_suite_app_manage_install.mas_app_id }}"
             mas_app_catalog_source: "{{ .Values.ibm_suite_app_manage_install.mas_app_catalog_source }}"
             mas_app_channel: "{{ .Values.ibm_suite_app_manage_install.mas_app_channel }}"
+            mas_app_install_plan: "{{ .Values.ibm_suite_app_manage_install.mas_app_install_plan }}"
             mas_edition: "{{ .Values.ibm_suite_app_manage_install.mas_edition }}"
             run_sync_hooks: {{ .Values.ibm_suite_app_manage_install.run_sync_hooks }}
             mas_manual_cert_mgmt: {{ .Values.ibm_suite_app_manage_install.mas_manual_cert_mgmt  }}

--- a/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-assist-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-assist-install.yaml
@@ -43,6 +43,7 @@ spec:
             mas_app_id: "{{ .Values.ibm_suite_app_assist_install.mas_app_id }}"
             mas_app_catalog_source: "{{ .Values.ibm_suite_app_assist_install.mas_app_catalog_source }}"
             mas_app_channel: "{{ .Values.ibm_suite_app_assist_install.mas_app_channel }}"
+            mas_app_install_plan: "{{ .Values.ibm_suite_app_assist_install.mas_app_install_plan }}"
             mas_edition: "{{ .Values.ibm_suite_app_assist_install.mas_edition }}"
             run_sync_hooks: {{ .Values.ibm_suite_app_assist_install.run_sync_hooks }}
             mas_manual_cert_mgmt: {{ .Values.ibm_suite_app_assist_install.mas_manual_cert_mgmt   }}

--- a/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-iot-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-iot-install.yaml
@@ -43,6 +43,7 @@ spec:
             mas_app_id: "{{ .Values.ibm_suite_app_iot_install.mas_app_id }}"
             mas_app_catalog_source: "{{ .Values.ibm_suite_app_iot_install.mas_app_catalog_source }}"
             mas_app_channel: "{{ .Values.ibm_suite_app_iot_install.mas_app_channel }}"
+            mas_app_install_plan: "{{ .Values.ibm_suite_app_iot_install.mas_app_install_plan }}"
             mas_edition: "{{ .Values.ibm_suite_app_iot_install.mas_edition }}"
             run_sync_hooks: {{ .Values.ibm_suite_app_iot_install.run_sync_hooks }}
             mas_manual_cert_mgmt: {{ .Values.ibm_suite_app_iot_install.mas_manual_cert_mgmt    }}

--- a/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-visualinspection-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-visualinspection-install.yaml
@@ -43,6 +43,7 @@ spec:
             mas_app_id: "{{ .Values.ibm_suite_app_visualinspection_install.mas_app_id }}"
             mas_app_catalog_source: "{{ .Values.ibm_suite_app_visualinspection_install.mas_app_catalog_source }}"
             mas_app_channel: "{{ .Values.ibm_suite_app_visualinspection_install.mas_app_channel }}"
+            mas_app_install_plan: "{{ .Values.ibm_suite_app_visualinspection_install.mas_app_install_plan }}"
             mas_edition: "{{ .Values.ibm_suite_app_visualinspection_install.mas_edition }}"
             run_sync_hooks: {{ .Values.ibm_suite_app_visualinspection_install.run_sync_hooks }}
             mas_manual_cert_mgmt: {{ .Values.ibm_suite_app_visualinspection_install.mas_manual_cert_mgmt   }}

--- a/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-health-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-health-install.yaml
@@ -43,6 +43,7 @@ spec:
             mas_app_id: "{{ .Values.ibm_suite_app_health_install.mas_app_id }}"
             mas_app_catalog_source: "{{ .Values.ibm_suite_app_health_install.mas_app_catalog_source }}"
             mas_app_channel: "{{ .Values.ibm_suite_app_health_install.mas_app_channel }}"
+            mas_app_install_plan: "{{ .Values.ibm_suite_app_health_install.mas_app_install_plan }}"
             mas_edition: "{{ .Values.ibm_suite_app_health_install.mas_edition }}"
             run_sync_hooks: {{ .Values.ibm_suite_app_health_install.run_sync_hooks }}
             mas_manual_cert_mgmt: {{ .Values.ibm_suite_app_health_install.mas_manual_cert_mgmt   }}

--- a/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-monitor-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-monitor-install.yaml
@@ -43,6 +43,7 @@ spec:
             mas_app_id: "{{ .Values.ibm_suite_app_monitor_install.mas_app_id }}"
             mas_app_catalog_source: "{{ .Values.ibm_suite_app_monitor_install.mas_app_catalog_source }}"
             mas_app_channel: "{{ .Values.ibm_suite_app_monitor_install.mas_app_channel }}"
+            mas_app_install_plan: "{{ .Values.ibm_suite_app_monitor_install.mas_app_install_plan }}"
             mas_edition: "{{ .Values.ibm_suite_app_monitor_install.mas_edition }}"
             run_sync_hooks: {{ .Values.ibm_suite_app_monitor_install.run_sync_hooks }}
             mas_manual_cert_mgmt: {{ .Values.ibm_suite_app_monitor_install.mas_manual_cert_mgmt   }}

--- a/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-optimizer-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-optimizer-install.yaml
@@ -43,6 +43,7 @@ spec:
             mas_app_id: "{{ .Values.ibm_suite_app_optimizer_install.mas_app_id }}"
             mas_app_catalog_source: "{{ .Values.ibm_suite_app_optimizer_install.mas_app_catalog_source }}"
             mas_app_channel: "{{ .Values.ibm_suite_app_optimizer_install.mas_app_channel }}"
+            mas_app_install_plan: "{{ .Values.ibm_suite_app_optimizer_install.mas_app_install_plan }}"
             mas_edition: "{{ .Values.ibm_suite_app_optimizer_install.mas_edition }}"
             run_sync_hooks: {{ .Values.ibm_suite_app_optimizer_install.run_sync_hooks }}
             mas_manual_cert_mgmt: {{ .Values.ibm_suite_app_optimizer_install.mas_manual_cert_mgmt   }}

--- a/root-applications/ibm-mas-instance-root/templates/540-ibm-mas-masapp-predict-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/540-ibm-mas-masapp-predict-install.yaml
@@ -43,6 +43,7 @@ spec:
             mas_app_id: "{{ .Values.ibm_suite_app_predict_install.mas_app_id }}"
             mas_app_catalog_source: "{{ .Values.ibm_suite_app_predict_install.mas_app_catalog_source }}"
             mas_app_channel: "{{ .Values.ibm_suite_app_predict_install.mas_app_channel }}"
+            mas_app_install_plan: "{{ .Values.ibm_suite_app_predict_install.mas_app_install_plan }}"
             mas_edition: "{{ .Values.ibm_suite_app_predict_install.mas_edition }}"
             run_sync_hooks: {{ .Values.ibm_suite_app_predict_install.run_sync_hooks }}
             mas_manual_cert_mgmt: {{ .Values.ibm_suite_app_predict_install.mas_manual_cert_mgmt  }}


### PR DESCRIPTION
SRE team want to control when updates happen to anything on a cluster, and control it at a fine-grain level.
To achieve this  installPlanApproval on any subscription needs to be configurable.

Tested in test cluster to ensure that the defaults get set even if no varialbe is set in gitops repo.

https://jsw.ibm.com/browse/MASCORE-3901