### PR TITLE
[minor] Add Selenium grid to cluster app

### DIFF
--- a/root-applications/ibm-mas-account-root/templates/000-cluster-appset.yaml
+++ b/root-applications/ibm-mas-account-root/templates/000-cluster-appset.yaml
@@ -62,6 +62,11 @@ spec:
               revision: "{{ .Values.generator.revision }}"
               files:
               - path: "{{ .Values.account.id }}/*/cluster-promotion.yaml"
+          - git:
+              repoURL: "{{ .Values.generator.repo_url }}"
+              revision: "{{ .Values.generator.revision }}"
+              files:
+              - path: "{{ .Values.account.id }}/*/selenium-grid.yaml"
   syncPolicy:
     applicationsSync: "{{- if .Values.auto_delete }}sync{{- else }}create-update{{- end }}"
   template:

--- a/root-applications/ibm-mas-cluster-root/templates/060-selenium-grid.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/060-selenium-grid.yaml
@@ -28,7 +28,7 @@ spec:
     repoURL: https://www.selenium.dev/docker-selenium
     targetRevision: 0.36.1
     helm:
-      releaseName: selenium-grid
+      releaseName: selenium-grid.{{ .Values.cluster.id }}
       values: |
         hub:
           imageTag: 4.19.1-20240402

--- a/root-applications/ibm-mas-cluster-root/templates/060-selenium-grid.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/060-selenium-grid.yaml
@@ -22,7 +22,7 @@ spec:
   project: "{{ .Values.argo.projects.apps }}"
   destination:
     server: {{ .Values.cluster.url }}
-    namespace: {{ .Values.selenium_grid.selenium_namespace }}
+    namespace: default
   source:
     chart: selenium-grid
     repoURL: https://www.selenium.dev/docker-selenium

--- a/root-applications/ibm-mas-cluster-root/templates/060-selenium-grid.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/060-selenium-grid.yaml
@@ -22,7 +22,7 @@ spec:
   project: "{{ .Values.argo.projects.apps }}"
   destination:
     server: {{ .Values.cluster.url }}
-    namespace: {{ .Values.selenium_grid.gpu_namespace }}
+    namespace: {{ .Values.selenium_grid.namespace }}
   source:
     chart: selenium-grid
     repoURL: https://www.selenium.dev/docker-selenium

--- a/root-applications/ibm-mas-cluster-root/templates/060-selenium-grid.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/060-selenium-grid.yaml
@@ -1,0 +1,69 @@
+# {{- if not (empty .Values.selenium_grid) }}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: selenium-grid.{{ .Values.cluster.id }}
+  namespace: {{ .Values.argo.namespace }}
+  labels:
+    environment: '{{ .Values.account.id }}'
+    region: '{{ .Values.region.id }}'
+    cluster: '{{ .Values.cluster.id }}'
+  annotations:
+    argocd.argoproj.io/sync-wave: "060"
+    healthCheckTimeout: "1800"
+    {{- if and .Values.notifications .Values.notifications.slack_channel_id }}
+    notifications.argoproj.io/subscribe.on-sync-failed.workspace1: {{ .Values.notifications.slack_channel_id }}
+    notifications.argoproj.io/subscribe.on-sync-succeeded.workspace1: {{ .Values.notifications.slack_channel_id }}
+    {{- end }}
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: "{{ .Values.argo.projects.apps }}"
+  destination:
+    server: {{ .Values.cluster.url }}
+    namespace: {{ .Values.selenium_grid.selenium_namespace }}
+  source:
+    chart: selenium-grid
+    repoURL: https://www.selenium.dev/docker-selenium
+    helm:
+      releaseName: selenium-grid
+      values: |
+        hub:
+          imageTag: 4.19.1-20240402
+        chromeNode:
+          imageTag: 4.19.1-20240402
+          resources:
+            requests:
+              cpu: "0.1"
+        firefoxNode:
+          enabled: false
+        edgeNode:
+          enabled: false
+        autoscaling:
+          enabled: true
+          scalingType: job
+          scaledOptions:
+            maxReplicaCount: 999
+          scaledJobOptions:
+            scalingStrategy:
+              strategy: default
+        ingress:
+          hostname: selenium-grid.local
+          path: /selenium
+  syncPolicy:
+    automated:
+      {{- if .Values.auto_delete }}
+      prune: true
+      {{- end }}
+      selfHeal: true
+    retry:
+      limit: 20
+    syncOptions:
+      - CreateNamespace=true
+    managedNamespaceMetadata:
+      labels:
+{{- if .Values.custom_labels }}
+{{ .Values.custom_labels | toYaml | indent 8 }}
+{{- end }}
+# {{- end }}

--- a/root-applications/ibm-mas-cluster-root/templates/060-selenium-grid.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/060-selenium-grid.yaml
@@ -26,6 +26,7 @@ spec:
   source:
     chart: selenium-grid
     repoURL: https://www.selenium.dev/docker-selenium
+    targetRevision: 0.36.1
     helm:
       releaseName: selenium-grid
       values: |

--- a/root-applications/ibm-mas-cluster-root/templates/060-selenium-grid.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/060-selenium-grid.yaml
@@ -1,4 +1,4 @@
-# {{- if not (empty .Values.selenium_grid) }}
+{{- if not (empty .Values.selenium_grid) }}
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
@@ -22,7 +22,7 @@ spec:
   project: "{{ .Values.argo.projects.apps }}"
   destination:
     server: {{ .Values.cluster.url }}
-    namespace: default
+    namespace: {{ .Values.selenium_grid.gpu_namespace }}
   source:
     chart: selenium-grid
     repoURL: https://www.selenium.dev/docker-selenium
@@ -67,4 +67,4 @@ spec:
 {{- if .Values.custom_labels }}
 {{ .Values.custom_labels | toYaml | indent 8 }}
 {{- end }}
-# {{- end }}
+{{- end }}

--- a/root-applications/ibm-mas-cluster-root/templates/060-selenium-grid.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/060-selenium-grid.yaml
@@ -26,32 +26,12 @@ spec:
   source:
     chart: selenium-grid
     repoURL: https://www.selenium.dev/docker-selenium
-    targetRevision: 0.36.1
+    targetRevision: {{ .Values.selenium_grid.version }}
     helm:
       releaseName: selenium-grid.{{ .Values.cluster.id }}
       values: |
-        hub:
-          imageTag: 4.19.1-20240402
-        chromeNode:
-          imageTag: 4.19.1-20240402
-          resources:
-            requests:
-              cpu: "0.1"
-        firefoxNode:
-          enabled: false
-        edgeNode:
-          enabled: false
-        autoscaling:
-          enabled: true
-          scalingType: job
-          scaledOptions:
-            maxReplicaCount: 999
-          scaledJobOptions:
-            scalingStrategy:
-              strategy: default
-        ingress:
-          hostname: selenium-grid.local
-          path: /selenium
+{{ .Values.selenium_grid.values | indent 8 }}
+
   syncPolicy:
     automated:
       {{- if .Values.auto_delete }}


### PR DESCRIPTION
Adds the seleium grid by using the public selenium helm chart.

This will be used for running any sanity tests that require a selenium grid install and also in FVT to replace the one installed via ansible-fvt.

I tested this in fvtsaas but failed to get screenshots before it was deprovisioned.