### PR TITLE
[minor] Output verify and sanity test log to test record

### DIFF
--- a/cluster-applications/200-cluster-promotion/templates/02-cluster-verify_Job.yaml
+++ b/cluster-applications/200-cluster-promotion/templates/02-cluster-verify_Job.yaml
@@ -114,11 +114,19 @@ spec:
                       FOUND_CATALOG_VERION=$(oc get configmap -n $MAS_APP_NAMESPACE $MAS_APP_CM -o jsonpath='{.data.mas_catalog_version}')
                       if [[ $FOUND_CATALOG_VERION == $MAS_CATALOG_VERSION ]]; then
                           echo "Found ConfigMap $MAS_APP_CM with correct MAS_CATALOG_VERSION: $MAS_CATALOG_VERSION"
-                          SUCCESS=true
+
+                          TEST_PASSED=$(oc get configmap -n $MAS_APP_NAMESPACE $MAS_APP_CM -o jsonpath='{.data.test_passed}')
+                          echo "Found ConfigMap $MAS_APP_CM with TEST_PASSED value of: $TEST_PASSED"
+                          if [[ $TEST_PASSED ]]; then
+                            SUCCESS=true
+                          else
+                            SUCCESS=false
+                          fi
                       else
                           echo "Found ConfigMap $MAS_APP_CM with incorrect MAS_CATALOG_VERSION of $FOUND_CATALOG_VERION, expecting $MAS_CATALOG_VERSION"
                           SUCCESS=false
                       fi
+
 
                       if [[ $SUCCESS == "true" ]]; then
                           break

--- a/cluster-applications/200-cluster-promotion/templates/02-cluster-verify_Job.yaml
+++ b/cluster-applications/200-cluster-promotion/templates/02-cluster-verify_Job.yaml
@@ -35,7 +35,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cluster-verify-{{ .Values.cluster_id }}-v1-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
+  name: cluster-verify-{{ .Values.cluster_id }}-v2-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
   namespace: mas-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "202"

--- a/cluster-applications/200-cluster-promotion/templates/03-cluster-promoter_Job.yaml
+++ b/cluster-applications/200-cluster-promotion/templates/03-cluster-promoter_Job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cluster-promoter-{{ .Values.cluster_id }}-v1-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
+  name: cluster-promoter-{{ .Values.cluster_id }}-v2-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
   namespace: mas-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "205"

--- a/cluster-applications/200-cluster-promotion/templates/03-cluster-promoter_Job.yaml
+++ b/cluster-applications/200-cluster-promotion/templates/03-cluster-promoter_Job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: cluster-promoter-{{ .Values.cluster_id }}-v2-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
+  name: cluster-promoter-{{ .Values.cluster_id }}-v1-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
   namespace: mas-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "205"

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-sanity.yaml
@@ -1011,7 +1011,7 @@ metadata:
     argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
   labels:
-    type: mas-app-verification-record
+    type: mas-app-sanity-record
 {{- if .Values.custom_labels }}
 {{ .Values.custom_labels | toYaml | indent 4 }}
 {{- end }}

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-sanity.yaml
@@ -1031,6 +1031,11 @@ spec:
               oc set data cm $TEST_RECORD_CM test_passed=$TEST_PASSED
               oc set data cm $TEST_RECORD_CM --from-file=junitxml_test_output.xml
               oc set data cm $TEST_RECORD_CM --from-file=test_log.txt
+              
+              if [[ $TEST_PASSED == "false" ]]; then
+                echo "Test Result failed, exit 1"
+                exit 1
+              fi
 
       restartPolicy: Never
       serviceAccountName: {{ $sa_name }}

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-sanity.yaml
@@ -1017,6 +1017,7 @@ spec:
               source .venv/bin/activate
               pip install -r /tmp/tests/requirements.txt
 
+              set -o pipefail
               echo "Running tests..."
               pytest -v --junit-xml=junitxml_test_output.xml -o cache_dir=/tmp/__pycache__ /tmp/tests/tests.py 2>&1 | tee test_log.txt
               if [[ $? -ne 0 ]]; then
