### PR TITLE
[patch] Add instance id to instance level reporters

### DIFF
--- a/root-applications/ibm-mas-instance-root/templates/000-ibm-sync-resources.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/000-ibm-sync-resources.yaml
@@ -84,7 +84,7 @@ spec:
             {{- end }}
 
             junitreporter:
-              reporter_name: "ibm-sync-resources"
+              reporter_name: "ibm-sync-resources-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"

--- a/root-applications/ibm-mas-instance-root/templates/010-ibm-sync-jobs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/010-ibm-sync-jobs.yaml
@@ -91,7 +91,7 @@ spec:
             {{- end }}
 
             junitreporter:
-              reporter_name: "ibm-sync-jobs"
+              reporter_name: "ibm-sync-jobs-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"

--- a/root-applications/ibm-mas-instance-root/templates/100-ibm-sls-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/100-ibm-sls-app.yaml
@@ -59,7 +59,7 @@ spec:
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}
             junitreporter:
-              reporter_name: "ibm-sls"
+              reporter_name: "ibm-sls-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"

--- a/root-applications/ibm-mas-instance-root/templates/110-ibm-cp4d-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/110-ibm-cp4d-app.yaml
@@ -97,7 +97,7 @@ spec:
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}
             junitreporter:
-              reporter_name: "ibm-cp4d"
+              reporter_name: "ibm-cp4d-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"

--- a/root-applications/ibm-mas-instance-root/templates/110-ibm-cp4d-operator-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/110-ibm-cp4d-operator-app.yaml
@@ -89,7 +89,7 @@ spec:
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}
             junitreporter:
-              reporter_name: "ibm-cp4d-operator"
+              reporter_name: "ibm-cp4d-operator-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"

--- a/root-applications/ibm-mas-instance-root/templates/110-ibm-cs-control-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/110-ibm-cs-control-app.yaml
@@ -88,7 +88,7 @@ spec:
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}
             junitreporter:
-              reporter_name: "ibm-cs-control"
+              reporter_name: "ibm-cs-control-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"

--- a/root-applications/ibm-mas-instance-root/templates/110-ibm-db2u-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/110-ibm-db2u-app.yaml
@@ -43,7 +43,7 @@ spec:
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}
             junitreporter:
-              reporter_name: "ibm-db2u"
+              reporter_name: "ibm-db2u-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"

--- a/root-applications/ibm-mas-instance-root/templates/120-ibm-aiopenscale-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-ibm-aiopenscale-app.yaml
@@ -47,7 +47,7 @@ spec:
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}
             junitreporter:
-              reporter_name: "ibm-aiopenscale"
+              reporter_name: "ibm-aiopenscale-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"

--- a/root-applications/ibm-mas-instance-root/templates/120-ibm-spark-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-ibm-spark-app.yaml
@@ -51,7 +51,7 @@ spec:
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}
             junitreporter:
-              reporter_name: "ibm-spark"
+              reporter_name: "ibm-spark-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"

--- a/root-applications/ibm-mas-instance-root/templates/120-ibm-spss-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-ibm-spss-app.yaml
@@ -55,7 +55,7 @@ spec:
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}
             junitreporter:
-              reporter_name: "ibm-spss"
+              reporter_name: "ibm-spss-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"

--- a/root-applications/ibm-mas-instance-root/templates/120-ibm-wml-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-ibm-wml-app.yaml
@@ -52,7 +52,7 @@ spec:
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}
             junitreporter:
-              reporter_name: "ibm-wml"
+              reporter_name: "ibm-wml-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"

--- a/root-applications/ibm-mas-instance-root/templates/120-ibm-wsl-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-ibm-wsl-app.yaml
@@ -55,7 +55,7 @@ spec:
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}
             junitreporter:
-              reporter_name: "ibm-wsl"
+              reporter_name: "ibm-wsl-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"

--- a/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-app.yaml
@@ -113,7 +113,7 @@ spec:
             {{- end }}
 
             junitreporter:
-              reporter_name: "ibm-mas-suite"
+              reporter_name: "ibm-mas-suite-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"

--- a/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-configs-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-configs-app.yaml
@@ -55,7 +55,7 @@ spec:
             {{- end }}
             {{ $value | toYaml | nindent 12 }}
             junitreporter:
