### PR TITLE
[patch] Omit junitreporter from .Values when used in jobs

### DIFF
--- a/cluster-applications/010-redhat-cert-manager/templates/04-postsync-update-sm_Job.yaml
+++ b/cluster-applications/010-redhat-cert-manager/templates/04-postsync-update-sm_Job.yaml
@@ -101,7 +101,7 @@ metadata:
   # Any change to cluster config will trigger a rerun of the job.
   # The job is idempotent and quick so no real harm in running it when we don't actually need to.
   # The v1 in the name allows use to change this if there is a modification needed that is not in the yaml
-  name: "postsync-rhcm-update-sm-job-v2-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "postsync-rhcm-update-sm-job-v2-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "015"

--- a/cluster-applications/010-redhat-cert-manager/templates/04-postsync-update-sm_Job.yaml
+++ b/cluster-applications/010-redhat-cert-manager/templates/04-postsync-update-sm_Job.yaml
@@ -101,7 +101,7 @@ metadata:
   # Any change to cluster config will trigger a rerun of the job.
   # The job is idempotent and quick so no real harm in running it when we don't actually need to.
   # The v1 in the name allows use to change this if there is a modification needed that is not in the yaml
-  name: "postsync-rhcm-update-sm-job-v2-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
+  name: postsync-rhcm-update-sm-job-v2-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "015"

--- a/cluster-applications/010-redhat-cert-manager/templates/04-postsync-update-sm_Job.yaml
+++ b/cluster-applications/010-redhat-cert-manager/templates/04-postsync-update-sm_Job.yaml
@@ -101,7 +101,7 @@ metadata:
   # Any change to cluster config will trigger a rerun of the job.
   # The job is idempotent and quick so no real harm in running it when we don't actually need to.
   # The v1 in the name allows use to change this if there is a modification needed that is not in the yaml
-  name: "postsync-rhcm-update-sm-job-v2-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
+  name: "postsync-rhcm-update-sm-job-v2-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "015"

--- a/cluster-applications/010-redhat-cert-manager/templates/04-postsync-update-sm_Job.yaml
+++ b/cluster-applications/010-redhat-cert-manager/templates/04-postsync-update-sm_Job.yaml
@@ -101,7 +101,7 @@ metadata:
   # Any change to cluster config will trigger a rerun of the job.
   # The job is idempotent and quick so no real harm in running it when we don't actually need to.
   # The v1 in the name allows use to change this if there is a modification needed that is not in the yaml
-  name: "postsync-rhcm-update-sm-job-v2-{{ .Values | toYaml | adler32sum }}"
+  name: "postsync-rhcm-update-sm-job-v2-{{ omit .Values junitreporter | toYaml | adler32sum }}"
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "015"

--- a/cluster-applications/010-redhat-cert-manager/templates/04-postsync-update-sm_Job.yaml
+++ b/cluster-applications/010-redhat-cert-manager/templates/04-postsync-update-sm_Job.yaml
@@ -101,7 +101,7 @@ metadata:
   # Any change to cluster config will trigger a rerun of the job.
   # The job is idempotent and quick so no real harm in running it when we don't actually need to.
   # The v1 in the name allows use to change this if there is a modification needed that is not in the yaml
-  name: "postsync-rhcm-update-sm-job-v2-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
+  name: "postsync-rhcm-update-sm-job-v2-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "015"

--- a/cluster-applications/010-redhat-cert-manager/templates/04-postsync-update-sm_Job.yaml
+++ b/cluster-applications/010-redhat-cert-manager/templates/04-postsync-update-sm_Job.yaml
@@ -101,7 +101,7 @@ metadata:
   # Any change to cluster config will trigger a rerun of the job.
   # The job is idempotent and quick so no real harm in running it when we don't actually need to.
   # The v1 in the name allows use to change this if there is a modification needed that is not in the yaml
-  name: "postsync-rhcm-update-sm-job-v2-{{ omit .Values junitreporter | toYaml | adler32sum }}"
+  name: "postsync-rhcm-update-sm-job-v2-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "015"

--- a/cluster-applications/010-redhat-cert-manager/templates/04-postsync-update-sm_Job.yaml
+++ b/cluster-applications/010-redhat-cert-manager/templates/04-postsync-update-sm_Job.yaml
@@ -101,7 +101,7 @@ metadata:
   # Any change to cluster config will trigger a rerun of the job.
   # The job is idempotent and quick so no real harm in running it when we don't actually need to.
   # The v1 in the name allows use to change this if there is a modification needed that is not in the yaml
-  name: "postsync-rhcm-update-sm-job-v2-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "postsync-rhcm-update-sm-job-v2-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "015"

--- a/cluster-applications/020-ibm-dro/templates/08-postsync-update-sm_Job.yaml
+++ b/cluster-applications/020-ibm-dro/templates/08-postsync-update-sm_Job.yaml
@@ -89,7 +89,7 @@ metadata:
   # We can refine this in future to only take into account a subset of instance config (perhaps just values under ibm_dro?).
   # But the job is idempotent and quick so no real harm in running it when we don't actually need to.
   # The v1 in the name allows use to change this if there is a modification needed that is not in the yaml
-  name: "postsync-ibm-dro-update-sm-job-v2-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
+  name: postsync-ibm-dro-update-sm-job-v2-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "028"

--- a/cluster-applications/020-ibm-dro/templates/08-postsync-update-sm_Job.yaml
+++ b/cluster-applications/020-ibm-dro/templates/08-postsync-update-sm_Job.yaml
@@ -89,7 +89,7 @@ metadata:
   # We can refine this in future to only take into account a subset of instance config (perhaps just values under ibm_dro?).
   # But the job is idempotent and quick so no real harm in running it when we don't actually need to.
   # The v1 in the name allows use to change this if there is a modification needed that is not in the yaml
-  name: "postsync-ibm-dro-update-sm-job-v2-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
+  name: "postsync-ibm-dro-update-sm-job-v2-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "028"

--- a/cluster-applications/020-ibm-dro/templates/08-postsync-update-sm_Job.yaml
+++ b/cluster-applications/020-ibm-dro/templates/08-postsync-update-sm_Job.yaml
@@ -89,7 +89,7 @@ metadata:
   # We can refine this in future to only take into account a subset of instance config (perhaps just values under ibm_dro?).
   # But the job is idempotent and quick so no real harm in running it when we don't actually need to.
   # The v1 in the name allows use to change this if there is a modification needed that is not in the yaml
