### PR TITLE
[minor] Disable destructive/disruptive Manage admin API routes in production instances

### DIFF
--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/700-702-postsync-db2-manage.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/700-702-postsync-db2-manage.yaml
@@ -230,8 +230,8 @@ spec:
               # (see https://jsw.ibm.com/browse/MASCORE-4639)
               if [[ "${OPERATIONAL_MODE}" == "production" ]]; then
                 cat > ${UPDATE_DB2_SH_PATH} << EOF
-                  echo "TODO: run db2 update maximo.apiroute set active=0 where route in ('icheckerrepair','managestart','icheckerreport', 'managestop'); || exit \$?"  
-                EOF
+                  echo "TODO: run db2 update maximo.apiroute set active=0 where route in ('icheckerrepair','managestart','icheckerreport', 'managestop'); || exit \$?"
+              EOF
                 # IMPORTANT: Do not make any changes to the "EOF" line above (including its indentation)
               fi
 

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/700-702-postsync-db2-manage.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/700-702-postsync-db2-manage.yaml
@@ -219,10 +219,10 @@ spec:
                   exit 1
                 fi
 
-                db2 "select 'alter sequence maximo.' || sequencename || ' cache 500;' from maximo.maxsequence" | grep "alter sequence" > "alter_seq.sql"
-                echo "alter sequence maximo.maxseq cache 2000;" >> "alter_seq.sql"
+                db2 "select 'alter sequence maximo.' || sequencename || ' cache 500;' from maximo.maxsequence" | grep "alter sequence" > "/tmp/alter_seq.sql"
+                echo "alter sequence maximo.maxseq cache 2000;" >> "/tmp/alter_seq.sql"
 
-                db2 -tvf "alter_seq.sql" | tee "alter_seq.sql.log" || exit \$?
+                db2 -tvf "/tmp/alter_seq.sql" | tee "/tmp/alter_seq.sql.log" || exit \$?
               EOF
               # IMPORTANT: Do not make any changes to the "EOF" line above (including its indentation)
 
@@ -230,7 +230,7 @@ spec:
               # (see https://jsw.ibm.com/browse/MASCORE-4639)
               if [[ "${OPERATIONAL_MODE}" == "production" ]]; then
                 cat >> ${UPDATE_DB2_SH_PATH} << EOF
-                  echo "TODO: run db2 update maximo.apiroute set active=0 where route in ('icheckerrepair','managestart','icheckerreport', 'managestop'); || exit \$?"
+                db2 "update maximo.apiroute set active=0 where route in ('icheckerrepair','managestart','icheckerreport', 'managestop');" | tee "/tmp/disable_routes.log" || exit \$?"
               EOF
                 # IMPORTANT: Do not make any changes to the "EOF" line above (including its indentation)
               fi

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/700-702-postsync-db2-manage.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/700-702-postsync-db2-manage.yaml
@@ -140,7 +140,7 @@ metadata:
   # Suffix the Job name with a hash of all chart values
   # This is to ensure that ArgoCD will delete and recreate the job if anything changes in the application config
   # The job is idempotent
-  name: {{ $job_name }}-v1-{{ omit $.Values "junitreporter" | toYaml | adler32sum }}
+  name: {{ $job_name }}-v2-{{ omit $.Values "junitreporter" | toYaml | adler32sum }}
   namespace: "{{ $manage_ns }}"
   annotations:
     argocd.argoproj.io/sync-wave: "702"
@@ -178,6 +178,8 @@ spec:
               value: "{{ $db2_dbname }}"
             - name: DB2_INSTANCE_NAME
               value: "{{ $db2_instance_name }}"
+            - name: OPERATIONAL_MODE
+              value: "{{ $.Values.operational_mode }}"
 
           volumeMounts: []
           command:
@@ -199,16 +201,17 @@ spec:
               echo "AVP_TYPE ............................ ${AVP_TYPE}"
               echo "DB2_NAMESPACE ....................... ${DB2_NAMESPACE}"
               echo "DB2_POD_NAME ........................ ${DB2_POD_NAME}"
