### PR TITLE
[patch] read oauth_admin_secret via volumeMount

### DIFF
--- a/instance-applications/130-ibm-mas-suite/templates/06-postsync-configtool-oidc.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/06-postsync-configtool-oidc.yaml
@@ -83,7 +83,7 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ $job_label }}-v2-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
+  name: {{ $job_label }}-v3-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
   namespace: {{ $ns }}
   annotations:
     argocd.argoproj.io/sync-wave: "145"
@@ -121,16 +121,9 @@ spec:
             - name: OIDC_CONFIG_YAML
               value: {{ .Values.oidc | toYaml | replace "\n" "\\n" }}
                 
-            - name: OAUTH_ADMIN_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $oauth_admin_secret }}
-                  key: oauth-admin-username
-            - name: OAUTH_ADMIN_PWD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $oauth_admin_secret }}
-                  key: oauth-admin-password
+          volumeMounts:
+            - name: oauth-admin-secret
+              mountPath: /etc/mas/creds/oauth_admin_secret
             
           command:
             - /bin/sh
@@ -138,6 +131,9 @@ spec:
             - |
 
               set -e
+
+              export OAUTH_ADMIN_USERNAME="$(cat /etc/mas/creds/oauth_admin_secret/oauth-admin-username)"
+              export OAUTH_ADMIN_PWD="$(cat /etc/mas/creds/oauth_admin_secret/oauth-admin-password)"
 
               if $(echo -e "${OIDC_CONFIG_YAML}" | yq --exit-status=1 eval '(. | has("configtool")) and (.configtool | has("trusted_uri_prefixes"))' 1>/dev/null 2>&1); then
                 echo "- oidc.configtool configuration supplied, (re)registering client"
@@ -163,5 +159,11 @@ spec:
               
       restartPolicy: Never
       serviceAccountName: "{{ $sa_name }}"
+      volumes:
+        - name: oauth-admin-secret
+          secret:
+            secretName: "{{ $oauth_admin_secret }}"
+            defaultMode: 420
+            optional: false
   backoffLimit: 4
 


### PR DESCRIPTION
https://jsw.ibm.com/browse/MASCORE-5635

Simple PR to change postsync-oidc job to access the oauth-admin-secret via a volume mount rather than env vars, as per IBM policy. 

This will resolve the operator-maturity test case failure seen in fvtsaas.

# Testing

Changes verified in noble6:
![image](https://github.com/user-attachments/assets/c65a9bd5-8276-4569-b40e-ce0526231d89)

and fvtsaas:
![image](https://github.com/user-attachments/assets/79b224a3-2694-4a73-bf93-defaa396849b)
![image](https://github.com/user-attachments/assets/b1494199-f08c-4351-9226-00bc23d56ce2)
![image](https://github.com/user-attachments/assets/9df95092-6bee-4246-80ce-483a61e38bc2)

