### PR TITLE
[patch] Fix cp4d postgres license issue 

### DIFF
--- a/instance-applications/110-ibm-cp4d-operators/templates/02-ibm-cp4d_rbac.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/02-ibm-cp4d_rbac.yaml
@@ -226,7 +226,16 @@ rules:
       - ''
     resources:
       - serviceaccounts
-
+  - verbs:
+      - get
+      - list
+      - patch
+      - create
+      - delete
+    apiGroups:
+      - ''
+    resources:
+      - jobs
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/instance-applications/110-ibm-cp4d-operators/templates/02-ibm-cp4d_rbac.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/02-ibm-cp4d_rbac.yaml
@@ -233,7 +233,7 @@ rules:
       - create
       - delete
     apiGroups:
-      - ''
+      - 'batch'
     resources:
       - jobs
 ---

--- a/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_patch_zenservice.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_patch_zenservice.yaml
@@ -37,18 +37,20 @@ spec:
             - name: CPD_SCALE_CONFIG
               value: {{ .Values.cpd_scale_config }}
           command:
-            - /bin/sh
+            - /bin/bash
             - -c
             - |
 
               set -e
+              trap 'echo "[ERROR] Error occurred at line $LINENO, exited with $?"; exit 1' ERR
+
               echo
               echo "================================================================================"
               echo "Patch zenmetastore postgres job to workaround https://www.ibm.com/support/pages/node/7158524"
               echo "================================================================================"
               echo
               echo "Wait for create-postgres-license-config job to be present"
-              
+
               wait_period=0
               while true; do
                 wait_period=$(($wait_period+60))

--- a/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_patch_zenservice.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_patch_zenservice.yaml
@@ -64,6 +64,7 @@ spec:
                 POSTGRES_JOB_LOOKUP=$(oc get job create-postgres-license-config -n ${CPD_OPERATORS_NAMESPACE} --ignore-not-found -ojsonpath='{.spec}')
                 if [[ ! -z $POSTGRES_JOB_LOOKUP ]]; then
                   echo "create-postgres-license-config job has been fetched"
+                  echo "$POSTGRES_JOB_LOOKUP"
                   IS_PATCHED=$(echo $POSTGRES_JOB_LOOKUP | grep "cp.icr.io/cp/cpd/edb-postgres-license-provider@sha256:c1670e7dd93c1e65a6659ece644e44aa5c2150809ac1089e2fd6be37dceae4ce")
                   echo "IS_PATCHED=$IS_PATCHED"
                   if [[ -z $IS_PATCHED ]]; then

--- a/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_patch_zenservice.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_patch_zenservice.yaml
@@ -64,7 +64,7 @@ spec:
                 POSTGRES_JOB_LOOKUP=$(oc get job create-postgres-license-config -n ${CPD_OPERATORS_NAMESPACE} --ignore-not-found -ojsonpath='{.spec}')
                 if [[ ! -z $POSTGRES_JOB_LOOKUP ]]; then
                   echo "create-postgres-license-config job has been fetched $POSTGRES_JOB_LOOKUP"