-              reporter_name: "{{ $value.mas_config_chart }}"
+              reporter_name: "{{ $value.mas_config_chart }}-{{ $.Values.instance.id }}"
               cluster_id: "{{ $.Values.cluster.id }}"
               devops_mongo_uri: "{{ $.Values.devops.mongo_uri }}"
               devops_build_number: "{{ $.Values.devops.build_number }}"

--- a/root-applications/ibm-mas-instance-root/templates/200-ibm-mas-workspaces.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/200-ibm-mas-workspaces.yaml
@@ -46,7 +46,7 @@ spec:
             custom_labels: {{ $.Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}
             junitreporter:
-              reporter_name: "ibm-mas-workspace-{{ $value.mas_workspace_id }}"
+              reporter_name: "ibm-mas-ws-{{ $.Values.instance.id }}-{{ $value.mas_workspace_id }}"
               cluster_id: "{{ $.Values.cluster.id }}"
               devops_mongo_uri: "{{ $.Values.devops.mongo_uri }}"
               devops_build_number: "{{ $.Values.devops.build_number }}"

--- a/root-applications/ibm-mas-instance-root/templates/500-ibm-mas-masapp-manage-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/500-ibm-mas-masapp-manage-install.yaml
@@ -61,7 +61,7 @@ spec:
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}
             junitreporter:
-              reporter_name: "ibm-mas-suite-app-install-manage"
+              reporter_name: "app-install-manage-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"

--- a/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
@@ -94,7 +94,7 @@ spec:
             {{- end }}
 
             junitreporter:
-              reporter_name: "ibm-mas-suite-app-config-{{ $value.mas_app_id }}"
+              reporter_name: "app-config-{{ $value.mas_app_id }}-{{ $.Values.instance.id }}"
               cluster_id: "{{ $.Values.cluster.id }}"
               devops_mongo_uri: "{{ $.Values.devops.mongo_uri }}"
               devops_build_number: "{{ $.Values.devops.build_number }}"

--- a/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-assist-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-assist-install.yaml
@@ -60,7 +60,7 @@ spec:
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}
             junitreporter:
-              reporter_name: "ibm-mas-suite-app-install-assist"
+              reporter_name: "app-install-assist-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"

--- a/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-iot-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-iot-install.yaml
@@ -61,7 +61,7 @@ spec:
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}
             junitreporter:
-              reporter_name: "ibm-mas-suite-app-install-iot"
+              reporter_name: "app-install-iot-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"

--- a/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-visualinspection-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-visualinspection-install.yaml
@@ -65,7 +65,7 @@ spec:
             storage_class_definitions: {{ .Values.ibm_suite_app_visualinspection_install.storage_class_definitions | toYaml | nindent 14 }}
             {{- end }}
             junitreporter: 
-              reporter_name: "ibm-mas-suite-app-install-mvi"
+              reporter_name: "app-install-mvi-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"

--- a/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-health-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-health-install.yaml
@@ -61,7 +61,7 @@ spec:
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}
             junitreporter:
-              reporter_name: "ibm-mas-suite-app-install-health"
+              reporter_name: "app-install-health-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"

--- a/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-monitor-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-monitor-install.yaml
@@ -61,7 +61,7 @@ spec:
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}
             junitreporter:
-              reporter_name: "ibm-mas-suite-app-install-monitor"
+              reporter_name: "app-install-monitor-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"

--- a/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-optimizer-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-optimizer-install.yaml
@@ -61,7 +61,7 @@ spec:
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}
             junitreporter:
-              reporter_name: "ibm-mas-suite-app-install-optimizer"
+              reporter_name: "app-install-optimizer-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"

--- a/root-applications/ibm-mas-instance-root/templates/540-ibm-mas-masapp-predict-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/540-ibm-mas-masapp-predict-install.yaml
@@ -61,7 +61,7 @@ spec:
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}
             junitreporter:
-              reporter_name: "ibm-mas-suite-app-install-predict"
+              reporter_name: "app-install-predict-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"


### PR DESCRIPTION
When deploying multiple instances on the same cluster a warning was occurring as argo was trying to control the same reporter resources. These only appear when an app is syncing so you need the same apps for different instances synching at the same time.

Appended the instance id to the reporter name which is used as the prefix for the resources. Shorted the start of the app-install and app-config by 15 chars so we can fit it in.

Tested in mulit instance env