-  name: "postsync-ibm-dro-update-sm-job-v2-{{ omit .Values junitreporter | toYaml | adler32sum }}"
+  name: "postsync-ibm-dro-update-sm-job-v2-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "028"

--- a/cluster-applications/020-ibm-dro/templates/08-postsync-update-sm_Job.yaml
+++ b/cluster-applications/020-ibm-dro/templates/08-postsync-update-sm_Job.yaml
@@ -89,7 +89,7 @@ metadata:
   # We can refine this in future to only take into account a subset of instance config (perhaps just values under ibm_dro?).
   # But the job is idempotent and quick so no real harm in running it when we don't actually need to.
   # The v1 in the name allows use to change this if there is a modification needed that is not in the yaml
-  name: "postsync-ibm-dro-update-sm-job-v2-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "postsync-ibm-dro-update-sm-job-v2-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "028"

--- a/cluster-applications/020-ibm-dro/templates/08-postsync-update-sm_Job.yaml
+++ b/cluster-applications/020-ibm-dro/templates/08-postsync-update-sm_Job.yaml
@@ -89,7 +89,7 @@ metadata:
   # We can refine this in future to only take into account a subset of instance config (perhaps just values under ibm_dro?).
   # But the job is idempotent and quick so no real harm in running it when we don't actually need to.
   # The v1 in the name allows use to change this if there is a modification needed that is not in the yaml
-  name: "postsync-ibm-dro-update-sm-job-v2-{{ .Values | toYaml | adler32sum }}"
+  name: "postsync-ibm-dro-update-sm-job-v2-{{ omit .Values junitreporter | toYaml | adler32sum }}"
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "028"

--- a/cluster-applications/020-ibm-dro/templates/08-postsync-update-sm_Job.yaml
+++ b/cluster-applications/020-ibm-dro/templates/08-postsync-update-sm_Job.yaml
@@ -89,7 +89,7 @@ metadata:
   # We can refine this in future to only take into account a subset of instance config (perhaps just values under ibm_dro?).
   # But the job is idempotent and quick so no real harm in running it when we don't actually need to.
   # The v1 in the name allows use to change this if there is a modification needed that is not in the yaml
-  name: "postsync-ibm-dro-update-sm-job-v2-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
+  name: "postsync-ibm-dro-update-sm-job-v2-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "028"

--- a/cluster-applications/020-ibm-dro/templates/08-postsync-update-sm_Job.yaml
+++ b/cluster-applications/020-ibm-dro/templates/08-postsync-update-sm_Job.yaml
@@ -89,7 +89,7 @@ metadata:
   # We can refine this in future to only take into account a subset of instance config (perhaps just values under ibm_dro?).
   # But the job is idempotent and quick so no real harm in running it when we don't actually need to.
   # The v1 in the name allows use to change this if there is a modification needed that is not in the yaml
-  name: "postsync-ibm-dro-update-sm-job-v2-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "postsync-ibm-dro-update-sm-job-v2-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "028"

--- a/cluster-applications/200-cluster-promotion/templates/02-cluster-verify_Job.yaml
+++ b/cluster-applications/200-cluster-promotion/templates/02-cluster-verify_Job.yaml
@@ -35,7 +35,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cluster-verify-{{ .Values.cluster_id }}-v1-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}
+  name: cluster-verify-{{ .Values.cluster_id }}-v1-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
   namespace: mas-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "202"

--- a/cluster-applications/200-cluster-promotion/templates/02-cluster-verify_Job.yaml
+++ b/cluster-applications/200-cluster-promotion/templates/02-cluster-verify_Job.yaml
@@ -35,7 +35,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cluster-verify-{{ .Values.cluster_id }}-v1-{{ omit .Values junitreporter | toYaml | adler32sum }}
+  name: cluster-verify-{{ .Values.cluster_id }}-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}
   namespace: mas-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "202"

--- a/cluster-applications/200-cluster-promotion/templates/02-cluster-verify_Job.yaml
+++ b/cluster-applications/200-cluster-promotion/templates/02-cluster-verify_Job.yaml
@@ -35,7 +35,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cluster-verify-{{ .Values.cluster_id }}-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}
+  name: cluster-verify-{{ .Values.cluster_id }}-v1-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}
   namespace: mas-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "202"

--- a/cluster-applications/200-cluster-promotion/templates/02-cluster-verify_Job.yaml
+++ b/cluster-applications/200-cluster-promotion/templates/02-cluster-verify_Job.yaml
@@ -35,7 +35,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cluster-verify-{{ .Values.cluster_id }}-v1-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}
+  name: cluster-verify-{{ .Values.cluster_id }}-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}
   namespace: mas-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "202"

--- a/cluster-applications/200-cluster-promotion/templates/02-cluster-verify_Job.yaml
+++ b/cluster-applications/200-cluster-promotion/templates/02-cluster-verify_Job.yaml
@@ -35,7 +35,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cluster-verify-{{ .Values.cluster_id }}-v1-{{ .Values | toYaml | adler32sum }}
+  name: cluster-verify-{{ .Values.cluster_id }}-v1-{{ omit .Values junitreporter | toYaml | adler32sum }}
   namespace: mas-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "202"

--- a/cluster-applications/200-cluster-promotion/templates/02-cluster-verify_Job.yaml
+++ b/cluster-applications/200-cluster-promotion/templates/02-cluster-verify_Job.yaml
@@ -35,7 +35,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cluster-verify-{{ .Values.cluster_id }}-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}
+  name: cluster-verify-{{ .Values.cluster_id }}-v1-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}
   namespace: mas-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "202"

--- a/cluster-applications/200-cluster-promotion/templates/02-cluster-verify_Job.yaml
+++ b/cluster-applications/200-cluster-promotion/templates/02-cluster-verify_Job.yaml
@@ -35,7 +35,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cluster-verify-{{ .Values.cluster_id }}-v1-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}
+  name: cluster-verify-{{ .Values.cluster_id }}-v1-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}
   namespace: mas-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "202"