@@ -1025,6 +1026,7 @@ spec:
                   TEST_PASSED=true
               fi
               echo "Test Result Passed: $TEST_PASSED"
+              set +o pipefail
 
               set -e
               echo "Updating $TEST_RECORD_CM configmap with test result"

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-sanity.yaml
@@ -86,6 +86,14 @@ rules:
       - manageapp
       - manageworkspaces
       - manageapps
+  - verbs:
+      - get
+      - list
+      - patch
+    apiGroups:
+      - ""
+    resources:
+      - configmaps
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-sanity.yaml
@@ -930,6 +930,28 @@ data:
         response = session.delete(asset_url, headers=headers, params=querystring)
         assert_that(response.status_code).is_equal_to(204)
 
+
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ $record_cm_name }}
+  namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "604"
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+  labels:
+    type: mas-app-sanity-record
+{{- if .Values.custom_labels }}
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+immutable: false
+data:
+  mas_app: "manage"
+  mas_catalog_version: "{{ .Values.mas_catalog_version }}"
+  test_passed: "unknown"
+
 ---
 apiVersion: batch/v1
 kind: Job
@@ -937,7 +959,7 @@ metadata:
   name: {{ $job_name }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-wave: "604"
+    argocd.argoproj.io/sync-wave: "605"
     argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded,BeforeHookCreation
 {{- if .Values.custom_labels }}
@@ -974,6 +996,8 @@ spec:
               value: "{{ .Values.mas_app_namespace }}"
             - name: MAS_NAMESPACE
               value: "mas-{{ .Values.instance_id }}-core"
+            - name: TEST_RECORD_CM
+              value: "{{ $record_cm_name }}"
           volumeMounts:
             - name: tests
               mountPath: /tmp/tests
@@ -984,7 +1008,22 @@ spec:
               python -m venv .venv
               source .venv/bin/activate
               pip install -r /tmp/tests/requirements.txt
-              pytest -o cache_dir=/tmp/__pycache__ /tmp/tests/tests.py 
+
+              echo "Running tests..."
+              pytest -v --junit-xml=junitxml_test_output.xml -o cache_dir=/tmp/__pycache__ /tmp/tests/tests.py 2>&1 | tee test_log.txt
+              if [[ $? -ne 0 ]]; then
+                  TEST_PASSED=false
+              else
+                  TEST_PASSED=true
+              fi
+              echo "Test Result Passed: $TEST_PASSED"
+
+              set -e
+              echo "Updating $TEST_RECORD_CM configmap with test result"
+              oc set data cm $TEST_RECORD_CM test_passed=$TEST_PASSED
+              oc set data cm $TEST_RECORD_CM --from-file=junitxml_test_output.xml
+              oc set data cm $TEST_RECORD_CM --from-file=test_log.txt
+
       restartPolicy: Never
       serviceAccountName: {{ $sa_name }}
       volumes:
@@ -999,25 +1038,5 @@ spec:
             defaultMode: 420
             optional: false
   backoffLimit: 4
-
----
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: {{ $record_cm_name }}
-  namespace: {{ $ns }}
-  annotations:
-    argocd.argoproj.io/sync-wave: "605"
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
-  labels:
-    type: mas-app-sanity-record
-{{- if .Values.custom_labels }}
-{{ .Values.custom_labels | toYaml | indent 4 }}
-{{- end }}
-immutable: false
-data:
-  mas_app: "manage"
-  mas_catalog_version: "{{ .Values.mas_catalog_version }}"
 
 {{- end }}

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -207,6 +207,27 @@ data:
       if spec_serverbundles is not None:
         assert status_serverbundles == spec_serverbundles, f"Expected serverbundles set in the spec: {spec_serverbundles} to be equal to the languages in the status: {status_serverbundles}"
 
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ $record_cm_name }}
+  namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "604"
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+  labels:
+    type: mas-app-verification-record
+{{- if .Values.custom_labels }}
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+immutable: false
+data:
+  mas_app: "manage"
+  mas_catalog_version: "{{ .Values.mas_catalog_version }}"
+  test_passed: "unknown"
+
 
 ---
 apiVersion: batch/v1
