### PR TITLE
[patch] Fix for sanity tests in manage

### DIFF
--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-sanity.yaml
@@ -7,10 +7,10 @@
 {{ $ns               :=  .Values.mas_app_namespace }}
 {{ $np_name          :=  "postsync-sanity-manage-np" }}
 {{ $role_name        :=  "postsync-sanity-manage-role" }}
-{{ $crole_name       :=  "postsync-verify-manage-crole" }}
-{{ $sa_name          :=  "postsync-sanity-manage-sa" }}
+{{ $crole_name       :=  printf "postsync-sanity-manage-crole-%s" .Values.instance_id }}
+{{ $sa_name          :=  printf "postsync-sanity-manage-sa-%s" .Values.instance_id }}
 {{ $rb_name          :=  "postsync-sanity-manage-rb" }}
-{{ $crb_name         :=  "postsync-verify-manage-crb" }}
+{{ $crb_name         :=  printf "postsync-sanity-manage-crb-%s" .Values.instance_id }}
 {{ $tests_cm_name    :=  "postsync-sanity-tests-manage-cm" }}
 {{ $record_cm_name   :=  "postsync-sanity-tests-manage-record-cm" }}
 {{ $job_name         :=  "postsync-sanity-manage-job" }}
@@ -917,7 +917,7 @@ data:
         assetid = get_asset(asset, session, manage_host_ca_filepath)
         if assetid is not None:
             logger.info("assetid not none")
-            delete_asset(assetid,session)
+            delete_asset(assetid,session, manage_host_ca_filepath)
         # Create Asset
         create_asset(asset, session, manage_host_ca_filepath)
         # Get Asset id for newly created Asset

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-sanity.yaml
@@ -915,9 +915,6 @@ data:
     def test_asset_crud_operation_using_new_added_user(manage_host_ca_filepath):
         #Check if asset exists, delete it if present
         assetid = get_asset(asset, session, manage_host_ca_filepath)
-        if assetid is not None:
-            logger.info("assetid not none")
-            delete_asset(assetid,session, manage_host_ca_filepath)
         # Create Asset
         create_asset(asset, session, manage_host_ca_filepath)
         # Get Asset id for newly created Asset
@@ -927,8 +924,6 @@ data:
         time.sleep(20)
         # Update newly created Asset
         update_asset(assetid, session, manage_host_ca_filepath)
-        # Delete newly created Asset
-        delete_asset(assetid, session, manage_host_ca_filepath)
         
     def get_asset(asset, session, manage_host_ca_filepath):
         asset_url = f'''{MANAGE_URL}/maximo/api/os/mxapiasset?lean=1&oslc.select=assetnum&oslc.where=assetnum%3D%22{asset}%22'''
@@ -982,6 +977,7 @@ data:
         logger.info(response.text)
         assert_that(response.status_code).is_equal_to(204)
 
+    # This function only works if a dbc has been loaded to allow delete of assets
     def delete_asset(assetid, session, manage_host_ca_filepath):
         asset_url = MANAGE_URL+"/maximo/api/os/mxapiasset/"+assetid
         querystring = {"lean":"1"}


### PR DESCRIPTION
Fixes three issues with manage sanity tests:

1) if we go down the path where the asset is not found then we get a python error as the delete_asset doesn't have the manage_host_ca_filepath passed in.
2) When there are mulitple manage instances on the cluster then the cluster role and cluster rolebinding clash with other instances as these are not tidied to a namespace. SO appending the mas instance id to the name of these.
3) Removes the delete_asset call in the manage sanity test as this will only work when a dbc is applied that would allow the delete of an asset to be allowed. There is no issues with multiple assets being created.