### PR TITLE
[minor] Add config pod templates

### DIFF
--- a/instance-applications/130-ibm-mas-bas-config/templates/03-ibm-mas_BasCfg.yaml
+++ b/instance-applications/130-ibm-mas-bas-config/templates/03-ibm-mas_BasCfg.yaml
@@ -15,6 +15,10 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   displayName: DRO {{ .Values.instance_id }}
+{{- if not (empty .Values.mas_bascfg_pod_templates) }}
+  podTemplates:
+{{ .Values.mas_bascfg_pod_templates | toYaml | indent 4 }}
+{{- end }}
   config:
     url: "{{ .Values.dro_endpoint_url }}"
     contact:

--- a/instance-applications/130-ibm-mas-sls-config/templates/05-ibm-mas_SlsCfg.yaml
+++ b/instance-applications/130-ibm-mas-sls-config/templates/05-ibm-mas_SlsCfg.yaml
@@ -15,6 +15,10 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   displayName: SLS
+{{- if not (empty .Values.mas_slscfg_pod_templates) }}
+  podTemplates:
+{{ .Values.mas_slscfg_pod_templates | toYaml | indent 4 }}
+{{- end }}
   config:
     url: "{{ .Values.url }}"
     credentials:

--- a/instance-applications/130-ibm-mas-smtp-config/templates/02-ibm-mas_SmtpCfg.yaml
+++ b/instance-applications/130-ibm-mas-smtp-config/templates/02-ibm-mas_SmtpCfg.yaml
@@ -15,6 +15,10 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   displayName: "{{ .Values.suite_smtp_display_name }}"
+{{- if not (empty .Values.mas_smtpcfg_pod_templates) }}
+  podTemplates:
+{{ .Values.mas_smtpcfg_pod_templates | toYaml | indent 4 }}
+{{- end }}
   config:
     hostname: {{ .Values.suite_smtp_host }}
     port: {{ .Values.suite_smtp_port }}


### PR DESCRIPTION
Takes https://github.com/ibm-mas/cli/pull/1346 and allows the configured pod templates for bascfg, smtpcfg and slscfg to be set on the corrresponding CRs.

Tested in dev env