### PR TITLE
[patch] Only call db2apply when there is a change needed

### DIFF
--- a/instance-applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
@@ -207,6 +207,12 @@ spec:
                 RETRIES=${1:-5}
                 RETRY_DELAY_SECONDS=${2:-30}
 
+                mas-devops-db2-validate-config --mas-instance-id ${MAS_INSTANCE_ID} --mas-app-id ${MAS_APP_ID} --log-level DEBUG || rc=$?
+                if [[ "$rc" == "0" ]]; then
+                  echo "... db2 config already matches expected config, returning without calling apply-db2cfg-settings"
+                  return 0
+                fi
+
                 for (( c=1; c<="${RETRIES}"; c++ )); do
                   echo ""
                   echo "... attempt ${c} of ${RETRIES}"

--- a/instance-applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/05-postsync-setup-db2_Job.yaml
@@ -102,7 +102,7 @@ kind: Job
 metadata:
   # Suffix the Job name with a hash of all chart values
   # This is to ensure that ArgoCD will delete and recreate the job if (and only if) anything changes in the DB2 config
-  name: postsync-setup-db2-{{ .Values.db2_instance_name }}-v4-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
+  name: postsync-setup-db2-{{ .Values.db2_instance_name }}-v5-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
   namespace: "{{ .Values.db2_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "129"


### PR DESCRIPTION
When a value changes in the db2-db chart then we create a new postsync-setiup job. If that value is not related to a db config i.e. the db2 tls_version or even just a new version, then we always call the db2-apply script even if there is nothing to change. The db2apply script always restarts db2.

The check is to run the validate-config first and only if we detect some db2 config is not set then we should call apply (and then recheck)

Tested with the changes (the line `... db2 config already matches expected config, returning without calling apply-db2cfg-settings` is the new change):
```
Calling apply-db2cfg-settings.sh file on c-db2wh-inst1-manage-db2u-0
================================================================================
Loaded in-cluster configuration
DEBUG:mas.devops.db2:Getting Db2uInstance CR db2wh-inst1-manage in db2u-inst1
INFO:mas.devops.db2:Checking db cfg for BLUDB
================================================================
DEBUG:mas.devops.db2:db2 db BLUDB cfg output:
...
...
INFO:mas.devops.db2:All checks passed
... db2 config already matches expected config, returning without calling apply-db2cfg-settings
================================================================================
Invoke Suite DB2 Backup
================================================================================
Create /tmp/backupdb.sh
--------------------------------------------------------------------------------
Copy /tmp/backupdb.sh to db2u-inst1/c-db2wh-inst1-manage-db2u-0
--------------------------------------------------------------------------------
Executing /tmp/backupdb.sh file on db2u-inst1/c-db2wh-inst1-manage-db2u-0
--------------------------------------------------------------------------------
Defaulted container "db2u" out of: db2u, instdb (init), init-labels (init), init-kernel (init)
backupdb.sh: Database connect not returning SQL1116N, nothing to do, exit now
```

No restarts of DB2 seen