### PR TITLE
[minor] gitops: automated configtool oidc registration

### DIFF
--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-configtool-oidc.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-configtool-oidc.yaml
@@ -157,7 +157,7 @@ spec:
                 mas configtool-oidc \
                   unregister \
                   --mas-home "x.home.${DOMAIN}" \
-                  --ui-prefix "${TRUST_UI_PREFIX}"
+                  --ui-prefix "not_used_but_must_be_set"
               fi
 
               

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-configtool-oidc.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-configtool-oidc.yaml
@@ -102,7 +102,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:13.1.0-pre.mascore3763-amd64
+          image: quay.io/ibmmas/cli:latest
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-configtool-oidc.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-configtool-oidc.yaml
@@ -102,7 +102,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:latest
+          image: quay.io/ibmmas/cli:13.1.0-pre.mascore3763-amd64
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-configtool-oidc.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-configtool-oidc.yaml
@@ -1,0 +1,156 @@
+{{- if .Values.ingress }}
+
+{{ $ns :=                 printf "mas-%s-core" .Values.instance_id }}
+{{ $np_name :=            "postsync-configtool-oidc-np" }}
+{{ $role_name :=          "postsync-configtool-oidc-r" }}
+{{ $sa_name :=            "postsync-configtool-oidc-sa" }}
+{{ $rb_name :=            "postsync-configtool-oidc-rb" }}
+{{ $job_label :=          "postsync-configtool-oidc-job" }}
+{{ $oauth_admin_secret := printf "%s-credentials-oauth-admin" .Values.instance_id }}
+
+---
+# Permit outbound communication by the Job pods
+# (Needed to communicate with the K8S HTTP API and AWS SM)
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ $np_name }}
+  namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "140"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $job_label }}
+  egress:
+    - {}
+  policyTypes:
+    - Egress
+
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $sa_name }}
+  namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "140"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ $role_name }}
+  namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "140"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+rules: []
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ $rb_name }}
+  namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "141"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $sa_name }}
+    namespace: {{ $ns }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $role_name }}
+
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $job_label }}-v1-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
+  namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "142"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ $job_label }}
+{{- if .Values.custom_labels }}
+{{ .Values.custom_labels | toYaml | indent 8 }}
+{{- end }}
+    spec:
+      containers:
+        - name: run
+          image: quay.io/ibmmas/cli:latest
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 10m
+              memory: 64Mi
+          env:
+            # .Values.DOMAIN:
+            #   dns.cis.subdomain (if set) - e.g. fvtsaas.ibmmasfvt.com
+            #   mas_instance.domain (otherwise) - e.g. mascore3763.apps.noble6.cp.fyre.ibm.com
+            - name: DOMAIN
+              value: {{ .Values.domain }}
+
+            - name: TRUST_UI_PREFIX
+              value: mas-{{ .Values.instance_id }}-core
+
+            - name: OAUTH_ADMIN_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: oauth-admin-username
+                  key: {{ $oauth_admin_secret }}
+            - name: OAUTH_ADMIN_PWD
+              valueFrom:
+                secretKeyRef:
+                  name: oauth-admin-password
+                  key: {{ $oauth_admin_secret }}
+            - name: SM_AWS_ACCESS_KEY_ID
+          command:
+            - /bin/sh
+            - -c
+            - |
+
+              set -e
+
+              # NOTE: "x" is used as workspace ID. This is just so the MAS_HOME parameter conforms to the format expected by the 
+              # configtool-oidc script. This is not a workspace-level operation. Its actual value is not used for anything else.
+              mas configtool-oidc \
+                register \
+                --mas-home "x.home.${DOMAIN}" \
+                --ui-prefix "${TRUST_UI_PREFIX}"
+              
+      restartPolicy: Never
+      serviceAccountName: "{{ $sa_name }}"
+  backoffLimit: 4
+
+{{- end }}
+

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-configtool-oidc.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-configtool-oidc.yaml
@@ -119,8 +119,8 @@ spec:
               value: {{ .Values.domain }}
 
             - name: OIDC_CONFIG_YAML
