### PR TITLE
[patch] Only check mvi usage when over one hour

### DIFF
--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-sanity.yaml
@@ -151,6 +151,7 @@ data:
     import semver
     import tempfile
     import base64
+    import datetime
 
     # e.g. "dclain-1a"
     mas_instance_id = os.getenv("MAS_INSTANCE_ID")
@@ -175,6 +176,14 @@ data:
         k8s_client = config.new_client_from_config()
       dyn_client = DynamicClient(k8s_client)
       yield dyn_client
+
+    @pytest.fixture(scope="session")
+    def v1_mviworkspace(dyn_client):
+      yield dyn_client.resources.get(api_version='apps.mas.ibm.com/v1', kind='VisualInspectionAppWorkspace')
+
+    @pytest.fixture(scope="session")
+    def mvi_workspace_cr(v1_mviworkspace):
+      yield v1_mviworkspace.get(namespace=mvi_namespace, label_selector=f"mas.ibm.com/instanceId={mas_instance_id}, mas.ibm.com/workspaceId={mas_workspace_id}").items[0]
 
     @pytest.fixture(scope="session")
     def v1_pods(dyn_client):
@@ -284,9 +293,14 @@ data:
         assert False, "Expected data.dnn-apikey field not present in secret {mvi_apikey_secret_name} in {mvi_namespace}"
       yield base64.b64decode(dnn_apikey_b64)
 
-    def test_usage_reporter(get_usage_pod):
+    def test_usage_reporter(mvi_workspace_cr, get_usage_pod):
       print("Test usage reporter")
-      assert get_usage_pod.items[0].status['phase'] == 'Succeeded'
+      mvi_create_time = mvi_workspace_cr['metadata']['creationTimestamp']
+      current_time = datetime.now().strftime('%Y-%m-%dT%H:%M:%SZ')
+      if (current_time - mvi_create_time).total_seconds() > 3600:
+        assert get_usage_pod.items[0].status['phase'] == 'Succeeded'
+      else:
+        print("MVI CR created only recently")
 
     def test_bgtasks_api(mvi_host, mvi_host_ca_filepath, mvi_apikey):
       resp = requests.get(

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-sanity.yaml
@@ -299,12 +299,12 @@ data:
         assert False, "Expected data.dnn-apikey field not present in secret {mvi_apikey_secret_name} in {mvi_namespace}"
       yield base64.b64decode(dnn_apikey_b64)
 
-    def test_usage_reporter(mvi_workspace_cr, get_usage_pod):
+    def test_usage_reporter(mvi_workspace_cr, v1_pods):
       print("Test usage reporter")
       mvi_create_time = mvi_workspace_cr['metadata']['creationTimestamp']
       current_time = datetime.now().strftime('%Y-%m-%dT%H:%M:%SZ')
       if (current_time - mvi_create_time).total_seconds() > 3600:
-        assert get_usage_pod.items[0].status['phase'] == 'Succeeded'
+        assert get_usage_pod(v1_pods).items[0].status['phase'] == 'Succeeded'
       else:
         print("MVI CR created only recently")
 

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-sanity.yaml
@@ -195,12 +195,6 @@ data:
     def v1_pods(dyn_client):
       yield dyn_client.resources.get(api_version='v1', kind='Pod')
 
-    def get_usage_pod(v1_pods):
-        usage_pod = v1_pods.get(label_selector="app.kubernetes.io/name=usage-hourly-job", namespace=mvi_namespace)
-        if not usage_pod.items:
-            assert False, f"Could not find any usage-hourly-job in {mvi_namespace}"
-        yield usage_pod
-
     @pytest.fixture(scope="session")
     def v1_secrets(dyn_client):
       yield dyn_client.resources.get(api_version='v1', kind='Secret')
@@ -297,6 +291,12 @@ data:
       except:
         assert False, "Expected data.dnn-apikey field not present in secret {mvi_apikey_secret_name} in {mvi_namespace}"
       yield base64.b64decode(dnn_apikey_b64)
+
+    def get_usage_pod(v1_pods):
+        usage_pod = v1_pods.get(label_selector="app.kubernetes.io/name=usage-hourly-job", namespace=mvi_namespace)
+        if not usage_pod.items:
+            assert False, f"Could not find any usage-hourly-job in {mvi_namespace}"
+        return usage_pod
 
     def test_usage_reporter(mvi_workspace_cr, v1_pods):
       print("Test usage reporter")

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-sanity.yaml
@@ -195,7 +195,6 @@ data:
     def v1_pods(dyn_client):
       yield dyn_client.resources.get(api_version='v1', kind='Pod')
 
-    @pytest.fixture(scope="session")
     def get_usage_pod(v1_pods):
         usage_pod = v1_pods.get(label_selector="app.kubernetes.io/name=usage-hourly-job", namespace=mvi_namespace)
         if not usage_pod.items:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-sanity.yaml
@@ -93,7 +93,13 @@ rules:
       - ""
     resources:
       - configmaps
-
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - "apps.mas.ibm.com"
+    resources:
+      - visualinspectionappworkspaces
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-sanity.yaml
@@ -157,7 +157,7 @@ data:
     import semver
     import tempfile
     import base64
-    import datetime
+    from datetime import datetime
 
     # e.g. "dclain-1a"
     mas_instance_id = os.getenv("MAS_INSTANCE_ID")

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-sanity.yaml
@@ -301,8 +301,8 @@ data:
 
     def test_usage_reporter(mvi_workspace_cr, v1_pods):
       print("Test usage reporter")
-      mvi_create_time = mvi_workspace_cr['metadata']['creationTimestamp']
-      current_time = datetime.now().strftime('%Y-%m-%dT%H:%M:%SZ')
+      mvi_create_time = datetime.strptime(mvi_workspace_cr['metadata']['creationTimestamp'], '%Y-%m-%dT%H:%M:%SZ')
+      current_time = datetime.now()
       if (current_time - mvi_create_time).total_seconds() > 3600:
         assert get_usage_pod(v1_pods).items[0].status['phase'] == 'Succeeded'
       else:


### PR DESCRIPTION
If the MVI CR is only just created then the usage job won't be present. Only run this test when it is more than one hour after the CR creation.