+              echo "OPERATIONAL_MODE .................... ${OPERATIONAL_MODE}"
 
               # Path to the generated script, on both this pod and on the db2u pod
-              ALTERSEQ_SH_PATH="/tmp/alterseq.sh"
+              UPDATE_DB2_SH_PATH="/tmp/postsync_db2_manage.sh"
 
               echo ""
-              echo "Create ${ALTERSEQ_SH_PATH}"
+              echo "Create ${UPDATE_DB2_SH_PATH}"
               echo "--------------------------------------------------------------------------------"
 
               # Generate a script to copy and run on the db2u pod
-              cat > ${ALTERSEQ_SH_PATH} << EOF
+              cat > ${UPDATE_DB2_SH_PATH} << EOF
                 #!/bin/bash
                 db2 connect to ${DB2_DBNAME}
                 if [ \$? != 0 ]; then
@@ -216,27 +219,36 @@ spec:
                   exit 1
                 fi
 
-                db2 "select 'alter sequence maximo.' || sequencename || ' cache 500;' from maximo.maxsequence" | grep "alter sequence" > "${ALTERSEQ_SH_PATH}.sql"
-                echo "alter sequence maximo.maxseq cache 2000;" >> "${ALTERSEQ_SH_PATH}.sql"
+                db2 "select 'alter sequence maximo.' || sequencename || ' cache 500;' from maximo.maxsequence" | grep "alter sequence" > "alter_seq.sql"
+                echo "alter sequence maximo.maxseq cache 2000;" >> "alter_seq.sql"
 
-                db2 -tvf "${ALTERSEQ_SH_PATH}.sql" | tee "${ALTERSEQ_SH_PATH}.sql.log" || exit \$?
+                db2 -tvf "alter_seq.sql" | tee "alter_seq.sql.log" || exit \$?
               EOF
               # IMPORTANT: Do not make any changes to the "EOF" line above (including its indentation)
 
-              cat ${ALTERSEQ_SH_PATH}
+              # If this is a production instance, add an additional db2 command to disable destructive API routes
+              # (see https://jsw.ibm.com/browse/MASCORE-4639)
+              if [[ "${OPERATIONAL_MODE}" == "production" ]]; then
+                cat > ${UPDATE_DB2_SH_PATH} << EOF
+                  echo "TODO: run db2 update maximo.apiroute set active=0 where route in ('icheckerrepair','managestart','icheckerreport', 'managestop'); || exit \$?"  
+                EOF
+                # IMPORTANT: Do not make any changes to the "EOF" line above (including its indentation)
+              fi
 
-              chmod +x ${ALTERSEQ_SH_PATH}
+              cat ${UPDATE_DB2_SH_PATH}
+
+              chmod +x ${UPDATE_DB2_SH_PATH}
 
               echo ""
-              echo "Copy ${ALTERSEQ_SH_PATH} to ${DB2_NAMESPACE}/${DB2_POD_NAME}"
+              echo "Copy ${UPDATE_DB2_SH_PATH} to ${DB2_NAMESPACE}/${DB2_POD_NAME}"
               echo "--------------------------------------------------------------------------------"
-              oc cp ${ALTERSEQ_SH_PATH} ${DB2_NAMESPACE}/${DB2_POD_NAME}:${ALTERSEQ_SH_PATH} -c db2u || exit $?
+              oc cp ${UPDATE_DB2_SH_PATH} ${DB2_NAMESPACE}/${DB2_POD_NAME}:${UPDATE_DB2_SH_PATH} -c db2u || exit $?
               echo "... done"
 
               echo ""
-              echo "Executing ${ALTERSEQ_SH_PATH} file on ${DB2_NAMESPACE}/${DB2_POD_NAME}"
+              echo "Executing ${UPDATE_DB2_SH_PATH} file on ${DB2_NAMESPACE}/${DB2_POD_NAME}"
               echo "--------------------------------------------------------------------------------"
