### PR TITLE
[patch] Decrease prefix name of juniutreporter

### DIFF
--- a/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
@@ -94,7 +94,7 @@ spec:
             {{- end }}
 
             junitreporter:
-              reporter_name: "ibm-mas-suite-app-config-{{ $value.mas_app_id }}-{{ $value.mas_workspace_id }}"
+              reporter_name: "ibm-mas-suite-app-config-{{ $value.mas_app_id }}"
               cluster_id: "{{ $.Values.cluster.id }}"
               devops_mongo_uri: "{{ $.Values.devops.mongo_uri }}"
               devops_build_number: "{{ $.Values.devops.build_number }}"

--- a/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-visualinspection-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-visualinspection-install.yaml
@@ -61,7 +61,7 @@ spec:
             {{- end }}
             gpu_request_quota: "{{ .Values.ibm_suite_app_visualinspection_install.gpu_request_quota }}"
             junitreporter: 
-              reporter_name: "ibm-mas-suite-app-install-visualinspection"
+              reporter_name: "ibm-mas-suite-app-install-mvi"
               cluster_id: "{{ .Values.cluster.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"

--- a/sub-charts/junitreporter/templates/00-presync-report-starter.yaml
+++ b/sub-charts/junitreporter/templates/00-presync-report-starter.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.devops_mongo_uri }}
 
 
-{{ $prefix := printf "pre-junitreporter-%s" .Values.reporter_name }}
+{{ $prefix := printf "pre-jreporter-%s" .Values.reporter_name }}
 {{ $secret := printf "%s-devopsuri" $prefix }}
 {{ $role_name := printf "%s-role" $prefix }}
 {{ $rb_name := printf "%s-rb" $prefix }}

--- a/sub-charts/junitreporter/templates/10-postsync-report-starter.yaml
+++ b/sub-charts/junitreporter/templates/10-postsync-report-starter.yaml
@@ -1,10 +1,10 @@
 {{- if .Values.devops_mongo_uri }}
 
 
-{{ $preprefix := printf "pre-junitreporter-%s" .Values.reporter_name }}
+{{ $preprefix := printf "pre-jreporter-%s" .Values.reporter_name }}
 {{ $time_cm := printf "%s-synctime" $preprefix }}
 
-{{ $prefix := printf "post-junitreporter-%s" .Values.reporter_name }}
+{{ $prefix := printf "post-jreporter-%s" .Values.reporter_name }}
 {{ $role_name := printf "%s-role" $prefix }}
 {{ $rb_name := printf "%s-rb" $prefix }}
 {{ $sa_name := printf "%s-sa" $prefix }}


### PR DESCRIPTION
The prefix name was too long when used with apps like visualinspection. 