### PR TITLE
[patch] Remove unneeded zen catalog for cp4d 5.0

### DIFF
--- a/instance-applications/110-ibm-cp4d-operators/templates/01-ibm-cp4d_CatalogSources.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/01-ibm-cp4d_CatalogSources.yaml
@@ -91,27 +91,6 @@ spec:
     registryPoll:
       interval: 30m0s
 
----
-apiVersion: operators.coreos.com/v1alpha1
-kind: CatalogSource
-metadata:
-  name: ibm-zen-operator-catalog
-  namespace: "{{ .Values.cpd_operators_namespace }}"
-  annotations:
-    argocd.argoproj.io/sync-wave: "081"
-{{- if .Values.custom_labels }}
-  labels:
-{{ .Values.custom_labels | toYaml | indent 4 }}
-{{- end }}
-spec:
-  displayName: ibm-zen-6.0.1
-  image: icr.io/cpopen/ibm-zen-operator-catalog@sha256:6b43f09c1335a28e71669a0ecbd6fdee0ec2afe74d62c014b0d1d2d5a04b4ee3
-  publisher: IBM
-  sourceType: grpc
-  updateStrategy:
-    registryPoll:
-      interval: 30m0s
-
 {{- end }}
 
 {{- end }}


### PR DESCRIPTION
In the update to cp4d 5.0, we added a catalog to install zen service 6.0.1 but what we needed was 6.0.2 and since we have that in ibm-catalog, we don't need to add the zen catalog which has the wrong version. This is a correction for that. 