-              oc exec -n ${DB2_NAMESPACE} ${DB2_POD_NAME} -- su -lc "${ALTERSEQ_SH_PATH} | tee ${ALTERSEQ_SH_PATH}.log" db2inst1 || exit $?
+              oc exec -n ${DB2_NAMESPACE} ${DB2_POD_NAME} -- su -lc "${UPDATE_DB2_SH_PATH} | tee ${UPDATE_DB2_SH_PATH}.log" db2inst1 || exit $?
 
       restartPolicy: Never
       serviceAccountName: "{{ $sa_name }}"

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/700-702-postsync-db2-manage.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/700-702-postsync-db2-manage.yaml
@@ -226,14 +226,14 @@ spec:
               EOF
               # IMPORTANT: Do not make any changes to the "EOF" line above (including its indentation)
 
-              # If this is a production instance, add an additional db2 command to disable destructive API routes
+              # Disable destructive/disruptive API routes if this is a production instance.
+              # Otherwise (re)enable them
+              ROUTES_ACTIVE=$([[ "${OPERATIONAL_MODE}" == "production" ]] && echo "0" || echo "1")
               # (see https://jsw.ibm.com/browse/MASCORE-4639)
-              if [[ "${OPERATIONAL_MODE}" == "production" ]]; then
-                cat >> ${UPDATE_DB2_SH_PATH} << EOF
-                db2 "update maximo.apiroute set active=0 where route in ('icheckerrepair','managestart','icheckerreport', 'managestop');" | tee "/tmp/disable_routes.log" || exit \$?
+              cat >> ${UPDATE_DB2_SH_PATH} << EOF
+                db2 "update maximo.apiroute set active=${ROUTES_ACTIVE} where route in ('icheckerrepair','managestart','icheckerreport', 'managestop');" | tee "/tmp/disable_routes.log" || exit \$?
               EOF
-                # IMPORTANT: Do not make any changes to the "EOF" line above (including its indentation)
-              fi
+              # IMPORTANT: Do not make any changes to the "EOF" line above (including its indentation)
 
               cat ${UPDATE_DB2_SH_PATH}
 

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/700-702-postsync-db2-manage.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/700-702-postsync-db2-manage.yaml
@@ -229,7 +229,7 @@ spec:
               # If this is a production instance, add an additional db2 command to disable destructive API routes
               # (see https://jsw.ibm.com/browse/MASCORE-4639)
               if [[ "${OPERATIONAL_MODE}" == "production" ]]; then
-                cat > ${UPDATE_DB2_SH_PATH} << EOF
+                cat >> ${UPDATE_DB2_SH_PATH} << EOF
                   echo "TODO: run db2 update maximo.apiroute set active=0 where route in ('icheckerrepair','managestart','icheckerreport', 'managestop'); || exit \$?"
               EOF
                 # IMPORTANT: Do not make any changes to the "EOF" line above (including its indentation)

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/700-702-postsync-db2-manage.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/700-702-postsync-db2-manage.yaml
@@ -230,7 +230,7 @@ spec:
               # (see https://jsw.ibm.com/browse/MASCORE-4639)
               if [[ "${OPERATIONAL_MODE}" == "production" ]]; then
                 cat >> ${UPDATE_DB2_SH_PATH} << EOF
-                db2 "update maximo.apiroute set active=0 where route in ('icheckerrepair','managestart','icheckerreport', 'managestop');" | tee "/tmp/disable_routes.log" || exit \$?"
+                db2 "update maximo.apiroute set active=0 where route in ('icheckerrepair','managestart','icheckerreport', 'managestop');" | tee "/tmp/disable_routes.log" || exit \$?
               EOF
                 # IMPORTANT: Do not make any changes to the "EOF" line above (including its indentation)
               fi

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/700-702-postsync-db2-manage.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/700-702-postsync-db2-manage.yaml
@@ -228,9 +228,9 @@ spec:
 
               # If this is a production instance, add an additional db2 command to disable destructive API routes
               # (see https://jsw.ibm.com/browse/MASCORE-4639)
