### PR TITLE
[patch] Create unique networkpolicies for junitreporter

### DIFF
--- a/sub-charts/junitreporter/templates/00-presync-report-starter.yaml
+++ b/sub-charts/junitreporter/templates/00-presync-report-starter.yaml
@@ -174,9 +174,9 @@ spec:
               fi
               export SYNC_COMPLETE=$((oc get configmap $SYNC_TIME_CM_NAME -o json) | yq '.data.sync_complete')
               if [[ -z "${SYNC_COMPLETE}" || "${SYNC_COMPLETE}" == "null" ]]; then
-                echo "Sync not complete"
+                echo "Sync not complete yet."
               else
-                echo "Sync called again but was already marked as completed once"
+                echo "Sync called again but was already marked as completed once."
               fi
 
       restartPolicy: Never

--- a/sub-charts/junitreporter/templates/00-presync-report-starter.yaml
+++ b/sub-charts/junitreporter/templates/00-presync-report-starter.yaml
@@ -8,7 +8,7 @@
 {{ $sa_name := printf "%s-sa" $prefix }}
 {{ $time_cm := printf "%s-synctime" $prefix }}
 {{ $job := printf "%s-job" $prefix }}
-{{ $np_name :=  %s-np" $prefix }}
+{{ $np_name :=  "%s-np" $prefix }}
 
 ---
 # Permit outbound communication by the Job pod

--- a/sub-charts/junitreporter/templates/00-presync-report-starter.yaml
+++ b/sub-charts/junitreporter/templates/00-presync-report-starter.yaml
@@ -173,10 +173,10 @@ spec:
                 python3 /opt/app-root/src/register-start.py
               fi
               export SYNC_COMPLETE=$((oc get configmap $SYNC_TIME_CM_NAME -o json) | yq '.data.sync_complete')
-              if [[ -z "${SYNC_COMPLETE}" ]]; then
+              if [[ -z "${SYNC_COMPLETE}" || "${SYNC_COMPLETE}" == "null" ]]; then
                 echo "Sync not complete"
               else
-                echo "Sync called agin but was already marked as completed once"
+                echo "Sync called again but was already marked as completed once"
               fi
 
       restartPolicy: Never

--- a/sub-charts/junitreporter/templates/00-presync-report-starter.yaml
+++ b/sub-charts/junitreporter/templates/00-presync-report-starter.yaml
@@ -8,7 +8,7 @@
 {{ $sa_name := printf "%s-sa" $prefix }}
 {{ $time_cm := printf "%s-synctime" $prefix }}
 {{ $job := printf "%s-job" $prefix }}
-{{ $np_name :=  "pre-junitreporter" }}
+{{ $np_name :=  %s-np" $prefix }}
 
 ---
 # Permit outbound communication by the Job pod

--- a/sub-charts/junitreporter/templates/00-presync-report-starter.yaml
+++ b/sub-charts/junitreporter/templates/00-presync-report-starter.yaml
@@ -169,11 +169,15 @@ spec:
               if [[ -z $CONFIGMAP ]]; then
                 echo "Creating $SYNC_TIME_CM_NAME configmap"
                 oc create configmap $SYNC_TIME_CM_NAME --from-literal=sync_start=$(date +%s)
+                echo "Run register-start.py"
+                python3 /opt/app-root/src/register-start.py
               fi
-
-              echo "Run register-start.py"
-              python3 /opt/app-root/src/register-start.py
-
+              export SYNC_COMPLETE=$((oc get configmap $SYNC_TIME_CM_NAME -o json) | yq '.data.sync_complete')
+              if [[ -z "${SYNC_COMPLETE}" ]]; then
+                echo "Sync not complete"
+              else
+                echo "Sync called agin but was already marked as completed once"
+              fi
 
       restartPolicy: Never
       serviceAccountName: {{ $sa_name }}

--- a/sub-charts/junitreporter/templates/10-postsync-report-starter.yaml
+++ b/sub-charts/junitreporter/templates/10-postsync-report-starter.yaml
@@ -78,7 +78,7 @@ metadata:
 {{- end }}
 rules:
   - verbs:
-      - delete
+      - patch
     apiGroups:
       - ""
     resources:
@@ -151,6 +151,12 @@ spec:
                 configMapKeyRef:
                   name: {{ $time_cm }}
                   key: sync_start
+            - name: SYNC_COMPLETE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ $time_cm }}
+                  key: sync_complete
+                  optional: true 
             - name: SYNC_TIME_CM_NAME
               value: {{ $time_cm }}
           volumeMounts:
@@ -165,19 +171,24 @@ spec:
               trap 'echo "[ERROR] Error occurred at line $LINENO, exited with $?"; exit 1' ERR
 
               export DEVOPS_MONGO_URI=$(cat /etc/mas/devops-uri/devops_mongo_uri)
-              # Compute elapsed time between pre-sync and post-sync
-              CURRENTTIME=$(date +%s)
-              ELAPSEDTIME=$(($CURRENTTIME-$SYNC_START))
-              echo "Elapsed time is ${ELAPSEDTIME}"
 
-              # Create junit xml for one testsuite of the parent argo app, and the testcase of sync
-              python3 /opt/app-root/src/junit-xml-generator.py --test-suite-name ${DEVOPS_SUITE_NAME} --test-cases Sync:$ELAPSEDTIME --output-dir ${JUNIT_OUTPUT_DIR}
+              if [[ -z "${SYNC_COMPLETE}" ]]; then
+                # Compute elapsed time between pre-sync and post-sync
+                CURRENTTIME=$(date +%s)
+                ELAPSEDTIME=$(($CURRENTTIME-$SYNC_START))
+                echo "Elapsed time is ${ELAPSEDTIME}"
 
-              echo "Run save-junit-to-mongo.py"
-              python3 /opt/app-root/src/save-junit-to-mongo.py
+                # Create junit xml for one testsuite of the parent argo app, and the testcase of sync
+                python3 /opt/app-root/src/junit-xml-generator.py --test-suite-name ${DEVOPS_SUITE_NAME} --test-cases Sync:$ELAPSEDTIME --output-dir ${JUNIT_OUTPUT_DIR}
 
-              echo "Delete $SYNC_TIME_CM_NAME configmap"
-              oc delete configmap $SYNC_TIME_CM_NAME -n $NAMESPACE
+                echo "Run save-junit-to-mongo.py"
+                python3 /opt/app-root/src/save-junit-to-mongo.py
+
+                echo "Patching $SYNC_TIME_CM_NAME configmap with sync_complete"
+                oc patch configmap $SYNC_TIME_CM_NAME -p '{"data":{"sync_start":"'$SYNC_START'","sync_complete":"'$CURRENTTIME'"}}'
+              else
+                echo "SYNC_COMPLETE already set in configmap"
+              fi
 
       restartPolicy: Never
       serviceAccountName: {{ $sa_name }}

--- a/sub-charts/junitreporter/templates/10-postsync-report-starter.yaml
+++ b/sub-charts/junitreporter/templates/10-postsync-report-starter.yaml
@@ -188,7 +188,7 @@ spec:
                 echo "Patching $SYNC_TIME_CM_NAME configmap with sync_complete"
                 oc patch configmap $SYNC_TIME_CM_NAME -p '{"data":{"sync_start":"'$SYNC_START'","sync_complete":"'$CURRENTTIME'"}}'
               else
-                echo "SYNC_COMPLETE already set in configmap"
+                echo "SYNC_COMPLETE already set in configmap $SYNC_TIME_CM_NAME, so nothing to do."
               fi
 
       restartPolicy: Never

--- a/sub-charts/junitreporter/templates/10-postsync-report-starter.yaml
+++ b/sub-charts/junitreporter/templates/10-postsync-report-starter.yaml
@@ -10,7 +10,7 @@
 {{ $sa_name := printf "%s-sa" $prefix }}
 {{ $secret := printf "%s-devopsuri" $prefix }}
 {{ $job := printf "%s-job" $prefix }}
-{{ $np_name :=  "post-junitreporter" }}
+{{ $np_name :=  %s-np" $prefix }}
 
 ---
 # Permit outbound communication by the Job pod

--- a/sub-charts/junitreporter/templates/10-postsync-report-starter.yaml
+++ b/sub-charts/junitreporter/templates/10-postsync-report-starter.yaml
@@ -79,6 +79,7 @@ metadata:
 rules:
   - verbs:
       - patch
+      - get
     apiGroups:
       - ""
     resources:

--- a/sub-charts/junitreporter/templates/10-postsync-report-starter.yaml
+++ b/sub-charts/junitreporter/templates/10-postsync-report-starter.yaml
@@ -10,7 +10,7 @@
 {{ $sa_name := printf "%s-sa" $prefix }}
 {{ $secret := printf "%s-devopsuri" $prefix }}
 {{ $job := printf "%s-job" $prefix }}
-{{ $np_name :=  %s-np" $prefix }}
+{{ $np_name :=  "%s-np" $prefix }}
 
 ---
 # Permit outbound communication by the Job pod


### PR DESCRIPTION
The junitreporter was creating network policies with the same name in each chart, this caused some warnings in Argo. Changed the name of the networkpolicy to be unique