### PR TITLE
[patch] Set releasename for seleniumgrid

### DIFF
--- a/root-applications/ibm-mas-cluster-root/templates/060-selenium-grid.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/060-selenium-grid.yaml
@@ -28,7 +28,7 @@ spec:
     repoURL: https://www.selenium.dev/docker-selenium
     targetRevision: {{ .Values.selenium_grid.version }}
     helm:
-      releaseName: selenium-grid.{{ .Values.cluster.id }}
+      releaseName: selenium-grid
       values: |
 {{ .Values.selenium_grid.values | toYaml | indent 8 }}
 


### PR DESCRIPTION
The seleniumgrid release should just be selenium-grid as this controls what the servicename/route is called