--- a/cluster-applications/200-cluster-promotion/templates/03-cluster-promoter_Job.yaml
+++ b/cluster-applications/200-cluster-promotion/templates/03-cluster-promoter_Job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cluster-promoter-{{ .Values.cluster_id }}-v1-{{ .Values | toYaml | adler32sum }}
+  name: cluster-promoter-{{ .Values.cluster_id }}-v1-{{ omit .Values junitreporter | toYaml | adler32sum }}
   namespace: mas-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "205"

--- a/cluster-applications/200-cluster-promotion/templates/03-cluster-promoter_Job.yaml
+++ b/cluster-applications/200-cluster-promotion/templates/03-cluster-promoter_Job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cluster-promoter-{{ .Values.cluster_id }}-v1-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}
+  name: cluster-promoter-{{ .Values.cluster_id }}-v1-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}
   namespace: mas-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "205"

--- a/cluster-applications/200-cluster-promotion/templates/03-cluster-promoter_Job.yaml
+++ b/cluster-applications/200-cluster-promotion/templates/03-cluster-promoter_Job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cluster-promoter-{{ .Values.cluster_id }}-v1-{{ omit .Values junitreporter | toYaml | adler32sum }}
+  name: cluster-promoter-{{ .Values.cluster_id }}-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}
   namespace: mas-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "205"

--- a/cluster-applications/200-cluster-promotion/templates/03-cluster-promoter_Job.yaml
+++ b/cluster-applications/200-cluster-promotion/templates/03-cluster-promoter_Job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cluster-promoter-{{ .Values.cluster_id }}-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}
+  name: cluster-promoter-{{ .Values.cluster_id }}-v1-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}
   namespace: mas-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "205"

--- a/cluster-applications/200-cluster-promotion/templates/03-cluster-promoter_Job.yaml
+++ b/cluster-applications/200-cluster-promotion/templates/03-cluster-promoter_Job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cluster-promoter-{{ .Values.cluster_id }}-v1-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}
+  name: cluster-promoter-{{ .Values.cluster_id }}-v1-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
   namespace: mas-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "205"

--- a/cluster-applications/200-cluster-promotion/templates/03-cluster-promoter_Job.yaml
+++ b/cluster-applications/200-cluster-promotion/templates/03-cluster-promoter_Job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cluster-promoter-{{ .Values.cluster_id }}-v1-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}
+  name: cluster-promoter-{{ .Values.cluster_id }}-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}
   namespace: mas-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "205"

--- a/cluster-applications/200-cluster-promotion/templates/03-cluster-promoter_Job.yaml
+++ b/cluster-applications/200-cluster-promotion/templates/03-cluster-promoter_Job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cluster-promoter-{{ .Values.cluster_id }}-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}
+  name: cluster-promoter-{{ .Values.cluster_id }}-v1-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}
   namespace: mas-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "205"

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-cp4d-presync.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-cp4d-presync.yaml
@@ -70,7 +70,7 @@ metadata:
   # Any change to cluster config will trigger a rerun of the job.
   # The job is idempotent and quick so no real harm in running it when we don't actually need to.
   # The v1 in the name allows use to change this if there is a modification needed that is not in the yaml
-  name: "presync-cpd-olm-job-v2-{{ omit .Values junitreporter | toYaml | adler32sum }}"
+  name: "presync-cpd-olm-job-v2-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: mas-{{ .Values.instance_id }}-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "003"

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-cp4d-presync.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-cp4d-presync.yaml
@@ -70,7 +70,7 @@ metadata:
   # Any change to cluster config will trigger a rerun of the job.
   # The job is idempotent and quick so no real harm in running it when we don't actually need to.
   # The v1 in the name allows use to change this if there is a modification needed that is not in the yaml
-  name: "presync-cpd-olm-job-v2-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
+  name: "presync-cpd-olm-job-v2-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
   namespace: mas-{{ .Values.instance_id }}-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "003"

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-cp4d-presync.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-cp4d-presync.yaml
@@ -70,7 +70,7 @@ metadata:
   # Any change to cluster config will trigger a rerun of the job.
   # The job is idempotent and quick so no real harm in running it when we don't actually need to.
   # The v1 in the name allows use to change this if there is a modification needed that is not in the yaml
-  name: "presync-cpd-olm-job-v2-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "presync-cpd-olm-job-v2-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
   namespace: mas-{{ .Values.instance_id }}-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "003"

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-cp4d-presync.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-cp4d-presync.yaml
@@ -70,7 +70,7 @@ metadata:
   # Any change to cluster config will trigger a rerun of the job.
   # The job is idempotent and quick so no real harm in running it when we don't actually need to.
   # The v1 in the name allows use to change this if there is a modification needed that is not in the yaml
-  name: "presync-cpd-olm-job-v2-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
+  name: "presync-cpd-olm-job-v2-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: mas-{{ .Values.instance_id }}-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "003"

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-cp4d-presync.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-cp4d-presync.yaml
@@ -70,7 +70,7 @@ metadata:
   # Any change to cluster config will trigger a rerun of the job.
   # The job is idempotent and quick so no real harm in running it when we don't actually need to.
   # The v1 in the name allows use to change this if there is a modification needed that is not in the yaml
-  name: "presync-cpd-olm-job-v2-{{ .Values | toYaml | adler32sum }}"
+  name: "presync-cpd-olm-job-v2-{{ omit .Values junitreporter | toYaml | adler32sum }}"
   namespace: mas-{{ .Values.instance_id }}-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "003"

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-cp4d-presync.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-cp4d-presync.yaml
@@ -70,7 +70,7 @@ metadata:
   # Any change to cluster config will trigger a rerun of the job.
   # The job is idempotent and quick so no real harm in running it when we don't actually need to.
   # The v1 in the name allows use to change this if there is a modification needed that is not in the yaml
-  name: "presync-cpd-olm-job-v2-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
+  name: presync-cpd-olm-job-v2-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
   namespace: mas-{{ .Values.instance_id }}-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "003"

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-cp4d-presync.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-cp4d-presync.yaml
@@ -70,7 +70,7 @@ metadata:
   # Any change to cluster config will trigger a rerun of the job.
   # The job is idempotent and quick so no real harm in running it when we don't actually need to.
   # The v1 in the name allows use to change this if there is a modification needed that is not in the yaml
