### PR TITLE
[patch] Add guard around no archivelogs

### DIFF
--- a/instance-applications/120-ibm-db2u-database/templates/03-db2uinstance.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/03-db2uinstance.yaml
@@ -150,6 +150,7 @@ spec:
             storage: "{{ .Values.db2_audit_logs_storage_size }}"
         storageClassName: "{{ .Values.db2_audit_logs_storage_class }}"
 {{- end }}
+{{- if .Values.db2_archivelogs_storage_class }}
     - name: archivelogs
       type: create
       spec:
@@ -159,3 +160,4 @@ spec:
         resources:
           requests:
             storage: "{{ .Values.db2_archivelogs_storage_size }}"
+{{- end }}


### PR DESCRIPTION
Add a guard around db2 archivelogs if the storage class is not set as it is optional