-                  IS_PATCHED=$(echo \'$POSTGRES_JOB_LOOKUP\' | grep "cp.icr.io/cp/cpd/edb-postgres-license-provider@sha256:c1670e7dd93c1e65a6659ece644e44aa5c2150809ac1089e2fd6be37dceae4ce")
+                  IS_PATCHED=$(echo \'$POSTGRES_JOB_LOOKUP\' | grep "cp.icr.io/cp/cpd/edb-postgres-license-provider@sha256:c1670e7dd93c1e65a6659ece644e44aa5c2150809ac1089e2fd6be37dceae4ce" || true)
                   echo "IS_PATCHED=$IS_PATCHED"
                   if [[ -z $IS_PATCHED ]]; then
                     echo "patching create-postgres-license-config..."

--- a/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_patch_zenservice.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_patch_zenservice.yaml
@@ -63,9 +63,8 @@ spec:
                 
                 POSTGRES_JOB_LOOKUP=$(oc get job create-postgres-license-config -n ${CPD_OPERATORS_NAMESPACE} --ignore-not-found -ojsonpath='{.spec}')
                 if [[ ! -z $POSTGRES_JOB_LOOKUP ]]; then
-                  echo "create-postgres-license-config job has been fetched"
-                  echo "$POSTGRES_JOB_LOOKUP"
-                  IS_PATCHED=$(echo $POSTGRES_JOB_LOOKUP | grep "cp.icr.io/cp/cpd/edb-postgres-license-provider@sha256:c1670e7dd93c1e65a6659ece644e44aa5c2150809ac1089e2fd6be37dceae4ce")
+                  echo "create-postgres-license-config job has been fetched $POSTGRES_JOB_LOOKUP"
+                  IS_PATCHED=$(echo \'$POSTGRES_JOB_LOOKUP\' | grep "cp.icr.io/cp/cpd/edb-postgres-license-provider@sha256:c1670e7dd93c1e65a6659ece644e44aa5c2150809ac1089e2fd6be37dceae4ce")
                   echo "IS_PATCHED=$IS_PATCHED"
                   if [[ -z $IS_PATCHED ]]; then
                     echo "patching create-postgres-license-config..."

--- a/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_patch_zenservice.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_patch_zenservice.yaml
@@ -44,6 +44,39 @@ spec:
               set -e
               echo
               echo "================================================================================"
+              echo "Patch zenmetastore postgres job to workaround https://www.ibm.com/support/pages/node/7158524"
+              echo "================================================================================"
+              echo
+              echo "Wait for create-postgres-license-config job to be present"
+              
+              wait_period=0
+              while true; do
+                wait_period=$(($wait_period+60))
+                if [ $wait_period -gt 1200 ]; then
+                  echo "create-postgres-license-config job is not found after 20 minutes of waiting. exiting..."
+                  exit 1
+                else
+                  sleep 60
+                fi
+                
+                POSTGRES_JOB_LOOKUP=$(oc get job create-postgres-license-config -n ${CPD_OPERATORS_NAMESPACE} --ignore-not-found -ojsonpath='{.spec}')
+                if [[ ! -z $POSTGRES_JOB_LOOKUP ]]; then
+                  echo "create-postgres-license-config job has been fetched"
+                  IS_PATCHED=$(echo $POSTGRES_JOB_LOOKUP | grep "cp.icr.io/cp/cpd/edb-postgres-license-provider@sha256:c1670e7dd93c1e65a6659ece644e44aa5c2150809ac1089e2fd6be37dceae4ce")
+                  if [[ -z $IS_PATCHED ]]; then
+                    echo "patching create-postgres-license-config..."
+                    oc get job create-postgres-license-config -n ${CPD_OPERATORS_NAMESPACE} -o yaml | \
+                    sed -e 's/operator.ibm.com\/opreq-control: "true"/operator.ibm.com\/opreq-control: "false"/' \
+                    -e 's|\(image: \).*|\1"cp.icr.io/cp/cpd/edb-postgres-license-provider@sha256:c1670e7dd93c1e65a6659ece644e44aa5c2150809ac1089e2fd6be37dceae4ce"|' \
+                    -e '/controller-uid:/d' | \
+                    oc replace --force -f -
+                  fi
+                  break
+                fi
+              done
+
+              echo
+              echo "================================================================================"
               echo "Wait for ZenService Cr and patch it if needed"
               echo "================================================================================"
               echo

--- a/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_patch_zenservice.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_patch_zenservice.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-patch-zenservices-v1-{{ .Values | toYaml | adler32sum }}"
+  name: "cpd-patch-zenservices-v2-{{ .Values | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "087"
@@ -65,6 +65,7 @@ spec:
                 if [[ ! -z $POSTGRES_JOB_LOOKUP ]]; then
                   echo "create-postgres-license-config job has been fetched"
                   IS_PATCHED=$(echo $POSTGRES_JOB_LOOKUP | grep "cp.icr.io/cp/cpd/edb-postgres-license-provider@sha256:c1670e7dd93c1e65a6659ece644e44aa5c2150809ac1089e2fd6be37dceae4ce")
+                  echo "IS_PATCHED=$IS_PATCHED"
                   if [[ -z $IS_PATCHED ]]; then
                     echo "patching create-postgres-license-config..."
                     oc get job create-postgres-license-config -n ${CPD_OPERATORS_NAMESPACE} -o yaml | \


### PR DESCRIPTION
The problem reported in technote https://www.ibm.com/support/pages/node/7158524 is impacting the cp4d install. This change implements the workaround noted by updating the patch zenservice job to execute the workaround. Tested in fvtsaas env:

![image- 2024-10-03 at 09 17 54](https://github.com/user-attachments/assets/72aab758-aa58-4d5e-bc86-4426d5be99ca)