-              if [[ "${OPERATIONAL_MODE}" == "productionx" ]]; then
+              if [[ "${OPERATIONAL_MODE}" == "production" ]]; then
                 cat >> ${UPDATE_DB2_SH_PATH} << EOF
-                echo "TODO: run db2 update maximo.apiroute set active=0 where route in ('icheckerrepair','managestart','icheckerreport', 'managestop'); || exit \$?"
+                  echo "TODO: run db2 update maximo.apiroute set active=0 where route in ('icheckerrepair','managestart','icheckerreport', 'managestop'); || exit \$?"
               EOF
                 # IMPORTANT: Do not make any changes to the "EOF" line above (including its indentation)
               fi

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/700-702-postsync-db2-manage.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/700-702-postsync-db2-manage.yaml
@@ -228,9 +228,9 @@ spec:
 
               # If this is a production instance, add an additional db2 command to disable destructive API routes
               # (see https://jsw.ibm.com/browse/MASCORE-4639)
-              if [[ "${OPERATIONAL_MODE}" == "production" ]]; then
+              if [[ "${OPERATIONAL_MODE}" == "productionx" ]]; then
                 cat >> ${UPDATE_DB2_SH_PATH} << EOF
-                  echo "TODO: run db2 update maximo.apiroute set active=0 where route in ('icheckerrepair','managestart','icheckerreport', 'managestop'); || exit \$?"
+                echo "TODO: run db2 update maximo.apiroute set active=0 where route in ('icheckerrepair','managestart','icheckerreport', 'managestop'); || exit \$?"
               EOF
                 # IMPORTANT: Do not make any changes to the "EOF" line above (including its indentation)
               fi

--- a/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
@@ -99,8 +99,8 @@ spec:
 
             {{- if $.Values.ibm_mas_suite }}
               {{- if $.Values.ibm_mas_suite.mas_annotations }}
-                {{- if (index $.Values.ibm_mas_suite.mas_annotations "mas.ibm.com/operationalMode") }}
-            operational_mode: {{ index $.Values.ibm_mas_suite.mas_annotations "mas.ibm.com/operationalMode" }}
+                {{- if (index $.Values.ibm_mas_suite.mas_annotations "mas.ibm.com/operationalModex") }}
+            operational_mode: {{ index $.Values.ibm_mas_suite.mas_annotations "mas.ibm.com/operationalModex" }}
                 {{- end }}
               {{- end }}
             {{- end }}

--- a/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
@@ -99,8 +99,8 @@ spec:
 
             {{- if $.Values.ibm_mas_suite }}
               {{- if $.Values.ibm_mas_suite.mas_annotations }}
-                {{- if (index $.Values.ibm_mas_suite.mas_annotations "mas.ibm.com/operationalModex") }}
-            operational_mode: {{ index $.Values.ibm_mas_suite.mas_annotations "mas.ibm.com/operationalModex" }}
+                {{- if (index $.Values.ibm_mas_suite.mas_annotations "mas.ibm.com/operationalMode") }}
+            operational_mode: {{ index $.Values.ibm_mas_suite.mas_annotations "mas.ibm.com/operationalMode" }}
                 {{- end }}
               {{- end }}
             {{- end }}

--- a/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
@@ -99,8 +99,8 @@ spec:
 
             {{- if $.Values.ibm_mas_suite }}
               {{- if $.Values.ibm_mas_suite.mas_annotations }}
-                {{- if (index $.Values.ibm_mas_suite.mas_annotations 'mas.ibm.com/operationalMode') }}
-            operational_mode: {{ index $.Values.ibm_mas_suite.mas_annotations 'mas.ibm.com/operationalMode' }}
+                {{- if (index $.Values.ibm_mas_suite.mas_annotations "mas.ibm.com/operationalMode") }}
+            operational_mode: {{ index $.Values.ibm_mas_suite.mas_annotations "mas.ibm.com/operationalMode" }}
                 {{- end }}
               {{- end }}
             {{- end }}

