### PR TITLE
[patch] Fix default Falcon Helm values field

### DIFF
--- a/cluster-applications/053-falcon-operator/values.yaml
+++ b/cluster-applications/053-falcon-operator/values.yaml
@@ -5,6 +5,6 @@ falcon_operator_client_id: xxx
 falcon_operator_client_secret: xxx
 falcon_operator_node_sensor:
   node:
-    terminationGracePeriodSeconds: 30
+    terminationGracePeriod: 30
   falcon:
     trace: err


### PR DESCRIPTION
Fix the field name in the defaul Falcon Operator Helm values. Kubernetes resources such as `Deployment` use the standard name `terminationGracePeriodSeconds` for this field, but it's actually `terminationGracePeriod` in the `FalconNodeSensor` CRD.

Reference: https://github.com/CrowdStrike/falcon-operator/blob/main/docs/resources/node/README.md