-  name: "presync-cpd-olm-job-v2-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "presync-cpd-olm-job-v2-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
   namespace: mas-{{ .Values.instance_id }}-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "003"

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
@@ -4,7 +4,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "ibm-suite-certs-v1-{{ .Values | toYaml | adler32sum }}"
+  name: "ibm-suite-certs-v1-{{ omit .Values junitreporter | toYaml | adler32sum }}"
   namespace: mas-{{ .Values.instance_id }}-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "003"

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
@@ -4,7 +4,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "ibm-suite-certs-v1-{{ omit .Values junitreporter | toYaml | adler32sum }}"
+  name: "ibm-suite-certs-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: mas-{{ .Values.instance_id }}-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "003"

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
@@ -4,7 +4,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "ibm-suite-certs-v1-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
+  name: "ibm-suite-certs-v1-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
   namespace: mas-{{ .Values.instance_id }}-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "003"

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
@@ -4,7 +4,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "ibm-suite-certs-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "ibm-suite-certs-v1-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
   namespace: mas-{{ .Values.instance_id }}-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "003"

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
@@ -4,7 +4,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "ibm-suite-certs-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "ibm-suite-certs-v1-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
   namespace: mas-{{ .Values.instance_id }}-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "003"

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
@@ -4,7 +4,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "ibm-suite-certs-v1-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
+  name: "ibm-suite-certs-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: mas-{{ .Values.instance_id }}-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "003"

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
@@ -4,7 +4,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "ibm-suite-certs-v1-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
+  name: ibm-suite-certs-v1-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
   namespace: mas-{{ .Values.instance_id }}-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "003"

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
@@ -3,7 +3,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "ibm-suite-dns-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "ibm-suite-dns-v1-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
   namespace: mas-{{ .Values.instance_id }}-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "003"

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
@@ -3,7 +3,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "ibm-suite-dns-v1-{{ omit .Values junitreporter | toYaml | adler32sum }}"
+  name: "ibm-suite-dns-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: mas-{{ .Values.instance_id }}-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "003"

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
@@ -3,7 +3,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "ibm-suite-dns-v1-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
+  name: ibm-suite-dns-v1-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
   namespace: mas-{{ .Values.instance_id }}-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "003"

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
@@ -3,7 +3,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "ibm-suite-dns-v1-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
+  name: "ibm-suite-dns-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: mas-{{ .Values.instance_id }}-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "003"

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
@@ -3,7 +3,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "ibm-suite-dns-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "ibm-suite-dns-v1-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
   namespace: mas-{{ .Values.instance_id }}-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "003"

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
@@ -3,7 +3,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "ibm-suite-dns-v1-{{ .Values | toYaml | adler32sum }}"
+  name: "ibm-suite-dns-v1-{{ omit .Values junitreporter | toYaml | adler32sum }}"
   namespace: mas-{{ .Values.instance_id }}-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "003"

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
@@ -3,7 +3,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "ibm-suite-dns-v1-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
+  name: "ibm-suite-dns-v1-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
   namespace: mas-{{ .Values.instance_id }}-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "003"

--- a/instance-applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
+++ b/instance-applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
@@ -116,7 +116,7 @@ metadata:
   # Any change to instance config will trigger a rerun of the job. 
   # We can refine this in future to only take into account a subset of instance config (perhaps just values under ibm_sls?).
   # But the job is idempotent and quick so no real harm in running it when we don't actually need to.
-  name: "{{ $job_label }}-v2-{{ omit .Values junitreporter | toYaml | adler32sum }}"
+  name: "{{ $job_label }}-v2-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "112"

--- a/instance-applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
+++ b/instance-applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
@@ -116,7 +116,7 @@ metadata:
   # Any change to instance config will trigger a rerun of the job. 
   # We can refine this in future to only take into account a subset of instance config (perhaps just values under ibm_sls?).
   # But the job is idempotent and quick so no real harm in running it when we don't actually need to.
-  name: "{{ $job_label }}-v2-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
+  name: {{ $job_label }}-v2-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "112"

--- a/instance-applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
+++ b/instance-applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
@@ -116,7 +116,7 @@ metadata:
   # Any change to instance config will trigger a rerun of the job. 
   # We can refine this in future to only take into account a subset of instance config (perhaps just values under ibm_sls?).
   # But the job is idempotent and quick so no real harm in running it when we don't actually need to.
-  name: "{{ $job_label }}-v2-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
+  name: "{{ $job_label }}-v2-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "112"

--- a/instance-applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
+++ b/instance-applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
@@ -116,7 +116,7 @@ metadata:
   # Any change to instance config will trigger a rerun of the job. 
   # We can refine this in future to only take into account a subset of instance config (perhaps just values under ibm_sls?).
   # But the job is idempotent and quick so no real harm in running it when we don't actually need to.
-  name: "{{ $job_label }}-v2-{{ .Values | toYaml | adler32sum }}"
+  name: "{{ $job_label }}-v2-{{ omit .Values junitreporter | toYaml | adler32sum }}"
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "112"

--- a/instance-applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
+++ b/instance-applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
@@ -116,7 +116,7 @@ metadata:
   # Any change to instance config will trigger a rerun of the job. 
   # We can refine this in future to only take into account a subset of instance config (perhaps just values under ibm_sls?).
   # But the job is idempotent and quick so no real harm in running it when we don't actually need to.
-  name: "{{ $job_label }}-v2-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "{{ $job_label }}-v2-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "112"

--- a/instance-applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
+++ b/instance-applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
@@ -116,7 +116,7 @@ metadata:
   # Any change to instance config will trigger a rerun of the job. 
   # We can refine this in future to only take into account a subset of instance config (perhaps just values under ibm_sls?).
   # But the job is idempotent and quick so no real harm in running it when we don't actually need to.
-  name: "{{ $job_label }}-v2-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
+  name: "{{ $job_label }}-v2-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "112"