-              value: |-
-                {{ .Values.oidc | toYaml | nindent 16 }}
+              value: {{ .Values.oidc | toYaml | nindent 16 | replace "\n" "\\n" }}
+                
 
             - name: OAUTH_ADMIN_USERNAME
               valueFrom:

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-configtool-oidc.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-configtool-oidc.yaml
@@ -1,5 +1,3 @@
-{{- if .Values.ingress }}
-
 {{ $ns :=                 printf "mas-%s-core" .Values.instance_id }}
 {{ $np_name :=            "postsync-configtool-oidc-np" }}
 {{ $role_name :=          "postsync-configtool-oidc-r" }}
@@ -120,8 +118,8 @@ spec:
             - name: DOMAIN
               value: {{ .Values.domain }}
 
-            - name: TRUST_UI_PREFIX
-              value: mas-{{ .Values.instance_id }}-core
+            - name: OIDC_CONFIG_YAML
+              value: {{ .Values.oidc }}
 
             - name: OAUTH_ADMIN_USERNAME
               valueFrom:
@@ -141,16 +139,16 @@ spec:
 
               set -e
 
+              echo ${OIDC_CONFIG_YAML}
+
               # NOTE: "x" is used as workspace ID. This is just so the MAS_HOME parameter conforms to the format expected by the 
               # configtool-oidc script. This is not a workspace-level operation. Its actual value is not used for anything else.
-              mas configtool-oidc \
-                register \
-                --mas-home "x.home.${DOMAIN}" \
-                --ui-prefix "${TRUST_UI_PREFIX}"
+              # mas configtool-oidc \
+              #   register \
+              #   --mas-home "x.home.${DOMAIN}" \
+              #   --ui-prefix "${TRUST_UI_PREFIX}"
               
       restartPolicy: Never
       serviceAccountName: "{{ $sa_name }}"
   backoffLimit: 4
-
-{{- end }}
 

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-configtool-oidc.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-configtool-oidc.yaml
@@ -140,7 +140,7 @@ spec:
 
               set -e
 
-              echo ${OIDC_CONFIG_YAML}
+              echo "${OIDC_CONFIG_YAML}"
 
               # NOTE: "x" is used as workspace ID. This is just so the MAS_HOME parameter conforms to the format expected by the 
               # configtool-oidc script. This is not a workspace-level operation. Its actual value is not used for anything else.

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-configtool-oidc.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-configtool-oidc.yaml
@@ -131,7 +131,7 @@ spec:
                 secretKeyRef:
                   name: {{ $oauth_admin_secret }}
                   key: oauth-admin-password
-            - name: SM_AWS_ACCESS_KEY_ID
+            
           command:
             - /bin/sh
             - -c

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-configtool-oidc.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-configtool-oidc.yaml
@@ -119,7 +119,7 @@ spec:
               value: {{ .Values.domain }}
 
             - name: OIDC_CONFIG_YAML
-              value: {{ .Values.oidc | toYaml | nindent 16 | replace "\n" "\\n" }}
+              value: {{ .Values.oidc | toYaml | replace "\n" "\\n" }}
                 
 
             - name: OAUTH_ADMIN_USERNAME
@@ -140,7 +140,7 @@ spec:
 
               set -e
 
-              echo "${OIDC_CONFIG_YAML}"
+              echo -e "${OIDC_CONFIG_YAML}"
 
               # NOTE: "x" is used as workspace ID. This is just so the MAS_HOME parameter conforms to the format expected by the 
               # configtool-oidc script. This is not a workspace-level operation. Its actual value is not used for anything else.

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-configtool-oidc.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-configtool-oidc.yaml
@@ -119,19 +119,19 @@ spec:
               value: {{ .Values.domain }}
 
             - name: OIDC_CONFIG_YAML
-              value: |
+              value: |-
                 {{ .Values.oidc | toYaml | nindent 16 }}
 
             - name: OAUTH_ADMIN_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: oauth-admin-username
-                  key: {{ $oauth_admin_secret }}
+                  name: {{ $oauth_admin_secret }}
+                  key: oauth-admin-username
             - name: OAUTH_ADMIN_PWD
               valueFrom:
                 secretKeyRef:
