### PR TITLE
[minor] Increase sync retry limit for all argo apps to 20

### DIFF
--- a/root-applications/ibm-mas-cluster-root/templates/000-ibm-operator-catalog-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/000-ibm-operator-catalog-app.yaml
@@ -62,6 +62,8 @@ spec:
       prune: true
       {{- end }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=false
       - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-cluster-root/templates/010-ibm-redhat-cert-manager-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/010-ibm-redhat-cert-manager-app.yaml
@@ -62,6 +62,8 @@ spec:
       prune: true
       {{- end }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=true
       - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-cluster-root/templates/020-ibm-dro-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/020-ibm-dro-app.yaml
@@ -75,6 +75,8 @@ spec:
       prune: true
       {{- end }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=true
       - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-cluster-root/templates/021-ibm-dro-cleanup.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/021-ibm-dro-cleanup.yaml
@@ -57,6 +57,8 @@ spec:
       prune: true
       {{- end }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=false
       - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-cluster-root/templates/030-ibm-cis-cert-manager.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/030-ibm-cis-cert-manager.yaml
@@ -62,6 +62,8 @@ spec:
       prune: true
       {{- end }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=false
       - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-cluster-root/templates/040-cis-compliance-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/040-cis-compliance-app.yaml
@@ -55,6 +55,8 @@ spec:
       prune: true
       {{- end }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=true
       - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-cluster-root/templates/041-cis-compliance-cleanup.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/041-cis-compliance-cleanup.yaml
@@ -57,6 +57,8 @@ spec:
       prune: true
       {{- end }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=false
       - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-cluster-root/templates/050-nfd-operator-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/050-nfd-operator-app.yaml
@@ -57,6 +57,8 @@ spec:
       prune: true
       {{- end }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=true
     managedNamespaceMetadata:

--- a/root-applications/ibm-mas-cluster-root/templates/051-nvidia-gpu-operator-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/051-nvidia-gpu-operator-app.yaml
@@ -58,6 +58,8 @@ spec:
       prune: true
       {{- end }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=true
     managedNamespaceMetadata:

--- a/root-applications/ibm-mas-cluster-root/templates/200-cluster-promotion-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/200-cluster-promotion-app.yaml
@@ -72,6 +72,8 @@ spec:
       prune: true
       {{- end }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=true
       - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-instance-root/templates/000-ibm-sync-resources.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/000-ibm-sync-resources.yaml
@@ -106,6 +106,8 @@ spec:
       prune: true
       {{- end }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=true
       - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-instance-root/templates/010-ibm-sync-jobs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/010-ibm-sync-jobs.yaml
@@ -111,6 +111,8 @@ spec:
       prune: true
       {{- end }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=false
       - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-instance-root/templates/100-ibm-sls-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/100-ibm-sls-app.yaml
@@ -75,6 +75,8 @@ spec:
       prune: true
       {{- end }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=true
       - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-instance-root/templates/110-ibm-cp4d-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/110-ibm-cp4d-app.yaml
@@ -105,6 +105,8 @@ spec:
       prune: true
       {{- end }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=true
       - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-instance-root/templates/110-ibm-cp4d-operator-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/110-ibm-cp4d-operator-app.yaml
@@ -97,6 +97,8 @@ spec:
       prune: true
       {{- end }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=true
       - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-instance-root/templates/110-ibm-cs-control-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/110-ibm-cs-control-app.yaml
@@ -97,6 +97,8 @@ spec:
       prune: true
       {{- end }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=true
       - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-instance-root/templates/110-ibm-db2u-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/110-ibm-db2u-app.yaml
@@ -59,6 +59,8 @@ spec:
       prune: true
       {{- end }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=true
     managedNamespaceMetadata:

--- a/root-applications/ibm-mas-instance-root/templates/120-db2-databases-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-db2-databases-app.yaml
@@ -64,6 +64,8 @@ spec:
     automated:
       prune: {{ $.Values.auto_delete }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=false
       - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-instance-root/templates/120-ibm-aiopenscale-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-ibm-aiopenscale-app.yaml
@@ -63,6 +63,8 @@ spec:
       prune: true
       {{- end }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=false
 {{- end }}

--- a/root-applications/ibm-mas-instance-root/templates/120-ibm-spark-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-ibm-spark-app.yaml
@@ -67,6 +67,8 @@ spec:
       prune: true
       {{- end }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=false
       - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-instance-root/templates/120-ibm-spss-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-ibm-spss-app.yaml
@@ -70,6 +70,8 @@ spec:
       prune: true
       {{- end }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=false
 {{- end }}

--- a/root-applications/ibm-mas-instance-root/templates/120-ibm-wml-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-ibm-wml-app.yaml
@@ -68,6 +68,8 @@ spec:
       prune: true
       {{- end }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=false
       - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-instance-root/templates/120-ibm-wsl-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-ibm-wsl-app.yaml
@@ -71,6 +71,8 @@ spec:
       prune: true
       {{- end }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=false
 {{- end }}

--- a/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-app.yaml
@@ -130,6 +130,8 @@ spec:
       prune: true
       {{- end }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=true
       - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-configs-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-configs-app.yaml
@@ -70,6 +70,8 @@ spec:
     automated:
       prune: {{ $.Values.auto_delete }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=false
       - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-instance-root/templates/200-ibm-mas-workspaces.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/200-ibm-mas-workspaces.yaml
@@ -60,6 +60,8 @@ spec:
     automated:
       prune: {{ $.Values.auto_delete }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=false
       - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-instance-root/templates/500-ibm-mas-masapp-manage-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/500-ibm-mas-masapp-manage-install.yaml
@@ -77,6 +77,8 @@ spec:
       prune: true
       {{- end }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=true
       - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
@@ -110,6 +110,8 @@ spec:
     automated:
       prune: {{ $.Values.auto_delete }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=false
       - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-assist-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-assist-install.yaml
@@ -72,12 +72,13 @@ spec:
           value: {{ .Values.avp.secret }}
         {{- end }}
   syncPolicy:
-  syncPolicy:
     automated:
       {{- if .Values.auto_delete }}
       prune: true
       {{- end }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=true
       - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-iot-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-iot-install.yaml
@@ -77,6 +77,8 @@ spec:
       prune: true
       {{- end }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=true
       - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-visualinspection-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-visualinspection-install.yaml
@@ -78,6 +78,8 @@ spec:
       prune: true
       {{- end }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=true
       - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-health-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-health-install.yaml
@@ -77,6 +77,8 @@ spec:
       prune: true
       {{- end }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=true
       - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-monitor-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-monitor-install.yaml
@@ -77,6 +77,8 @@ spec:
       prune: true
       {{- end }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=true
       - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-optimizer-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-optimizer-install.yaml
@@ -77,6 +77,8 @@ spec:
       prune: true
       {{- end }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=true
       - RespectIgnoreDifferences=true

--- a/root-applications/ibm-mas-instance-root/templates/540-ibm-mas-masapp-predict-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/540-ibm-mas-masapp-predict-install.yaml
@@ -77,6 +77,8 @@ spec:
       prune: true
       {{- end }}
       selfHeal: true
+    retry:
+      limit: 20
     syncOptions:
       - CreateNamespace=true
       - RespectIgnoreDifferences=true


### PR DESCRIPTION
Increases the sync retry limit from the default (5) to 20. The retry is exponential by default up to the 3 minutes. This means the sync retry from an error will increase to around 50 minutes compared to around 5 minutes as it is now. This will allow for syncs of apps that experience so temporal error (certificate request failure or dependent service not working at that time) to have less of an impact. However, a failure that is still happening after 50 minutes would need to be investigated.

Note: this is not a timeout of the sync itself, but the timeout of the number of retries Argo makes to sync an app in error. A well behavioured app should not error even if the sync takes 2 hours.

This does not change the applicationsets which still has an unlimited timeout.