--- a/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
@@ -99,8 +99,8 @@ spec:
 
             {{- if $.Values.ibm_mas_suite }}
               {{- if $.Values.ibm_mas_suite.mas_annotations }}
-                {{- if $.Values.ibm_mas_suite.mas_annotations.mas.ibm.com/operationalMode }}
-            operational_mode: {{ .Values.ibm_mas_suite.mas_annotations.mas.ibm.com/operationalMode }}
+                {{- if (index $.Values.ibm_mas_suite.mas_annotations 'mas.ibm.com/operationalMode') }}
+            operational_mode: {{ index $.Values.ibm_mas_suite.mas_annotations 'mas.ibm.com/operationalMode' }}
                 {{- end }}
               {{- end }}
             {{- end }}

--- a/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
@@ -97,6 +97,14 @@ spec:
             custom_labels: {{ $.Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}
 
+            {{- if $.Values.ibm_mas_suite }}
+              {{- if $.Values.ibm_mas_suite.mas_annotations }}
+                {{- if $.Values.ibm_mas_suite.mas_annotations.mas.ibm.com/operationalMode }}
+            operational_mode: {{ .Values.ibm_mas_suite.mas_annotations.mas.ibm.com/operationalMode }}
+                {{- end }}
+              {{- end }}
+            {{- end }}
+
             junitreporter:
               reporter_name: "app-config-{{ $value.mas_app_id }}-{{ $.Values.instance.id }}"
               cluster_id: "{{ $.Values.cluster.id }}"


### PR DESCRIPTION
# Description

These changes disable various destructive/disruptive Manage Admin API routes in production instances. The routes are re-enabled if the instance transitions from production -> nonproduction (not sure this will ever happen, but just in case).

The existing `ibm_mas_suite.mas_annotation.mas.ibm.com/operationalMode` annotation is used to determine whether this is a production instance or not. 

~This is provisional, awaiting confirmation that this is the correct approach. I will leave this PR as draft until I get this confirmation.~ Confirmed with @benbakowski.

https://jsw.ibm.com/browse/MASCORE-4639

# Testing

When mas-instance-params.yaml has:
```
mas_instance:
  annotations:
    mas.ibm.com/operationalMode: production
```

the `postsync-db2-manage` job appends the following to the SQL script that it executes inside the db2 pod:
```
db2 "update maximo.apiroute set active=0 where route in ('icheckerrepair','managestart','icheckerreport', 'managestop');" | tee "/tmp/disable_routes.log" || exit $?
```
(note: `active=0`)

![image](https://github.com/user-attachments/assets/5e9064ee-a93e-450d-992a-0b24315ec29b)


After the job completes, attempt to call one of the now disabled APIs:
```
$ http -phHbB --verify=no POST https://maxinst.manage.mascore3763.apps.noble6.cp.fyre.ibm.com/toolsapi/toolservice/managestart "apikey: $apikey"

HTTP/1.1 400 Bad Request
```


When mas-instance-params.yaml has:
```
mas_instance:
  annotations:
    mas.ibm.com/operationalMode: nonproduction
```
(or any other operationalMode)

the `postsync-db2-manage` job appends the following to the SQL script that it executes inside the db2 pod:
```
db2 "update maximo.apiroute set active=1 where route in ('icheckerrepair','managestart','icheckerreport', 'managestop');" | tee "/tmp/disable_routes.log" || exit $?
```
(note: `active=1`)

![image](https://github.com/user-attachments/assets/f8854821-9d7c-43b1-9d56-6c50248c34f5)


After the job completes, attempt to call one of the now (re)enabled APIs:
```
$ http -phHbB --verify=no POST https://maxinst.manage.mascore3763.apps.noble6.cp.fyre.ibm.com/toolsapi/toolservice/managestart "apikey: $apikey"

HTTP/1.1 200 OK
```