@@ -215,7 +236,7 @@ metadata:
   name: {{ $job_name }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-wave: "604"
+    argocd.argoproj.io/sync-wave: "605"
     argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded,BeforeHookCreation
 {{- if .Values.custom_labels }}
@@ -248,6 +269,8 @@ spec:
               value: "{{ .Values.instance_id }}"
             - name: MAS_WORKSPACE_ID
               value: "{{ .Values.mas_workspace_id }}"
+            - name: TEST_RECORD_CM
+              value: "{{ $record_cm_name }}"
           volumeMounts:
             - name: tests
               mountPath: /tmp/tests
@@ -255,8 +278,25 @@ spec:
             - /bin/sh
             - -c
             - |
+              python -m venv .venv
+              source .venv/bin/activate
               pip install -r /tmp/tests/requirements.txt
-              pytest -o cache_dir=/tmp/__pycache__ /tmp/tests/tests.py 
+
+              echo "Running tests..."
+              pytest -v --junit-xml=junitxml_test_output.xml -o cache_dir=/tmp/__pycache__ /tmp/tests/tests.py 2>&1 | tee test_log.txt
+              if [[ $? -ne 0 ]]; then
+                  TEST_PASSED=false
+              else
+                  TEST_PASSED=true
+              fi
+              echo "Test Result Passed: $TEST_PASSED"
+
+              set -e
+              echo "Updating $TEST_RECORD_CM configmap with test result"
+              oc set data cm $TEST_RECORD_CM test_passed=$TEST_PASSED
+              oc set data cm $TEST_RECORD_CM --from-file=junitxml_test_output.xml
+              oc set data cm $TEST_RECORD_CM --from-file=test_log.txt
+
       restartPolicy: Never
       serviceAccountName: {{ $sa_name }}
       volumes:
@@ -272,24 +312,5 @@ spec:
             optional: false
   backoffLimit: 4
 
----
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: {{ $record_cm_name }}
-  namespace: {{ $ns }}
-  annotations:
-    argocd.argoproj.io/sync-wave: "605"
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
-  labels:
-    type: mas-app-verification-record
-{{- if .Values.custom_labels }}
-{{ .Values.custom_labels | toYaml | indent 4 }}
-{{- end }}
-immutable: false
-data:
-  mas_app: "manage"
-  mas_catalog_version: "{{ .Values.mas_catalog_version }}"
 
 {{- end }}

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -290,6 +290,7 @@ spec:
               source .venv/bin/activate
               pip install -r /tmp/tests/requirements.txt
 
+              set -o pipefail
               echo "Running tests..."
               pytest -v --junit-xml=junitxml_test_output.xml -o cache_dir=/tmp/__pycache__ /tmp/tests/tests.py 2>&1 | tee test_log.txt
               if [[ $? -ne 0 ]]; then
@@ -298,6 +299,7 @@ spec:
                   TEST_PASSED=true
               fi
               echo "Test Result Passed: $TEST_PASSED"
+              set +o pipefail
 
               set -e
               echo "Updating $TEST_RECORD_CM configmap with test result"

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -305,6 +305,10 @@ spec:
               oc set data cm $TEST_RECORD_CM --from-file=junitxml_test_output.xml
               oc set data cm $TEST_RECORD_CM --from-file=test_log.txt
 
+              if [[ $TEST_PASSED == "false" ]]; then
+                echo "Test Result failed, exit 1"
+                exit 1
+              fi
       restartPolicy: Never
       serviceAccountName: {{ $sa_name }}
       volumes:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -83,6 +83,14 @@ rules:
       - manageapp
       - manageworkspaces
       - manageapps
+  - verbs:
+      - get
+      - list
+      - patch
+    apiGroups:
+      - ""
+    resources:
+      - configmaps
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-sanity.yaml
@@ -85,6 +85,14 @@ rules:
       - "route.openshift.io"
     resources:
       - routes
+  - verbs:
+      - get
+      - list
+      - patch
+    apiGroups:
+      - ""
+    resources:
+      - configmaps
 
 ---
 kind: RoleBinding

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-sanity.yaml
@@ -528,7 +528,7 @@ metadata:
     argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
   labels:
-      type: mas-app-verification-record
+      type: mas-app-sanity-record
 {{- if .Values.custom_labels }}
 {{ .Values.custom_labels | toYaml | indent 4 }}
 {{- end }}

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-sanity.yaml
@@ -549,6 +549,10 @@ spec:
               oc set data cm $TEST_RECORD_CM --from-file=junitxml_test_output.xml
               oc set data cm $TEST_RECORD_CM --from-file=test_log.txt
 
+              if [[ $TEST_PASSED == "false" ]]; then
+                echo "Test Result failed, exit 1"
+                exit 1
+              fi
       restartPolicy: Never
       serviceAccountName: {{ $sa_name }}
       volumes:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-sanity.yaml
@@ -534,6 +534,7 @@ spec:
               source .venv/bin/activate
               pip install -r /tmp/tests/requirements.txt
 
+              set -o pipefail
               echo "Running tests..."
               pytest -v --junit-xml=junitxml_test_output.xml -o cache_dir=/tmp/__pycache__ /tmp/tests/tests.py 2>&1 | tee test_log.txt
               if [[ $? -ne 0 ]]; then
@@ -542,6 +543,7 @@ spec:
                   TEST_PASSED=true
               fi
               echo "Test Result Passed: $TEST_PASSED"
+              set +o pipefail
 
               set -e
               echo "Updating $TEST_RECORD_CM configmap with test result"

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-sanity.yaml
@@ -451,6 +451,27 @@ data:
         print("Placeholder for sanity tests to be added")
 
 
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ $record_cm_name }}
+  namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "604"
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+  labels:
+      type: mas-app-sanity-record
+{{- if .Values.custom_labels }}
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+immutable: false
+data:
+  mas_app: "visualinspection"
+  mas_catalog_version: "{{ .Values.mas_catalog_version }}"
+  test_passed: "unknown"
+
 
 ---
 apiVersion: batch/v1
