### PR TITLE
[patch] change ibmcpd sync wave

### DIFF
--- a/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_Ibmcpd.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_Ibmcpd.yaml
@@ -5,7 +5,7 @@ metadata:
   name: "{{ .Values.cpd_platform_cr_name }}"
   namespace: "{{ .Values.cpd_instance_namespace }}"
   annotations:
-    argocd.argoproj.io/sync-wave: "088"
+    argocd.argoproj.io/sync-wave: "087"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 {{- if .Values.custom_labels }}
   labels:


### PR DESCRIPTION
Zen patch job is running before Ibmcpd even though they are in the same sync wave and this is causing cp4d to fail or run longer than intended. Since the job depends on ibmcpd, we need to run ibmcpd before the job to solve the problem. 
This is a temporary fix until we find a better approach.