### PR TITLE
[patch] Make seleniumgrid serversideapply

### DIFF
--- a/root-applications/ibm-mas-cluster-root/templates/060-selenium-grid.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/060-selenium-grid.yaml
@@ -42,6 +42,7 @@ spec:
       limit: 20
     syncOptions:
       - CreateNamespace=true
+      - ServerSideApply=true
     managedNamespaceMetadata:
       labels:
 {{- if .Values.custom_labels }}


### PR DESCRIPTION
Set the sync option as  - ServerSideApply=true for SeleniumGrid as the CRD it needs to install is too large to be used with the default client-side apply