@@ -459,7 +480,7 @@ metadata:
   name: {{ $job_name }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-wave: "604"
+    argocd.argoproj.io/sync-wave: "605"
     argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded,BeforeHookCreation
 {{- if .Values.custom_labels }}
@@ -492,6 +513,8 @@ spec:
               value: "{{ .Values.instance_id }}"
             - name: MAS_WORKSPACE_ID
               value: "{{ .Values.mas_workspace_id }}"
+            - name: TEST_RECORD_CM
+              value: "{{ $record_cm_name }}"
           volumeMounts:
             - name: tests
               mountPath: /tmp/tests
@@ -499,8 +522,24 @@ spec:
             - /bin/sh
             - -c
             - |
+              python -m venv .venv
+              source .venv/bin/activate
               pip install -r /tmp/tests/requirements.txt
-              pytest -o cache_dir=/tmp/__pycache__ /tmp/tests/tests.py
+
+              echo "Running tests..."
+              pytest -v --junit-xml=junitxml_test_output.xml -o cache_dir=/tmp/__pycache__ /tmp/tests/tests.py 2>&1 | tee test_log.txt
+              if [[ $? -ne 0 ]]; then
+                  TEST_PASSED=false
+              else
+                  TEST_PASSED=true
+              fi
+              echo "Test Result Passed: $TEST_PASSED"
+
+              set -e
+              echo "Updating $TEST_RECORD_CM configmap with test result"
+              oc set data cm $TEST_RECORD_CM test_passed=$TEST_PASSED
+              oc set data cm $TEST_RECORD_CM --from-file=junitxml_test_output.xml
+              oc set data cm $TEST_RECORD_CM --from-file=test_log.txt
 
       restartPolicy: Never
       serviceAccountName: {{ $sa_name }}
@@ -516,25 +555,5 @@ spec:
             defaultMode: 420
             optional: false
   backoffLimit: 4
-
----
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: {{ $record_cm_name }}
-  namespace: {{ $ns }}
-  annotations:
-    argocd.argoproj.io/sync-wave: "605"
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
-  labels:
-      type: mas-app-sanity-record
-{{- if .Values.custom_labels }}
-{{ .Values.custom_labels | toYaml | indent 4 }}
-{{- end }}
-immutable: false
-data:
-  mas_app: "visualinspection"
-  mas_catalog_version: "{{ .Values.mas_catalog_version }}"
 
 {{- end }}

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-verify.yaml
@@ -503,13 +503,14 @@ spec:
             - -c
             - |
               pip install -r /tmp/tests/requirements.txt
-              pytest -vr --junit-xml=junitxml_test_output.xml --log-file=test_log.txt -o cache_dir=/tmp/__pycache__ /tmp/tests/tests.py 
+              pytest -v --junit-xml=junitxml_test_output.xml --log-file=test_log.txt -o cache_dir=/tmp/__pycache__ /tmp/tests/tests.py 
               if [[ $? -ne 0 ]]; then
                   TEST_PASSED=false
               else
                   TEST_PASSED=true
               fi
 
+              set -e
               echo "Updating $TEST_RECORD_CM configmap with test result"
               oc set data cm $TEST_RECORD_CM test_passed=$TEST_PASSED
               oc set data cm $TEST_RECORD_CM --from-file=junitxml_test_output.xml

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-verify.yaml
@@ -521,6 +521,11 @@ spec:
               oc set data cm $TEST_RECORD_CM --from-file=junitxml_test_output.xml
               oc set data cm $TEST_RECORD_CM --from-file=test_log.txt
 
+              if [[ $TEST_PASSED == "false" ]]; then
+                echo "Test Result failed, exit 1"
+                exit 1
+              fi
+              
       restartPolicy: Never
       serviceAccountName: {{ $sa_name }}
       volumes:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-verify.yaml
@@ -424,7 +424,26 @@ data:
       except KeyError as e:
         assert False, f"Expected status key not found in response from GET /api/ping. Body: {resp_json}"
 
-
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ $record_cm_name }}
+  namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "604"
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+  labels:
+      type: mas-app-verification-record
+{{- if .Values.custom_labels }}
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+immutable: false
+data:
+  mas_app: "visualinspection"
+  mas_catalog_version: "{{ .Values.mas_catalog_version }}"
+  test_passed: "unknown"
 
 ---
 apiVersion: batch/v1
