### PR TITLE
[patch] Ensure external label added to routes prior to configtool oidc registration attempt. Fix `.Values.ingress` checks.

### DIFF
--- a/cluster-applications/030-ibm-cis-cert-manager/templates/00-8-ibm-cis-webhook_cis-ingress-controller.yaml
+++ b/cluster-applications/030-ibm-cis-cert-manager/templates/00-8-ibm-cis-webhook_cis-ingress-controller.yaml
@@ -1,4 +1,7 @@
-{{- if and (eq .Values.dns_provider "cis") (.Values.ingress) }}
+# .Values.ingress is properly passed into the cis-cert-manager app as a boolean
+# (see https://github.com/ibm-mas/gitops/blob/d46e6577fc2081e0a5624dddf575cead5310d794/root-applications/ibm-mas-cluster-root/templates/030-ibm-cis-cert-manager.yaml#L51)
+# Nevertheless, for consistency with checks against .Values.ingress in other charts, we will also accept the string "true" here.
+{{- if and (eq .Values.dns_provider "cis") (eq (toString .Values.ingress) "true") }}
 ---
 apiVersion: operator.openshift.io/v1
 kind: IngressController

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -11,8 +11,6 @@ metadata:
   namespace: mas-{{ .Values.instance_id }}-core
   annotations:
     argocd.argoproj.io/sync-wave: "140"
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded,BeforeHookCreation
 {{- if .Values.custom_labels }}
   labels:
 {{ .Values.custom_labels | toYaml | indent 4 }}
@@ -35,8 +33,6 @@ metadata:
   namespace: mas-{{ .Values.instance_id }}-core
   annotations:
     argocd.argoproj.io/sync-wave: "140"
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded,BeforeHookCreation
 {{- if .Values.custom_labels }}
   labels:
 {{ .Values.custom_labels | toYaml | indent 4 }}
@@ -50,8 +46,6 @@ metadata:
   name: mas-route-prereq-role-{{ .Values.instance_id }}
   annotations:
     argocd.argoproj.io/sync-wave: "140"
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded,BeforeHookCreation
 {{- if .Values.custom_labels }}
   labels:
 {{ .Values.custom_labels | toYaml | indent 4 }}
@@ -81,8 +75,6 @@ metadata:
   name: mas-route-prereq-rb-{{ .Values.instance_id }}
   annotations:
     argocd.argoproj.io/sync-wave: "141"
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded,BeforeHookCreation
 {{- if .Values.custom_labels }}
   labels:
 {{ .Values.custom_labels | toYaml | indent 4 }}
@@ -100,12 +92,10 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: mas-route-patch-v1-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
+  name: mas-route-patch-v2-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
   namespace: mas-{{ .Values.instance_id }}-core
   annotations:
     argocd.argoproj.io/sync-wave: "142"
-    argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded,BeforeHookCreation
 {{- if .Values.custom_labels }}
   labels:
 {{ .Values.custom_labels | toYaml | indent 4 }}

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -1,4 +1,8 @@
-{{- if .Values.ingress }}
+# .Values.ingress is passed into the suite as a string (even though the original value is a boolean)
+# (see https://github.com/ibm-mas/gitops/blob/d46e6577fc2081e0a5624dddf575cead5310d794/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-app.yaml#L60)
+# This meant the check was passing even when ingress was false (.Values.ingress is considered true when it is the string "false")
+# Rather than change the suite app (and force it to resync in all existing envs), we'll instead fix the check here to look for either boolean true OR the string "true".
+{{- if (eq (toString .Values.ingress) "true") }}
 
 {{ $job_label :=  "mas-route-patch" }}
 ---

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -1,4 +1,4 @@
-# {{- if .Values.ingress }}
+{{- if .Values.ingress }}
 
 {{ $job_label :=  "mas-route-patch" }}
 ---
@@ -170,5 +170,5 @@ spec:
       serviceAccountName: "mas-route-sa"
   backoffLimit: 4
 
-# {{- end }}
+{{- end }}
 

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -145,6 +145,8 @@ spec:
               echo "================================================================================"
               echo
 