--- a/instance-applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
+++ b/instance-applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
@@ -116,7 +116,7 @@ metadata:
   # Any change to instance config will trigger a rerun of the job. 
   # We can refine this in future to only take into account a subset of instance config (perhaps just values under ibm_sls?).
   # But the job is idempotent and quick so no real harm in running it when we don't actually need to.
-  name: "{{ $job_label }}-v2-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "{{ $job_label }}-v2-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "112"

--- a/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_prereqs_ops.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_prereqs_ops.yaml
@@ -69,7 +69,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "patch-common-service-job-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "patch-common-service-job-v1-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "088"

--- a/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_prereqs_ops.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_prereqs_ops.yaml
@@ -69,7 +69,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "patch-common-service-job-v1-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
+  name: patch-common-service-job-v1-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "088"

--- a/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_prereqs_ops.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_prereqs_ops.yaml
@@ -69,7 +69,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "patch-common-service-job-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "patch-common-service-job-v1-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "088"

--- a/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_prereqs_ops.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_prereqs_ops.yaml
@@ -69,7 +69,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "patch-common-service-job-v1-{{ omit .Values junitreporter | toYaml | adler32sum }}"
+  name: "patch-common-service-job-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "088"

--- a/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_prereqs_ops.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_prereqs_ops.yaml
@@ -69,7 +69,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "patch-common-service-job-v1-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
+  name: "patch-common-service-job-v1-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "088"

--- a/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_prereqs_ops.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_prereqs_ops.yaml
@@ -69,7 +69,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "patch-common-service-job-v1-{{ .Values | toYaml | adler32sum }}"
+  name: "patch-common-service-job-v1-{{ omit .Values junitreporter | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "088"

--- a/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_prereqs_ops.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_prereqs_ops.yaml
@@ -69,7 +69,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "patch-common-service-job-v1-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
+  name: "patch-common-service-job-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "088"

--- a/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_upg_cleanup.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_upg_cleanup.yaml
@@ -8,7 +8,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-upg-cleanup-v1-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
+  name: "cpd-upg-cleanup-v1-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "086"

--- a/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_upg_cleanup.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_upg_cleanup.yaml
@@ -8,7 +8,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-upg-cleanup-v1-{{ omit .Values junitreporter | toYaml | adler32sum }}"
+  name: "cpd-upg-cleanup-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "086"

--- a/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_upg_cleanup.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_upg_cleanup.yaml
@@ -8,7 +8,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-upg-cleanup-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "cpd-upg-cleanup-v1-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "086"

--- a/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_upg_cleanup.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_upg_cleanup.yaml
@@ -8,7 +8,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-upg-cleanup-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "cpd-upg-cleanup-v1-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "086"

--- a/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_upg_cleanup.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_upg_cleanup.yaml
@@ -8,7 +8,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-upg-cleanup-v1-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
+  name: cpd-upg-cleanup-v1-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "086"

--- a/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_upg_cleanup.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_upg_cleanup.yaml
@@ -8,7 +8,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-upg-cleanup-v1-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
+  name: "cpd-upg-cleanup-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "086"

--- a/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_upg_cleanup.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_upg_cleanup.yaml
@@ -8,7 +8,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-upg-cleanup-v1-{{ .Values | toYaml | adler32sum }}"
+  name: "cpd-upg-cleanup-v1-{{ omit .Values junitreporter | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "086"

--- a/instance-applications/110-ibm-cp4d/templates/03-ibm-cp4d-mcs_patch_sa.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/03-ibm-cp4d-mcs_patch_sa.yaml
@@ -8,7 +8,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-mcs-sa-patch-job-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "cpd-mcs-sa-patch-job-v1-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "084"

--- a/instance-applications/110-ibm-cp4d/templates/03-ibm-cp4d-mcs_patch_sa.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/03-ibm-cp4d-mcs_patch_sa.yaml
@@ -8,7 +8,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-mcs-sa-patch-job-v1-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
+  name: cpd-mcs-sa-patch-job-v1-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "084"

--- a/instance-applications/110-ibm-cp4d/templates/03-ibm-cp4d-mcs_patch_sa.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/03-ibm-cp4d-mcs_patch_sa.yaml
@@ -8,7 +8,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-mcs-sa-patch-job-v1-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
+  name: "cpd-mcs-sa-patch-job-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "084"

--- a/instance-applications/110-ibm-cp4d/templates/03-ibm-cp4d-mcs_patch_sa.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/03-ibm-cp4d-mcs_patch_sa.yaml
@@ -8,7 +8,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-mcs-sa-patch-job-v1-{{ omit .Values junitreporter | toYaml | adler32sum }}"
+  name: "cpd-mcs-sa-patch-job-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "084"

--- a/instance-applications/110-ibm-cp4d/templates/03-ibm-cp4d-mcs_patch_sa.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/03-ibm-cp4d-mcs_patch_sa.yaml
@@ -8,7 +8,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-mcs-sa-patch-job-v1-{{ .Values | toYaml | adler32sum }}"
+  name: "cpd-mcs-sa-patch-job-v1-{{ omit .Values junitreporter | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "084"

--- a/instance-applications/110-ibm-cp4d/templates/03-ibm-cp4d-mcs_patch_sa.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/03-ibm-cp4d-mcs_patch_sa.yaml
@@ -8,7 +8,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-mcs-sa-patch-job-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "cpd-mcs-sa-patch-job-v1-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "084"

--- a/instance-applications/110-ibm-cp4d/templates/03-ibm-cp4d-mcs_patch_sa.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/03-ibm-cp4d-mcs_patch_sa.yaml
@@ -8,7 +8,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-mcs-sa-patch-job-v1-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
+  name: "cpd-mcs-sa-patch-job-v1-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "084"

--- a/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_patch_zenservice.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_patch_zenservice.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-patch-zenservices-v3-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "cpd-patch-zenservices-v3-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "088"

--- a/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_patch_zenservice.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_patch_zenservice.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-patch-zenservices-v3-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "cpd-patch-zenservices-v3-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "088"

--- a/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_patch_zenservice.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_patch_zenservice.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-patch-zenservices-v3-{{ omit .Values junitreporter | toYaml | adler32sum }}"
+  name: "cpd-patch-zenservices-v3-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "088"

