### PR TITLE
[patch] Set revision history to 1 on instance appset

### DIFF
--- a/root-applications/ibm-mas-cluster-root/templates/099-instance-appset.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/099-instance-appset.yaml
@@ -224,3 +224,5 @@ spec:
           kind: MarketplaceConfig
           jsonPointers:
             - /spec
+      # revisionHistoryLimit set to 1 due to size limit of what can be stored in etcd for anything larger
+      revisionHistoryLimit: 1


### PR DESCRIPTION
The size of the instance application set can get to big for Argo to store all the data into etcd, when we have more than 1 revision history. The error you see in argo is:

```
failed to record sync to history: etcdserver: request is too large. 
```

Reducing the revision history to 1 so we have the current values and the previous values saved, solves the issue.