@@ -433,7 +452,7 @@ metadata:
   name: {{ $job_name }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-wave: "604"
+    argocd.argoproj.io/sync-wave: "605"
     argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded,BeforeHookCreation
 {{- if .Values.custom_labels }}
@@ -466,6 +485,8 @@ spec:
               value: "{{ .Values.instance_id }}"
             - name: MAS_WORKSPACE_ID
               value: "{{ .Values.mas_workspace_id }}"
+            - name: TEST_RECORD_CM
+              value: "{{ $record_cm_name }}"
           volumeMounts:
             - name: tests
               mountPath: /tmp/tests
@@ -474,7 +495,17 @@ spec:
             - -c
             - |
               pip install -r /tmp/tests/requirements.txt
-              pytest -o cache_dir=/tmp/__pycache__ /tmp/tests/tests.py
+              pytest -vor cache_dir=/tmp/__pycache__ /tmp/tests/tests.py --junit-xml=junitxml_test_output.xml --log-file=test_log.txt
+              if [[ $? -ne 0 ]]; then
+                  TEST_PASSED=false
+              else
+                  TEST_PASSED=true
+              fi
+
+              echo "Updating $TEST_RECORD_CM configmap with test result"
+              oc set data cm $TEST_RECORD_CM test_passed=$TEST_PASSED
+              oc set data cm $TEST_RECORD_CM --from-file=junitxml_test_output.xml
+              oc set data cm $TEST_RECORD_CM --from-file=test_log.txt
 
       restartPolicy: Never
       serviceAccountName: {{ $sa_name }}
@@ -490,25 +521,5 @@ spec:
             defaultMode: 420
             optional: false
   backoffLimit: 4
-
----
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: {{ $record_cm_name }}
-  namespace: {{ $ns }}
-  annotations:
-    argocd.argoproj.io/sync-wave: "605"
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
-  labels:
-      type: mas-app-verification-record
-{{- if .Values.custom_labels }}
-{{ .Values.custom_labels | toYaml | indent 4 }}
-{{- end }}
-immutable: false
-data:
-  mas_app: "visualinspection"
-  mas_catalog_version: "{{ .Values.mas_catalog_version }}"
 
 {{- end }}

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-verify.yaml
@@ -503,7 +503,7 @@ spec:
             - -c
             - |
               pip install -r /tmp/tests/requirements.txt
-              pytest -v --junit-xml=junitxml_test_output.xml --log-file=test_log.txt -o cache_dir=/tmp/__pycache__ /tmp/tests/tests.py 
+              pytest -v --junit-xml=junitxml_test_output.xml -o cache_dir=/tmp/__pycache__ /tmp/tests/tests.py > test_log.txt
               if [[ $? -ne 0 ]]; then
                   TEST_PASSED=false
               else

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-verify.yaml
@@ -83,6 +83,14 @@ rules:
       - secrets
   - verbs:
       - get
+      - list
+      - patch
+    apiGroups:
+      - ""
+    resources:
+      - configmaps
+  - verbs:
+      - get
     apiGroups:
       - "route.openshift.io"
     resources:
@@ -495,7 +503,7 @@ spec:
             - -c
             - |
               pip install -r /tmp/tests/requirements.txt
-              pytest -vor cache_dir=/tmp/__pycache__ /tmp/tests/tests.py --junit-xml=junitxml_test_output.xml --log-file=test_log.txt
+              pytest -vr --junit-xml=junitxml_test_output.xml --log-file=test_log.txt -o cache_dir=/tmp/__pycache__ /tmp/tests/tests.py 
               if [[ $? -ne 0 ]]; then
                   TEST_PASSED=false
               else

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-verify.yaml
@@ -502,13 +502,18 @@ spec:
             - /bin/sh
             - -c
             - |
+              python -m venv .venv
+              source .venv/bin/activate
               pip install -r /tmp/tests/requirements.txt
-              pytest -v --junit-xml=junitxml_test_output.xml -o cache_dir=/tmp/__pycache__ /tmp/tests/tests.py > test_log.txt
+
+              echo "Running tests..."
+              pytest -v --junit-xml=junitxml_test_output.xml -o cache_dir=/tmp/__pycache__ /tmp/tests/tests.py 2>&1 | tee test_log.txt
               if [[ $? -ne 0 ]]; then
                   TEST_PASSED=false
               else
                   TEST_PASSED=true
               fi
+              echo "Test Result Passed: $TEST_PASSED"
 
               set -e
               echo "Updating $TEST_RECORD_CM configmap with test result"

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-verify.yaml
@@ -506,6 +506,7 @@ spec:
               source .venv/bin/activate
               pip install -r /tmp/tests/requirements.txt
 
+              set -o pipefail
               echo "Running tests..."
               pytest -v --junit-xml=junitxml_test_output.xml -o cache_dir=/tmp/__pycache__ /tmp/tests/tests.py 2>&1 | tee test_log.txt
               if [[ $? -ne 0 ]]; then
@@ -514,7 +515,8 @@ spec:
                   TEST_PASSED=true
               fi
               echo "Test Result Passed: $TEST_PASSED"
-
+              set +o pipefail
+              
               set -e
               echo "Updating $TEST_RECORD_CM configmap with test result"
               oc set data cm $TEST_RECORD_CM test_passed=$TEST_PASSED
@@ -525,7 +527,7 @@ spec:
                 echo "Test Result failed, exit 1"
                 exit 1
               fi
-              
+
       restartPolicy: Never
       serviceAccountName: {{ $sa_name }}
       volumes:


### PR DESCRIPTION
Outputs the log and junitxml log to the test record configmap, so we can see what tests are run and what the output was.

Tested in fvt environment, and the configmap(s) now contains the following:

![image- 2024-11-11 at 09 07 40](https://github.com/user-attachments/assets/3ef05af2-79a5-402f-b40c-ca5b5ae26a03)