+              exit 1
+
               echo "Wait for Suite Routes to be ready"
               wait_period=0
               while true; do

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress }}
+# {{- if .Values.ingress }}
 
 {{ $job_label :=  "mas-route-patch" }}
 ---
@@ -180,5 +180,5 @@ spec:
       serviceAccountName: "mas-route-sa"
   backoffLimit: 4
 
-{{- end }}
+# {{- end }}
 

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -135,8 +135,6 @@ spec:
               echo "================================================================================"
               echo
 
-              exit 1
-
               echo "Wait for Suite Routes to be ready"
               wait_period=0
               while true; do

--- a/instance-applications/130-ibm-mas-suite/templates/06-postsync-configtool-oidc.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/06-postsync-configtool-oidc.yaml
@@ -103,7 +103,7 @@ spec:
       containers:
         - name: run
           image: quay.io/ibmmas/cli:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           resources:
             limits:
               cpu: 200m

--- a/instance-applications/130-ibm-mas-suite/templates/06-postsync-configtool-oidc.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/06-postsync-configtool-oidc.yaml
@@ -103,7 +103,7 @@ spec:
       containers:
         - name: run
           image: quay.io/ibmmas/cli:latest
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           resources:
             limits:
               cpu: 200m

--- a/instance-applications/130-ibm-mas-suite/templates/06-postsync-configtool-oidc.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/06-postsync-configtool-oidc.yaml
@@ -15,7 +15,7 @@ metadata:
   name: {{ $np_name }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-wave: "140"
+    argocd.argoproj.io/sync-wave: "143"
 {{- if .Values.custom_labels }}
   labels:
 {{ .Values.custom_labels | toYaml | indent 4 }}
@@ -37,7 +37,7 @@ metadata:
   name: {{ $sa_name }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-wave: "140"
+    argocd.argoproj.io/sync-wave: "143"
 {{- if .Values.custom_labels }}
   labels:
 {{ .Values.custom_labels | toYaml | indent 4 }}
@@ -50,7 +50,7 @@ metadata:
   name: {{ $role_name }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-wave: "140"
+    argocd.argoproj.io/sync-wave: "143"
 {{- if .Values.custom_labels }}
   labels:
 {{ .Values.custom_labels | toYaml | indent 4 }}
@@ -64,7 +64,7 @@ metadata:
   name: {{ $rb_name }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-wave: "141"
+    argocd.argoproj.io/sync-wave: "144"
 {{- if .Values.custom_labels }}
   labels:
 {{ .Values.custom_labels | toYaml | indent 4 }}
@@ -83,10 +83,10 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ $job_label }}-v1-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
+  name: {{ $job_label }}-v2-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
   namespace: {{ $ns }}
   annotations:
-    argocd.argoproj.io/sync-wave: "142"
+    argocd.argoproj.io/sync-wave: "145"
 {{- if .Values.custom_labels }}
   labels:
 {{ .Values.custom_labels | toYaml | indent 4 }}

--- a/instance-applications/220-ibm-mas-workspace/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/220-ibm-mas-workspace/templates/05-postsync-add-label_Job.yaml
@@ -1,5 +1,8 @@
-{{- if .Values.ingress }}
-
+# .Values.ingress is passed into the workspace as a string (even though the original value is a boolean)
+# (see https://github.com/ibm-mas/gitops/blob/d46e6577fc2081e0a5624dddf575cead5310d794/root-applications/ibm-mas-instance-root/templates/200-ibm-mas-workspaces.yaml#L44)
+# This meant the check was passing even when ingress was false (.Values.ingress is considered true when it is the string "false")
+# Rather than change the workspace app (and force it to resync in all existing envs), we'll instead fix the check here to look for either boolean true OR the string "true".
+{{- if (eq (toString .Values.ingress) "true") }}
 {{ $job_label :=  "mas-ws-route-patch" }}
 ---
 # Permit outbound communication by the Job pods

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
@@ -1,4 +1,7 @@
-{{- if .Values.ingress }}
+# .Values.ingress is properly passed into the suite-app-config app as a boolean 
+# (see https://github.com/ibm-mas/gitops/blob/d46e6577fc2081e0a5624dddf575cead5310d794/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml#L67)
+# Nevertheless, for consistency with checks against .Values.ingress in other charts, we will also accept the string "true" here.
+{{- if (eq (toString .Values.ingress) "true") }}
 
 {{ $ns        :=  .Values.mas_app_namespace }}
 {{ $job_label :=  "mas-app-route-patch" }}


### PR DESCRIPTION
## Description

Two issues are resolved by this PR:

### Ensure external label added to routes prior to configtool oidc registration attempt

An issue was identified when running in `ingress: true` mode whereby the `configtool-oidc` job would fail with HTTP 526 "Invalid SSL certificate" when it attempted to call the external `/oidc/endpoint/MaximoAppSuite/registration` route.

This was because the `add-label` job responsible for adding the `type: external` label to MAS routes (necessary for them to function properly in `ingress: true` mode) was annotated as an ArgoCD `PostSync` hook, but the `configtool-oidc` is not. This meant that `configtool-oidc` would run *before* `add-label`, but would fail and never allow `add-label` to run.

This PR resolves this problem by removing the `PostSync` label from the `add-label` job and ensures it runs before `configtool-oidc` by allocating it to an earlier syncwave. This approach also has the (desirable) effects of: (1) meaning `add-label` job completion status will now be taken into account when computing the overall health of the suite application (PostSync hooks are not) and (2)  `add-label`  is guaranteed to run before `configtool-oidc` (if they were both PostSync hooks, they would run concurrently and race - potentially causing one or more reattempts of `configtool-oidc`).

> To limit the impact of this PR, I have not attempted to remove the "PostSync" label from the other `add-label` jobs in the `ibm-mas-workspace` and `ibm-mas-suite-app-config` applications. We may want to think about doing this in future.

### Fix `.Values.ingress` checks.

While fixing the above issue, I also noticed that `.Values.ingress` was being passed in as a string to the `ibm-mas-suite` and `ibm-mas-workspace` applications. Both of these applications have the `add-label` job, which should only run in `ingress: true` mode. However, the conditional check in these charts was just `{{- if .Values.ingress }}`. This check passes when `.Values.ingress` is (the string) `"false"`, which means that `external: true` label has been added to all environments, even those with `ingress: false`.  I've updated these checks to only pass when .Values.ingress is (the boolean) `true` or (the string) `"true"` in all future deployments.

> NOTE: although this PR will fix the problem for future deployments, the presence of this bug until now will mean that the `type: external` label will have been added to all environments, even those in `ingress: false` mode. This PR will *not* attempt to remove the label in existing `ingress: false` environments.   I'm not exactly sure of the impact of having this label improperly and we may need to take further remediation steps in existing environments if necessary

> Two other charts (`ibm-cis-cert-manager` and `ibm-mas-suite-app-config`) *are* properly passed `.Values.ingress` as a boolean. Neverthess, I've update their logic to align (`true` OR `"true"`) for consistency.



https://jsw.ibm.com/browse/MASCORE-5413

## Testing

Verified that the `add-label` (aka `mas-route-patch`) job now runs prior to the `configtool-oidc` job when `ingress: true`:

![image](https://github.com/user-attachments/assets/f52178bf-dd45-456a-a7fd-d1f262069815)

![image](https://github.com/user-attachments/assets/187602f4-e840-467a-85aa-9bb1a7c6744b)

Verified that the status of the `add-label` (aka `mas-route-patch`) job is now taken into account when computing app health:
![image](https://github.com/user-attachments/assets/ddb5c151-93f9-46ad-850a-fbb8abb1d122)

Verified that the `add-label` (aka `mas-route-patch`) job no longer runs when `ingress: false`:
![image](https://github.com/user-attachments/assets/789a033e-4a3f-4dbb-9608-ec3d8fa64557)

Verified that the `ibm-mas-workspace` and `ibm-mas-app-config` applications still sync successfully:
![image](https://github.com/user-attachments/assets/a5ecce88-787c-4e04-b9df-c539c73cdfb7)

![image](https://github.com/user-attachments/assets/81df0c9a-947e-4c8e-83f1-d29c56a98584)