-                  name: oauth-admin-password
-                  key: {{ $oauth_admin_secret }}
+                  name: {{ $oauth_admin_secret }}
+                  key: oauth-admin-password
             - name: SM_AWS_ACCESS_KEY_ID
           command:
             - /bin/sh

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-configtool-oidc.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-configtool-oidc.yaml
@@ -43,7 +43,7 @@ metadata:
 {{ .Values.custom_labels | toYaml | indent 4 }}
 {{- end }}
 
-
+---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -119,7 +119,8 @@ spec:
               value: {{ .Values.domain }}
 
             - name: OIDC_CONFIG_YAML
-              value: {{ .Values.oidc }}
+              value: |
+                {{ .Values.oidc | toYaml | nindent 16 }}
 
             - name: OAUTH_ADMIN_USERNAME
               valueFrom:

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-configtool-oidc.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-configtool-oidc.yaml
@@ -121,7 +121,6 @@ spec:
             - name: OIDC_CONFIG_YAML
               value: {{ .Values.oidc | toYaml | replace "\n" "\\n" }}
                 
-
             - name: OAUTH_ADMIN_USERNAME
               valueFrom:
                 secretKeyRef:
@@ -140,14 +139,27 @@ spec:
 
               set -e
 
-              echo -e "${OIDC_CONFIG_YAML}"
+              if $(echo -e "${OIDC_CONFIG_YAML}" | yq --exit-status=1 eval '(. | has("configtool")) and (.configtool | has("trusted_uri_prefixes"))' 1>/dev/null 2>&1); then
+                echo "- oidc.configtool configuration supplied, (re)registering client"
+                echo "--------------------------------------------------------------"
+                echo ""
+                TRUST_UI_PREFIX=$(echo -e "${OIDC_CONFIG_YAML}" | yq eval '.configtool.trusted_uri_prefixes | join(",")')
+                # NOTE: "x" is used as workspace ID. This is just so the MAS_HOME parameter conforms to the format expected by the 
+                # configtool-oidc script. This is not a workspace-level operation. Its actual value is not used for anything else.
+                mas configtool-oidc \
+                  register \
+                  --mas-home "x.home.${DOMAIN}" \
+                  --ui-prefix "${TRUST_UI_PREFIX}"
+              else
+                echo "- oidc.configtool configuration absent, unregistering client"
+                echo "--------------------------------------------------------------"
+                echo ""
+                mas configtool-oidc \
+                  unregister \
+                  --mas-home "x.home.${DOMAIN}" \
+                  --ui-prefix "${TRUST_UI_PREFIX}"
+              fi
 
-              # NOTE: "x" is used as workspace ID. This is just so the MAS_HOME parameter conforms to the format expected by the 
-              # configtool-oidc script. This is not a workspace-level operation. Its actual value is not used for anything else.
-              # mas configtool-oidc \
-              #   register \
-              #   --mas-home "x.home.${DOMAIN}" \
-              #   --ui-prefix "${TRUST_UI_PREFIX}"
               
       restartPolicy: Never
       serviceAccountName: "{{ $sa_name }}"

--- a/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-app.yaml
@@ -119,6 +119,10 @@ spec:
               devops_build_number: "{{ .Values.devops.build_number }}"
               gitops_version: "{{ .Values.source.revision }}"
 
+            {{- if .Values.ibm_mas_suite.oidc }}
+            oidc: {{ .Values.ibm_mas_suite.oidc | toYaml | nindent 14 }}
+            {{- end }}
+
         - name: ARGOCD_APP_NAME
           value: suiteapp
         {{- if not (empty .Values.avp.secret) }}


### PR DESCRIPTION
# Description

These changes are part of the work to automate the registration of an OIDC client to support usage of the MAS Application Framework (MAF) configuration tool (https://jsw.ibm.com/browse/MASCORE-3763). 

This PR adds a new Job (and supporting resources) to the ibm-mas-suite Helm chart that picks up `oidc` configuration and uses it to register the oidc client if oidc config is present, or unregister the oidc client otherwise.

See https://github.com/ibm-mas/cli/pull/1437 for related changes and testing results.