--- a/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_patch_zenservice.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_patch_zenservice.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-patch-zenservices-v3-{{ .Values | toYaml | adler32sum }}"
+  name: "cpd-patch-zenservices-v3-{{ omit .Values junitreporter | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "088"

--- a/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_patch_zenservice.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_patch_zenservice.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-patch-zenservices-v3-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
+  name: "cpd-patch-zenservices-v3-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "088"

--- a/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_patch_zenservice.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_patch_zenservice.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-patch-zenservices-v3-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
+  name: cpd-patch-zenservices-v3-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "088"

--- a/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_patch_zenservice.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_patch_zenservice.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-patch-zenservices-v3-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
+  name: "cpd-patch-zenservices-v3-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "088"

--- a/instance-applications/110-ibm-cp4d/templates/08-ibm-cp4d-post-verify.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/08-ibm-cp4d-post-verify.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-post-verify-job-v1-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
+  name: cpd-post-verify-job-v1-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "089"

--- a/instance-applications/110-ibm-cp4d/templates/08-ibm-cp4d-post-verify.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/08-ibm-cp4d-post-verify.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-post-verify-job-v1-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
+  name: "cpd-post-verify-job-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "089"

--- a/instance-applications/110-ibm-cp4d/templates/08-ibm-cp4d-post-verify.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/08-ibm-cp4d-post-verify.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-post-verify-job-v1-{{ omit .Values junitreporter | toYaml | adler32sum }}"
+  name: "cpd-post-verify-job-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "089"

--- a/instance-applications/110-ibm-cp4d/templates/08-ibm-cp4d-post-verify.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/08-ibm-cp4d-post-verify.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-post-verify-job-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "cpd-post-verify-job-v1-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "089"

--- a/instance-applications/110-ibm-cp4d/templates/08-ibm-cp4d-post-verify.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/08-ibm-cp4d-post-verify.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-post-verify-job-v1-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
+  name: "cpd-post-verify-job-v1-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "089"

--- a/instance-applications/110-ibm-cp4d/templates/08-ibm-cp4d-post-verify.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/08-ibm-cp4d-post-verify.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-post-verify-job-v1-{{ .Values | toYaml | adler32sum }}"
+  name: "cpd-post-verify-job-v1-{{ omit .Values junitreporter | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "089"

--- a/instance-applications/110-ibm-cp4d/templates/08-ibm-cp4d-post-verify.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/08-ibm-cp4d-post-verify.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-post-verify-job-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "cpd-post-verify-job-v1-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "089"

--- a/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-base-sa-patch-job-v1-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
+  name: "cpd-base-sa-patch-job-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "089"

--- a/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-base-sa-patch-job-v1-{{ omit .Values junitreporter | toYaml | adler32sum }}"
+  name: "cpd-base-sa-patch-job-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "089"

--- a/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-base-sa-patch-job-v1-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
+  name: cpd-base-sa-patch-job-v1-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "089"

--- a/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-base-sa-patch-job-v1-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
+  name: "cpd-base-sa-patch-job-v1-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "089"

--- a/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-base-sa-patch-job-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "cpd-base-sa-patch-job-v1-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "089"

--- a/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-base-sa-patch-job-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "cpd-base-sa-patch-job-v1-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "089"

--- a/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-base-sa-patch-job-v1-{{ .Values | toYaml | adler32sum }}"
+  name: "cpd-base-sa-patch-job-v1-{{ omit .Values junitreporter | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "089"

--- a/instance-applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
@@ -102,7 +102,7 @@ kind: Job
 metadata:
   # Suffix the Job name with a hash of all chart values
   # This is to ensure that ArgoCD will delete and recreate the job if (and only if) anything changes in the DB2 config
-  name: "postsync-setup-db2-{{ .Values.db2_instance_name }}-v4-{{ .Values | toYaml | adler32sum }}"
+  name: "postsync-setup-db2-{{ .Values.db2_instance_name }}-v4-{{ omit .Values junitreporter | toYaml | adler32sum }}"
   namespace: "{{ .Values.db2_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "129"

--- a/instance-applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
@@ -102,7 +102,7 @@ kind: Job
 metadata:
   # Suffix the Job name with a hash of all chart values
   # This is to ensure that ArgoCD will delete and recreate the job if (and only if) anything changes in the DB2 config
