### PR TITLE
[patch] fix selenium-grid app template

### DIFF
--- a/root-applications/ibm-mas-cluster-root/templates/060-selenium-grid.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/060-selenium-grid.yaml
@@ -30,7 +30,7 @@ spec:
     helm:
       releaseName: selenium-grid.{{ .Values.cluster.id }}
       values: |
-{{ .Values.selenium_grid.values | indent 8 }}
+{{ .Values.selenium_grid.values | toYaml | indent 8 }}
 
   syncPolicy:
     automated:


### PR DESCRIPTION
Fixes issue seen in fvtsaas:

```
Error: template: ibm-mas-cluster-root/templates/060-selenium-grid.yaml:33:41: executing "ibm-mas-cluster-root/templates/060-selenium-grid.yaml" at <8>: wrong type for value; expected string; got map[string]interface {}
```