### PR TITLE
[patch] Fix reporter_name for db2

### DIFF
--- a/root-applications/ibm-mas-instance-root/templates/120-db2-databases-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-db2-databases-app.yaml
@@ -48,7 +48,7 @@ spec:
             custom_labels: {{ $.Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}
             junitreporter:
-              reporter_name: "db2-db.{{ $.Values.instance.id }}.{{ $value.mas_application_id }}"
+              reporter_name: "db2-db-{{ $.Values.instance.id }}-{{ $value.mas_application_id }}"
               cluster_id: "{{ $.Values.cluster.id }}"
               devops_mongo_uri: "{{ $.Values.devops.mongo_uri }}"
               devops_build_number: "{{ $.Values.devops.build_number }}"


### PR DESCRIPTION
Don't use dot notation for reportername as it gets added to mongo incorrectly.