-  name: "postsync-setup-db2-{{ .Values.db2_instance_name }}-v4-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
+  name: "postsync-setup-db2-{{ .Values.db2_instance_name }}-v4-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: "{{ .Values.db2_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "129"

--- a/instance-applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
@@ -102,7 +102,7 @@ kind: Job
 metadata:
   # Suffix the Job name with a hash of all chart values
   # This is to ensure that ArgoCD will delete and recreate the job if (and only if) anything changes in the DB2 config
-  name: "postsync-setup-db2-{{ .Values.db2_instance_name }}-v4-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "postsync-setup-db2-{{ .Values.db2_instance_name }}-v4-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
   namespace: "{{ .Values.db2_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "129"

--- a/instance-applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
@@ -102,7 +102,7 @@ kind: Job
 metadata:
   # Suffix the Job name with a hash of all chart values
   # This is to ensure that ArgoCD will delete and recreate the job if (and only if) anything changes in the DB2 config
-  name: "postsync-setup-db2-{{ .Values.db2_instance_name }}-v4-{{ omit .Values junitreporter | toYaml | adler32sum }}"
+  name: "postsync-setup-db2-{{ .Values.db2_instance_name }}-v4-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: "{{ .Values.db2_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "129"

--- a/instance-applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
@@ -102,7 +102,7 @@ kind: Job
 metadata:
   # Suffix the Job name with a hash of all chart values
   # This is to ensure that ArgoCD will delete and recreate the job if (and only if) anything changes in the DB2 config
-  name: "postsync-setup-db2-{{ .Values.db2_instance_name }}-v4-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
+  name: postsync-setup-db2-{{ .Values.db2_instance_name }}-v4-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
   namespace: "{{ .Values.db2_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "129"

--- a/instance-applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
@@ -102,7 +102,7 @@ kind: Job
 metadata:
   # Suffix the Job name with a hash of all chart values
   # This is to ensure that ArgoCD will delete and recreate the job if (and only if) anything changes in the DB2 config
-  name: "postsync-setup-db2-{{ .Values.db2_instance_name }}-v4-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "postsync-setup-db2-{{ .Values.db2_instance_name }}-v4-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
   namespace: "{{ .Values.db2_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "129"

--- a/instance-applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
@@ -102,7 +102,7 @@ kind: Job
 metadata:
   # Suffix the Job name with a hash of all chart values
   # This is to ensure that ArgoCD will delete and recreate the job if (and only if) anything changes in the DB2 config
-  name: "postsync-setup-db2-{{ .Values.db2_instance_name }}-v4-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
+  name: "postsync-setup-db2-{{ .Values.db2_instance_name }}-v4-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
   namespace: "{{ .Values.db2_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "129"

--- a/instance-applications/120-ibm-spss/templates/02-ibm-spss-post-verify.yaml
+++ b/instance-applications/120-ibm-spss/templates/02-ibm-spss-post-verify.yaml
@@ -91,7 +91,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-spss-post-verify-job-v1-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
+  name: cpd-spss-post-verify-job-v1-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "096"

--- a/instance-applications/120-ibm-spss/templates/02-ibm-spss-post-verify.yaml
+++ b/instance-applications/120-ibm-spss/templates/02-ibm-spss-post-verify.yaml
@@ -91,7 +91,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-spss-post-verify-job-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "cpd-spss-post-verify-job-v1-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "096"

--- a/instance-applications/120-ibm-spss/templates/02-ibm-spss-post-verify.yaml
+++ b/instance-applications/120-ibm-spss/templates/02-ibm-spss-post-verify.yaml
@@ -91,7 +91,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-spss-post-verify-job-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "cpd-spss-post-verify-job-v1-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "096"

--- a/instance-applications/120-ibm-spss/templates/02-ibm-spss-post-verify.yaml
+++ b/instance-applications/120-ibm-spss/templates/02-ibm-spss-post-verify.yaml
@@ -91,7 +91,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-spss-post-verify-job-v1-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
+  name: "cpd-spss-post-verify-job-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "096"

--- a/instance-applications/120-ibm-spss/templates/02-ibm-spss-post-verify.yaml
+++ b/instance-applications/120-ibm-spss/templates/02-ibm-spss-post-verify.yaml
@@ -91,7 +91,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-spss-post-verify-job-v1-{{ omit .Values junitreporter | toYaml | adler32sum }}"
+  name: "cpd-spss-post-verify-job-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "096"

--- a/instance-applications/120-ibm-spss/templates/02-ibm-spss-post-verify.yaml
+++ b/instance-applications/120-ibm-spss/templates/02-ibm-spss-post-verify.yaml
@@ -91,7 +91,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-spss-post-verify-job-v1-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
+  name: "cpd-spss-post-verify-job-v1-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "096"

--- a/instance-applications/120-ibm-spss/templates/02-ibm-spss-post-verify.yaml
+++ b/instance-applications/120-ibm-spss/templates/02-ibm-spss-post-verify.yaml
@@ -91,7 +91,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-spss-post-verify-job-v1-{{ .Values | toYaml | adler32sum }}"
+  name: "cpd-spss-post-verify-job-v1-{{ omit .Values junitreporter | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "096"

--- a/instance-applications/120-ibm-wsl/templates/02-ibm-wsl-post-verify.yaml
+++ b/instance-applications/120-ibm-wsl/templates/02-ibm-wsl-post-verify.yaml
@@ -74,7 +74,7 @@ type: Opaque
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-wsl-post-verify-v2-{{ omit .Values junitreporter | toYaml | adler32sum }}"
+  name: "cpd-wsl-post-verify-v2-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "094"

--- a/instance-applications/120-ibm-wsl/templates/02-ibm-wsl-post-verify.yaml
+++ b/instance-applications/120-ibm-wsl/templates/02-ibm-wsl-post-verify.yaml
@@ -74,7 +74,7 @@ type: Opaque
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-wsl-post-verify-v2-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
+  name: "cpd-wsl-post-verify-v2-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "094"

--- a/instance-applications/120-ibm-wsl/templates/02-ibm-wsl-post-verify.yaml
+++ b/instance-applications/120-ibm-wsl/templates/02-ibm-wsl-post-verify.yaml
@@ -74,7 +74,7 @@ type: Opaque
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-wsl-post-verify-v2-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "cpd-wsl-post-verify-v2-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "094"

--- a/instance-applications/120-ibm-wsl/templates/02-ibm-wsl-post-verify.yaml
+++ b/instance-applications/120-ibm-wsl/templates/02-ibm-wsl-post-verify.yaml
@@ -74,7 +74,7 @@ type: Opaque
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-wsl-post-verify-v2-{{ .Values | toYaml | adler32sum }}"
+  name: "cpd-wsl-post-verify-v2-{{ omit .Values junitreporter | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "094"

--- a/instance-applications/120-ibm-wsl/templates/02-ibm-wsl-post-verify.yaml
+++ b/instance-applications/120-ibm-wsl/templates/02-ibm-wsl-post-verify.yaml
@@ -74,7 +74,7 @@ type: Opaque
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-wsl-post-verify-v2-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
+  name: cpd-wsl-post-verify-v2-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "094"

--- a/instance-applications/120-ibm-wsl/templates/02-ibm-wsl-post-verify.yaml
+++ b/instance-applications/120-ibm-wsl/templates/02-ibm-wsl-post-verify.yaml
@@ -74,7 +74,7 @@ type: Opaque
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-wsl-post-verify-v2-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
+  name: "cpd-wsl-post-verify-v2-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "094"

--- a/instance-applications/120-ibm-wsl/templates/02-ibm-wsl-post-verify.yaml
+++ b/instance-applications/120-ibm-wsl/templates/02-ibm-wsl-post-verify.yaml
@@ -74,7 +74,7 @@ type: Opaque
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "cpd-wsl-post-verify-v2-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "cpd-wsl-post-verify-v2-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
   namespace: "{{ .Values.cpd_operators_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "094"

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -100,7 +100,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "mas-route-patch-v1-{{ omit .Values junitreporter | toYaml | adler32sum }}"
+  name: "mas-route-patch-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: mas-{{ .Values.instance_id }}-core
   annotations:
     argocd.argoproj.io/sync-wave: "142"

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -100,7 +100,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "mas-route-patch-v1-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
+  name: mas-route-patch-v1-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
   namespace: mas-{{ .Values.instance_id }}-core
   annotations:
     argocd.argoproj.io/sync-wave: "142"

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -100,7 +100,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "mas-route-patch-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "mas-route-patch-v1-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
   namespace: mas-{{ .Values.instance_id }}-core
   annotations:
     argocd.argoproj.io/sync-wave: "142"

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -100,7 +100,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "mas-route-patch-v1-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
+  name: "mas-route-patch-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: mas-{{ .Values.instance_id }}-core
   annotations:
     argocd.argoproj.io/sync-wave: "142"

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -100,7 +100,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "mas-route-patch-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "mas-route-patch-v1-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
   namespace: mas-{{ .Values.instance_id }}-core
   annotations:
     argocd.argoproj.io/sync-wave: "142"

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -100,7 +100,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "mas-route-patch-v1-{{ .Values | toYaml | adler32sum }}"
+  name: "mas-route-patch-v1-{{ omit .Values junitreporter | toYaml | adler32sum }}"
   namespace: mas-{{ .Values.instance_id }}-core
   annotations:
     argocd.argoproj.io/sync-wave: "142"

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -100,7 +100,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "mas-route-patch-v1-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
+  name: "mas-route-patch-v1-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
   namespace: mas-{{ .Values.instance_id }}-core
   annotations:
     argocd.argoproj.io/sync-wave: "142"

--- a/instance-applications/220-ibm-mas-workspace/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/220-ibm-mas-workspace/templates/05-postsync-add-label_Job.yaml
@@ -102,7 +102,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "mas-ws-route-patch-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "mas-ws-route-patch-v1-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
   namespace: mas-{{ .Values.instance_id }}-core
   annotations:
     argocd.argoproj.io/sync-wave: "223"

--- a/instance-applications/220-ibm-mas-workspace/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/220-ibm-mas-workspace/templates/05-postsync-add-label_Job.yaml
@@ -102,7 +102,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "mas-ws-route-patch-v1-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
+  name: mas-ws-route-patch-v1-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
   namespace: mas-{{ .Values.instance_id }}-core
   annotations:
     argocd.argoproj.io/sync-wave: "223"

--- a/instance-applications/220-ibm-mas-workspace/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/220-ibm-mas-workspace/templates/05-postsync-add-label_Job.yaml
@@ -102,7 +102,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "mas-ws-route-patch-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "mas-ws-route-patch-v1-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
   namespace: mas-{{ .Values.instance_id }}-core
   annotations:
     argocd.argoproj.io/sync-wave: "223"

--- a/instance-applications/220-ibm-mas-workspace/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/220-ibm-mas-workspace/templates/05-postsync-add-label_Job.yaml
@@ -102,7 +102,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "mas-ws-route-patch-v1-{{ .Values | toYaml | adler32sum }}"
+  name: "mas-ws-route-patch-v1-{{ omit .Values junitreporter | toYaml | adler32sum }}"
   namespace: mas-{{ .Values.instance_id }}-core
   annotations:
     argocd.argoproj.io/sync-wave: "223"

--- a/instance-applications/220-ibm-mas-workspace/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/220-ibm-mas-workspace/templates/05-postsync-add-label_Job.yaml
@@ -102,7 +102,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "mas-ws-route-patch-v1-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
+  name: "mas-ws-route-patch-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: mas-{{ .Values.instance_id }}-core
   annotations:
     argocd.argoproj.io/sync-wave: "223"

--- a/instance-applications/220-ibm-mas-workspace/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/220-ibm-mas-workspace/templates/05-postsync-add-label_Job.yaml
@@ -102,7 +102,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "mas-ws-route-patch-v1-{{ omit .Values junitreporter | toYaml | adler32sum }}"
+  name: "mas-ws-route-patch-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: mas-{{ .Values.instance_id }}-core
   annotations:
     argocd.argoproj.io/sync-wave: "223"

--- a/instance-applications/220-ibm-mas-workspace/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/220-ibm-mas-workspace/templates/05-postsync-add-label_Job.yaml
@@ -102,7 +102,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "mas-ws-route-patch-v1-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
+  name: "mas-ws-route-patch-v1-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
   namespace: mas-{{ .Values.instance_id }}-core
   annotations:
     argocd.argoproj.io/sync-wave: "223"

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
@@ -113,7 +113,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "mas-app-route-patch-v1-{{ omit .Values junitreporter | toYaml | adler32sum }}"
+  name: "mas-app-route-patch-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "604"

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
@@ -113,7 +113,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "mas-app-route-patch-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "mas-app-route-patch-v1-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "604"

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
@@ -113,7 +113,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "mas-app-route-patch-v1-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
+  name: "mas-app-route-patch-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "604"

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
@@ -113,7 +113,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "mas-app-route-patch-v1-{{ .Values | toYaml | adler32sum }}"
+  name: "mas-app-route-patch-v1-{{ omit .Values junitreporter | toYaml | adler32sum }}"
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "604"

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
@@ -113,7 +113,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "mas-app-route-patch-v1-{{ omit .Values 'junitreporter' '*' | toYaml | adler32sum }}"
+  name: "mas-app-route-patch-v1-{{ omit .Values 'junitreporter.devops_build_number' 'junitreporter.gitops_version' | toYaml | adler32sum }}"
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "604"

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
@@ -113,7 +113,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "mas-app-route-patch-v1-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
+  name: mas-app-route-patch-v1-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "604"

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
@@ -113,7 +113,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "mas-app-route-patch-v1-{{ omit .Values 'junitreporter' | toYaml | adler32sum }}"
+  name: "mas-app-route-patch-v1-{{ omit .Values \"junitreporter\" | toYaml | adler32sum }}"
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "604"


### PR DESCRIPTION
We use the adler32sum from the .Values to determine if a job should be re-run (as it will be a different name for the job). The problem was that the junitreporter.devops_build_number was included in these values and this changes with each build so the jobs were re-running when it wasn't needed.

The change omits the junitreporter key from the .values and uses the rest of the values which won't change unless there is an actual meaningful change.

Tested this out in fyre cluster, and it works.