### PR TITLE
[minor] Automate the HADR setup during provisioning

### DIFF
--- a/instance-applications/120-ibm-db2u-database/templates/04-db2u-Backup_Cron.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/04-db2u-Backup_Cron.yaml
@@ -1,4 +1,4 @@
-{{- if and (default .Values.replica_db false) (and .Values.db2_backup_bucket_name (not (contains "sdb" .Values.db2_instance_name))) }}
+{{- if and .Values.db2_backup_bucket_name (not (contains "sdb" .Values.db2_instance_name))  }}
 #apiVersion: batch/v1beta1
 kind: CronJob
 apiVersion: batch/v1

--- a/instance-applications/120-ibm-db2u-database/templates/04-db2u-Backup_Cron.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/04-db2u-Backup_Cron.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.db2_backup_bucket_name (not (contains "sdb" .Values.db2_instance_name))  }}
+{{- if and .Values.db2_backup_bucket_name (not (contains "sdb" .Values.db2_instance_name)) }}
 #apiVersion: batch/v1beta1
 kind: CronJob
 apiVersion: batch/v1

--- a/instance-applications/120-ibm-db2u-database/templates/04-db2u-Backup_Cron.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/04-db2u-Backup_Cron.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.db2_backup_bucket_name (not (contains "sdb" .Values.db2_instance_name)) }}
+{{- if and (default .Values.replica_db false) (and .Values.db2_backup_bucket_name (not (contains "sdb" .Values.db2_instance_name))) }}
 #apiVersion: batch/v1beta1
 kind: CronJob
 apiVersion: batch/v1

--- a/instance-applications/120-ibm-db2u-database/templates/07-postsync-setup-db2_Job.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/07-postsync-setup-db2_Job.yaml
@@ -719,6 +719,11 @@ spec:
                 oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "${INSTHOME}/bin/RUN_OnDemandFULL_BKP.sh | tee /tmp/runondemandfullbackup.log" db2inst1 || exit $?
               fi
 
+              echo ""
+              echo "Taking backup on ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0"
+              echo "--------------------------------------------------------------------------------"
+              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "mkdir -p /mnt/backup/standby; db2 backup db ${DB2_DBNAME} on all dbpartitionnums online to /mnt/backup/standby | tee /mnt/backup/standby/dbbackup.log" db2inst1 || exit $?
+
       restartPolicy: Never
 
       serviceAccountName: "postsync-sa-{{ .Values.db2_instance_name }}"

--- a/instance-applications/120-ibm-db2u-database/templates/07-postsync-setup-db2_Job.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/07-postsync-setup-db2_Job.yaml
@@ -166,6 +166,8 @@ spec:
               value: "{{ .Values.db2_backup_bucket_endpoint }}"
             - name: SLACKURL
               value: "{{ .Values.db2_backup_notify_slack_url }}"
+            - name: REPLICA_DB
+              value: "{{ .Values.replica_db }}"
 {{- end }}
 
           volumeMounts:
@@ -353,6 +355,11 @@ spec:
                 oc cp /tmp/db2-scripts.zip ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/tmp/db2-scripts.zip -c db2u || exit $?
                 oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0  -- su -lc "cd /tmp; unzip -o db2-scripts.zip; chmod -R +x /tmp/db2-scripts" db2inst1 || exit $?
                 oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0  -- su -lc "/tmp/db2-scripts/CopyDBScripts.sh | tee /tmp/copydbscripts.log" db2inst1 || exit $?
+              fi
+
+              IS_HADR_CONFIGURED=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0  -- su -lc "db2 get db cfg for BLUDB | grep HADR_LOCAL_HOST | cut -d'=' -f2 | tr -d ' '" db2inst1`
+              if [[ ! (-z $IS_HADR_CONFIGURED) &&  REPLICA_DB != 'true' ]]; then
+                oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0  -- su -lc "db2 stop hadr on db ${DB2_DBNAME} | tee /tmp/stophadr.log" db2inst1 || exit $?
               fi
 
               if [[ "$MAS_APP_ID" == "manage" ]]; then

--- a/instance-applications/120-ibm-db2u-database/templates/07-postsync-setup-db2_Job.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/07-postsync-setup-db2_Job.yaml
@@ -726,11 +726,6 @@ spec:
                 oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "${INSTHOME}/bin/RUN_OnDemandFULL_BKP.sh | tee /tmp/runondemandfullbackup.log" db2inst1 || exit $?
               fi
 
-              echo ""
-              echo "Taking backup on ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0"
-              echo "--------------------------------------------------------------------------------"
-              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "mkdir -p /mnt/backup/standby; db2 backup db ${DB2_DBNAME} on all dbpartitionnums online to /mnt/backup/standby | tee /mnt/backup/standby/dbbackup.log" db2inst1 || exit $?
-
       restartPolicy: Never
 
       serviceAccountName: "postsync-sa-{{ .Values.db2_instance_name }}"

--- a/instance-applications/120-ibm-db2u-database/templates/09-hadr_services.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/09-hadr_services.yaml
@@ -1,0 +1,45 @@
+{{ if (default .Values.replica_db false) }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: c-{{ .Values.db2_instance_name }}-db2u-hadr-svc
+spec:
+  selector:
+    app: {{ .Values.db2_instance_name }}
+    type: engine
+  ports:
+    - name: db2u-hadrp
+      port: 60006
+      targetPort: 60006
+    - name: db2u-hadrs
+      port: 60007
+      targetPort: 60007
+    - name: db2u-hadra1
+      port: 60008
+      targetPort: 60008
+    - name: db2u-hadra2
+      port: 60009
+      targetPort: 60009
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: c-{{ .Values.db2_instance_name }}-hadr-ext
+spec:
+  ingress:
+  - ports:
+{{- if not (contains "sdb" .Values.db2_instance_name) }}
+    - port: 60006
+{{- else }}
+    - port: 60007
+{{- end }}
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      formation_id: {{ .Values.db2_instance_name }}
+      type: engine
+  policyTypes:
+  - Ingress
+{{ end }}

--- a/instance-applications/120-ibm-db2u-database/templates/09-hadr_services.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/09-hadr_services.yaml
@@ -28,6 +28,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: c-{{ .Values.db2_instance_name }}-hadr-ext
+  namespace: "{{ .Values.db2_namespace }}"
 spec:
   ingress:
   - ports:

--- a/instance-applications/120-ibm-db2u-database/templates/09-hadr_services.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/09-hadr_services.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: c-{{ .Values.db2_instance_name }}-db2u-hadr-svc
+  namespace: "{{ .Values.db2_namespace }}"
 spec:
   selector:
     app: {{ .Values.db2_instance_name }}

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -83,6 +83,7 @@ spec:
 {{- end }}
     spec:
       restartPolicy: Never
+      serviceAccountName: "postsync-hadr-sa-{{ .Values.db2_instance_name }}"
       containers:
         - name: run
           image: quay.io/ibmmas/cli:latest

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -253,15 +253,14 @@ spec:
               db2apply || exit $?
 
               # # Start hadr in standby
-              # echo ""
-              # echo "Starting HADR in standby"
-              # echo "--------------------------------------------------------------------------------"
-              # oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2stop force; db2start; db2 start hadr on db bludb as standby; | tee /tmp//start_hadr_standby.log" db2inst1 || exit $?
+              echo ""
+              echo "Starting HADR in standby"
+              echo "--------------------------------------------------------------------------------"
+              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2stop force; db2start; db2 start hadr on db bludb as standby; | tee /tmp//start_hadr_standby.log" db2inst1 || exit $?
 
               # # Start hadr in Primary
-              # echo ""
-              # echo "Starting HADR in standby"
-              # echo "--------------------------------------------------------------------------------"
-              # oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "db2stop force; db2start; db2 start hadr on db bludb as primary; | tee /tmp//start_hadr_primary.log" db2inst1 || exit $?
-              exit 0
+              echo ""
+              echo "Starting HADR in standby"
+              echo "--------------------------------------------------------------------------------"
+              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "db2stop force; db2start; db2 start hadr on db bludb as primary; | tee /tmp//start_hadr_primary.log" db2inst1 || exit $?
 {{ end }}

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -213,7 +213,7 @@ spec:
               PRIMARY_ROLE=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "db2 get db cfg for BLUDB | grep role | cut -d'=' -f2 | tr -d ' '" db2inst1`
               STANDBY_ROLE=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 get db cfg for BLUDB | grep role | cut -d'=' -f2 | tr -d ' '" db2inst1`
 
-              if [[ ! ($PRIMARY_ROLE -eq 'PRIMARY' && $STANDBY_ROLE -eq 'STANDBY') ]]; then
+              if [[ ! ($PRIMARY_ROLE == 'PRIMARY' && $STANDBY_ROLE == 'STANDBY') ]]; then
                 # Copy the backup from primary to standby
                 echo ""
                 echo "Taking backup on ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0"
@@ -244,6 +244,8 @@ spec:
                 echo "Restoring ${timestamp} in standby server"
                 echo "--------------------------------------------------------------------------------"
                 oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 force applications all; db2 terminate; db2 deactivate db ${DB2_DBNAME}; db2 drop db ${DB2_DBNAME}; db2 restore db ${DB2_DBNAME} from /tmp taken at ${timestamp} with 15 buffers buffer 4096 parallelism 15 encrypt without prompting" db2inst1 || exit $?
+              else
+                echo "HADR is already setup. Hence skipping the restore on standby"
               fi
 
               echo ""

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -216,35 +216,35 @@ spec:
               # oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0  -- su -lc "mkdir -p /mnt/backup/MIRRORLOGPATH" db2inst1 || exit $?
 
               # Copy the backup from primary to standby
-              echo ""
-              echo "Taking backup on ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0"
-              echo "--------------------------------------------------------------------------------"
-              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "db2 backup db ${DB2_DBNAME} on all dbpartitionnums online to /mnt/backup | tee /tmp/dbbackup.log" db2inst1 || exit $?
+              # echo ""
+              # echo "Taking backup on ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0"
+              # echo "--------------------------------------------------------------------------------"
+              # oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "db2 backup db ${DB2_DBNAME} on all dbpartitionnums online to /mnt/backup | tee /tmp/dbbackup.log" db2inst1 || exit $?
 
-              echo ""
-              timestamp=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "cat /tmp/dbbackup.log | grep 'timestamp' | rev | cut -d ' ' -f1 | rev" db2inst1`
-              echo "Timestamp of backup is ${timestamp}"
-              backup_filename=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "ls /mnt/backup | grep ${timestamp}" db2inst1`
-              echo "Backup filename is ${backup_filename}"
+              # echo ""
+              # timestamp=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "cat /tmp/dbbackup.log | grep 'timestamp' | rev | cut -d ' ' -f1 | rev" db2inst1`
+              # echo "Timestamp of backup is ${timestamp}"
+              # backup_filename=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "ls /mnt/backup | grep ${timestamp}" db2inst1`
+              # echo "Backup filename is ${backup_filename}"
 
-              echo ""
-              echo "Copying backup /mnt/backup/${backup_filename} from ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 to ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0 "
-              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "cp /mnt/backup/${backup_filename} /tmp; chmod 777 /tmp/${backup_filename}" db2inst1 || exit $?
-              oc cp ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0:/tmp/${backup_filename} /tmp/${backup_filename}
-              oc cp /tmp/${backup_filename} ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/tmp/${backup_filename}
+              # echo ""
+              # echo "Copying backup /mnt/backup/${backup_filename} from ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 to ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0 "
+              # oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "cp /mnt/backup/${backup_filename} /tmp; chmod 777 /tmp/${backup_filename}" db2inst1 || exit $?
+              # oc cp ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0:/tmp/${backup_filename} /tmp/${backup_filename}
+              # oc cp /tmp/${backup_filename} ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/tmp/${backup_filename}
 
-              echo ""
-              echo "Copying keystore from primary to standby"
-              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "mkdir /tmp/keystore; cp /mnt/blumeta0/db2/keystore/* /tmp/keystore; chmod -R 777 /tmp/keystore" db2inst1 || exit $?
-              oc rsync ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0:/tmp/keystore /tmp
-              oc rsync /tmp/keystore ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/tmp
-              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "mv /mnt/blumeta0/db2/keystore/keystore.p12 /mnt/blumeta0/db2/keystore/keystore.p12_orig; mv /mnt/blumeta0/db2/keystore/keystore.sth /mnt/blumeta0/db2/keystore/keystore.sth_orig; cp /tmp/keystore/keystore.* /mnt/blumeta0/db2/keystore/; chown db2inst1.db2iadm1 /mnt/blumeta0/db2/keystore/keystore.*; chmod 600 /mnt/blumeta0/db2/keystore/keystore.*;" db2inst1 || exit $?
+              # echo ""
+              # echo "Copying keystore from primary to standby"
+              # oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "mkdir /tmp/keystore; cp /mnt/blumeta0/db2/keystore/* /tmp/keystore; chmod -R 777 /tmp/keystore" db2inst1 || exit $?
+              # oc rsync ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0:/tmp/keystore /tmp
+              # oc rsync /tmp/keystore ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/tmp
+              # oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "mv /mnt/blumeta0/db2/keystore/keystore.p12 /mnt/blumeta0/db2/keystore/keystore.p12_orig; mv /mnt/blumeta0/db2/keystore/keystore.sth /mnt/blumeta0/db2/keystore/keystore.sth_orig; cp /tmp/keystore/keystore.* /mnt/blumeta0/db2/keystore/; chown db2inst1.db2iadm1 /mnt/blumeta0/db2/keystore/keystore.*; chmod 600 /mnt/blumeta0/db2/keystore/keystore.*;" db2inst1 || exit $?
 
               # Restore in standby
-              echo ""
-              echo "Restoring ${timestamp} in standby server"
-              echo "--------------------------------------------------------------------------------"
-              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 force applications all; db2 terminate; db2 deactivate db ${DB2_DBNAME}; db2 drop db ${DB2_DBNAME}; db2 restore db ${DB2_DBNAME} from /tmp taken at ${timestamp} with 15 buffers buffer 4096 parallelism 15 encrypt without prompting" db2inst1 || exit $?
+              # echo ""
+              # echo "Restoring ${timestamp} in standby server"
+              # echo "--------------------------------------------------------------------------------"
+              # oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 force applications all; db2 terminate; db2 deactivate db ${DB2_DBNAME}; db2 drop db ${DB2_DBNAME}; db2 restore db ${DB2_DBNAME} from /tmp taken at ${timestamp} with 15 buffers buffer 4096 parallelism 15 encrypt without prompting" db2inst1 || exit $?
 
               echo ""
               echo "================================================================================"
@@ -260,7 +260,7 @@ spec:
 
               # # Start hadr in Primary
               echo ""
-              echo "Starting HADR in standby"
+              echo "Starting HADR in primary"
               echo "--------------------------------------------------------------------------------"
               oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "db2stop force; db2start; db2 start hadr on db bludb as primary | tee /tmp//start_hadr_primary.log" db2inst1 || exit $?
 {{ end }}

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -210,16 +210,10 @@ spec:
               echo "================================================================================"
               wait_for_resource "svc" "c-${DB2_INSTANCE_NAME:0:-4}-db2u-engn-svc" "${DB2_NAMESPACE}"
 
-              echo ""
-              echo "Creating /mnt/backup/MIRRORLOGPATH in c-${DB2_INSTANCE_NAME}-db2u-0"
-              echo "--------------------------------------------------------------------------------"
-              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0  -- su -lc "mkdir -p /mnt/backup/MIRRORLOGPATH" db2inst1 || exit $?
-
-              echo ""
-              echo "================================================================================"
-              echo "Calling apply-db2cfg-settings.sh file on c-${DB2_INSTANCE_NAME}-db2u-0"
-              echo "================================================================================"
-              db2apply || exit $?
+              # echo ""
+              # echo "Creating /mnt/backup/MIRRORLOGPATH in c-${DB2_INSTANCE_NAME}-db2u-0"
+              # echo "--------------------------------------------------------------------------------"
+              # oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0  -- su -lc "mkdir -p /mnt/backup/MIRRORLOGPATH" db2inst1 || exit $?
 
               # Copy the backup from primary to standby
               echo ""
@@ -246,12 +240,17 @@ spec:
               oc rsync /tmp/keystore ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/tmp
               oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "mv /mnt/blumeta0/db2/keystore/keystore.p12 /mnt/blumeta0/db2/keystore/keystore.p12_orig; mv /mnt/blumeta0/db2/keystore/keystore.sth /mnt/blumeta0/db2/keystore/keystore.sth_orig; cp /tmp/keystore/keystore.* /mnt/blumeta0/db2/keystore/; chown db2inst1.db2iadm1 /mnt/blumeta0/db2/keystore/keystore.*; chmod 600 /mnt/blumeta0/db2/keystore/keystore.*;" db2inst1 || exit $?
 
-
               # Restore in standby
               echo ""
               echo "Restoring ${timestamp} in standby server"
               echo "--------------------------------------------------------------------------------"
               oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 force applications all; db2 terminate; db2 deactivate db ${DB2_DBNAME}; db2 drop db ${DB2_DBNAME}; db2 restore db ${DB2_DBNAME} from /tmp taken at ${timestamp} with 15 buffers buffer 4096 parallelism 15 encrypt without prompting" db2inst1 || exit $?
+
+              echo ""
+              echo "================================================================================"
+              echo "Calling apply-db2cfg-settings.sh file on c-${DB2_INSTANCE_NAME}-db2u-0"
+              echo "================================================================================"
+              db2apply || exit $?
 
               # # Start hadr in standby
               # echo ""

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -248,10 +248,10 @@ spec:
 
 
               # Restore in standby
-              # echo ""
-              # echo "Restoring ${timestamp} in standby server"
-              # echo "--------------------------------------------------------------------------------"
-              # oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 drop db ${DB2_DBNAME}; db2 restore db ${DB2_DBNAME} taken at ${timestamp}" db2inst1 | | exit $?
+              echo ""
+              echo "Restoring ${timestamp} in standby server"
+              echo "--------------------------------------------------------------------------------"
+              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 force applications all; db2 terminate; db2 deactivate db ${DB2_DBNAME}; db2 drop db ${DB2_DBNAME}; db2 restore db ${DB2_DBNAME} from /tmp taken at ${timestamp} with 15 buffers buffer 4096 parallelism 15 encrypt without prompting" db2inst1 | | exit $?
 
               # # Start hadr in standby
               # echo ""

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -251,7 +251,7 @@ spec:
               echo ""
               echo "Restoring ${timestamp} in standby server"
               echo "--------------------------------------------------------------------------------"
-              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 force applications all; db2 terminate; db2 deactivate db ${DB2_DBNAME}; db2 drop db ${DB2_DBNAME}; db2 restore db ${DB2_DBNAME} from /tmp taken at ${timestamp} with 15 buffers buffer 4096 parallelism 15 encrypt without prompting" db2inst1 | | exit $?
+              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 force applications all; db2 terminate; db2 deactivate db ${DB2_DBNAME}; db2 drop db ${DB2_DBNAME}; db2 restore db ${DB2_DBNAME} from /tmp taken at ${timestamp} with 15 buffers buffer 4096 parallelism 15 encrypt without prompting" db2inst1 || exit $?
 
               # # Start hadr in standby
               # echo ""

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -235,7 +235,7 @@ spec:
 
               echo ""
               echo "Copying backup /mnt/backup/${backup_filename} from ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 to ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0 "
-              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "cp /mnt/backup/${backup_filename} /tmp" db2inst1
+              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "cp /mnt/backup/${backup_filename} /tmp; chmod 777 /tmp/${backup_filename}" db2inst1 || exit $?
               oc cp ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0:/tmp/${backup_filename} /tmp/${backup_filename}
               oc cp /tmp/${backup_filename} ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/tmp/${backup_filename}
 

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -210,8 +210,8 @@ spec:
               echo "================================================================================"
               wait_for_resource "svc" "c-${DB2_INSTANCE_NAME:0:-4}-db2u-engn-svc" "${DB2_NAMESPACE}"
 
-              PRIMARY_ROLE=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "db2 get db cfg for BLUDB | grep role | awk '{print $5}'" db2inst1`
-              STANDBY_ROLE=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 get db cfg for BLUDB | grep role | awk '{print $5}'" db2inst1`
+              PRIMARY_ROLE=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "db2 get db cfg for BLUDB | grep role | cut -d'=' -f2 | tr -d ' '" db2inst1`
+              STANDBY_ROLE=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 get db cfg for BLUDB | grep role | cut -d'=' -f2 | tr -d ' '" db2inst1`
 
               if [[ ! ($PRIMARY_ROLE -eq 'PRIMARY' && $STANDBY_ROLE -eq 'STANDBY') ]]; then
                 # Copy the backup from primary to standby

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -1,5 +1,65 @@
 {{ if and (default .Values.replica_db false) (contains "sdb" .Values.db2_instance_name) }}
 ---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: "postsync-hadr-sa-{{ .Values.db2_instance_name }}"
+  namespace: "{{ .Values.db2_namespace }}"
+  annotations:
+    argocd.argoproj.io/sync-wave: "128"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "db2-database-postsync-hadr-sa-role-{{ .Values.db2_instance_name }}"
+  namespace: "{{ .Values.db2_namespace }}"
+  annotations:
+    argocd.argoproj.io/sync-wave: "128"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+rules:
+- apiGroups:
+    - ""
+  resources:
+    - pods
+  verbs:
+    - get
+- apiGroups:
+    - ""
+  resources:
+    - pods/exec
+  verbs:
+    - get
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "db2-database-postsync-hadr-sa-rb-{{ .Values.db2_instance_name }}"
+  namespace: "{{ .Values.db2_namespace }}"
+  annotations:
+    argocd.argoproj.io/sync-wave: "128"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+subjects:
+  - kind: ServiceAccount
+    name: "postsync-hadr-sa-{{ .Values.db2_instance_name }}"
+    namespace: "{{ .Values.db2_namespace }}"
+roleRef:
+  kind: Role
+  name: "db2-database-postsync-hadr-sa-role-{{ .Values.db2_instance_name }}"
+  apiGroup: rbac.authorization.k8s.io
+
 ---
 apiVersion: batch/v1
 kind: Job

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -41,6 +41,7 @@ rules:
   verbs:
     - get
     - list
+    - create
 - apiGroups:
     - ""
   resources:

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -218,6 +218,18 @@ spec:
                 echo ""
                 timestamp=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "cat /mnt/backup/standby/dbbackup.log | grep 'timestamp' | rev | cut -d ' ' -f1 | rev" db2inst1`
                 echo "Timestamp of backup is ${timestamp}"
+
+                if [[ -z ${timestamp} ]]; then
+                  echo "Backup is not available in primary. Attempting to backup"
+                  echo ""
+                  echo "Taking backup on ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0"
+                  echo "--------------------------------------------------------------------------------"
+                  oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "mkdir -p /mnt/backup/standby; db2 backup db ${DB2_DBNAME} on all dbpartitionnums online to /mnt/backup/standby | tee /mnt/backup/standby/dbbackup.log" db2inst1 || exit $?
+                  echo ""
+                  timestamp=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "cat /mnt/backup/standby/dbbackup.log | grep 'timestamp' | rev | cut -d ' ' -f1 | rev" db2inst1`
+                  echo "Timestamp of backup is ${timestamp}"
+                fi
+
                 backup_filename=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "ls /mnt/backup/standby | grep ${timestamp}" db2inst1`
                 echo "Backup filename is ${backup_filename}"
 

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -210,41 +210,41 @@ spec:
               echo "================================================================================"
               wait_for_resource "svc" "c-${DB2_INSTANCE_NAME:0:-4}-db2u-engn-svc" "${DB2_NAMESPACE}"
 
-              # echo ""
-              # echo "Creating /mnt/backup/MIRRORLOGPATH in c-${DB2_INSTANCE_NAME}-db2u-0"
-              # echo "--------------------------------------------------------------------------------"
-              # oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0  -- su -lc "mkdir -p /mnt/backup/MIRRORLOGPATH" db2inst1 || exit $?
+              PRIMARY_ROLE=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "db2 get db cfg for BLUDB | grep role | awk '{print $5}'" db2inst1`
+              STANDBY_ROLE=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 get db cfg for BLUDB | grep role | awk '{print $5}'" db2inst1`
 
-              # Copy the backup from primary to standby
-              echo ""
-              echo "Taking backup on ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0"
-              echo "--------------------------------------------------------------------------------"
-              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "db2 backup db ${DB2_DBNAME} on all dbpartitionnums online to /mnt/backup | tee /tmp/dbbackup.log" db2inst1 || exit $?
+              if [[ ! ($PRIMARY_ROLE -eq 'PRIMARY' && $STANDBY_ROLE -eq 'STANDBY') ]]; then
+                # Copy the backup from primary to standby
+                echo ""
+                echo "Taking backup on ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0"
+                echo "--------------------------------------------------------------------------------"
+                oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "db2 backup db ${DB2_DBNAME} on all dbpartitionnums online to /mnt/backup | tee /tmp/dbbackup.log" db2inst1 || exit $?
 
-              echo ""
-              timestamp=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "cat /tmp/dbbackup.log | grep 'timestamp' | rev | cut -d ' ' -f1 | rev" db2inst1`
-              echo "Timestamp of backup is ${timestamp}"
-              backup_filename=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "ls /mnt/backup | grep ${timestamp}" db2inst1`
-              echo "Backup filename is ${backup_filename}"
+                echo ""
+                timestamp=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "cat /tmp/dbbackup.log | grep 'timestamp' | rev | cut -d ' ' -f1 | rev" db2inst1`
+                echo "Timestamp of backup is ${timestamp}"
+                backup_filename=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "ls /mnt/backup | grep ${timestamp}" db2inst1`
+                echo "Backup filename is ${backup_filename}"
 
-              echo ""
-              echo "Copying backup /mnt/backup/${backup_filename} from ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 to ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0 "
-              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "cp /mnt/backup/${backup_filename} /tmp; chmod 777 /tmp/${backup_filename}" db2inst1 || exit $?
-              oc cp ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0:/tmp/${backup_filename} /tmp/${backup_filename}
-              oc cp /tmp/${backup_filename} ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/tmp/${backup_filename}
+                echo ""
+                echo "Copying backup /mnt/backup/${backup_filename} from ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 to ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0 "
+                oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "cp /mnt/backup/${backup_filename} /tmp; chmod 777 /tmp/${backup_filename}" db2inst1 || exit $?
+                oc cp ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0:/tmp/${backup_filename} /tmp/${backup_filename}
+                oc cp /tmp/${backup_filename} ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/tmp/${backup_filename}
 
-              echo ""
-              echo "Copying keystore from primary to standby"
-              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "mkdir /tmp/keystore; cp /mnt/blumeta0/db2/keystore/* /tmp/keystore; chmod -R 777 /tmp/keystore" db2inst1 || exit $?
-              oc rsync ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0:/tmp/keystore /tmp
-              oc rsync /tmp/keystore ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/tmp
-              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "mv /mnt/blumeta0/db2/keystore/keystore.p12 /mnt/blumeta0/db2/keystore/keystore.p12_orig; mv /mnt/blumeta0/db2/keystore/keystore.sth /mnt/blumeta0/db2/keystore/keystore.sth_orig; cp /tmp/keystore/keystore.* /mnt/blumeta0/db2/keystore/; chown db2inst1.db2iadm1 /mnt/blumeta0/db2/keystore/keystore.*; chmod 600 /mnt/blumeta0/db2/keystore/keystore.*;" db2inst1 || exit $?
+                echo ""
+                echo "Copying keystore from primary to standby"
+                oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "mkdir /tmp/keystore; cp /mnt/blumeta0/db2/keystore/* /tmp/keystore; chmod -R 777 /tmp/keystore" db2inst1 || exit $?
+                oc rsync ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0:/tmp/keystore /tmp
+                oc rsync /tmp/keystore ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/tmp
+                oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "mv /mnt/blumeta0/db2/keystore/keystore.p12 /mnt/blumeta0/db2/keystore/keystore.p12_orig; mv /mnt/blumeta0/db2/keystore/keystore.sth /mnt/blumeta0/db2/keystore/keystore.sth_orig; cp /tmp/keystore/keystore.* /mnt/blumeta0/db2/keystore/; chown db2inst1.db2iadm1 /mnt/blumeta0/db2/keystore/keystore.*; chmod 600 /mnt/blumeta0/db2/keystore/keystore.*;" db2inst1 || exit $?
 
-              # Restore in standby
-              echo ""
-              echo "Restoring ${timestamp} in standby server"
-              echo "--------------------------------------------------------------------------------"
-              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 force applications all; db2 terminate; db2 deactivate db ${DB2_DBNAME}; db2 drop db ${DB2_DBNAME}; db2 restore db ${DB2_DBNAME} from /tmp taken at ${timestamp} with 15 buffers buffer 4096 parallelism 15 encrypt without prompting" db2inst1 || exit $?
+                # Restore in standby
+                echo ""
+                echo "Restoring ${timestamp} in standby server"
+                echo "--------------------------------------------------------------------------------"
+                oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 force applications all; db2 terminate; db2 deactivate db ${DB2_DBNAME}; db2 drop db ${DB2_DBNAME}; db2 restore db ${DB2_DBNAME} from /tmp taken at ${timestamp} with 15 buffers buffer 4096 parallelism 15 encrypt without prompting" db2inst1 || exit $?
+              fi
 
               echo ""
               echo "================================================================================"

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -191,6 +191,11 @@ spec:
               wait_for_resource "svc" "c-${DB2_INSTANCE_NAME}-db2u-engn-svc" "${DB2_NAMESPACE}"
 
               echo ""
+              echo "Creating /mnt/backup/MIRRORLOGPATH in c-${DB2_INSTANCE_NAME}-db2u-0"
+              echo "--------------------------------------------------------------------------------"
+              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0  -- su -lc "mkdir -p /mnt/backup/MIRRORLOGPATH" db2inst1 || exit $?
+
+              echo ""
               echo "================================================================================"
               echo "Calling apply-db2cfg-settings.sh file on c-${DB2_INSTANCE_NAME}-db2u-0"
               echo "================================================================================"

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -228,8 +228,10 @@ spec:
               oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "db2 backup db ${DB2_DBNAME} on all dbpartitionnums online to /mnt/backup | tee /tmp/dbbackup.log" db2inst1 || exit $?
 
               echo ""
-              timestamp=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "cat /tmp/dbbackup.log | grep timestamp | awk '{print $NF}'" db2inst1`
-              backup_filename=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "ls /mnt/backup | grep ${timestamp} " db2inst1`
+              timestamp=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "cat /tmp/dbbackup.log | grep 'timestamp' | awk '{print $NF}'" db2inst1`
+              echo "Timestamp of backup is ${timestamp}"
+              backup_filename=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "ls /mnt/backup | grep ${timestamp}" db2inst1`
+              echo "Backup filename is ${backup_filename}"
 
               echo ""
               echo "Copying backup /mnt/backup/${backup_filename} from ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 to ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0 "

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -221,7 +221,7 @@ spec:
               echo "================================================================================"
               db2apply || exit $?
 
-              # Copy the backup from primary and restore in standby
+              # Copy the backup from primary to standby
               echo ""
               echo "Taking backup on ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0"
               echo "--------------------------------------------------------------------------------"
@@ -238,6 +238,20 @@ spec:
               oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "cp /mnt/backup/${backup_filename} /tmp; chmod 777 /tmp/${backup_filename}" db2inst1 || exit $?
               oc cp ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0:/tmp/${backup_filename} /tmp/${backup_filename}
               oc cp /tmp/${backup_filename} ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/tmp/${backup_filename}
+
+              echo ""
+              echo "Copying keystore from primary to standby"
+              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "mkdir /tmp/keystore; cp /mnt/blumeta0/db2/keystore/* /tmp/keystore; chmod -R 777 /tmp/keystore" db2inst1 || exit $?
+              oc rsync ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0:/tmp/keystore/ /tmp
+              oc rsync /tmp/keystore ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/tmp
+              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "mv /mnt/blumeta0/db2/keystore/keystore.p12 /mnt/blumeta0/db2/keystore/keystore.p12_orig; mv /mnt/blumeta0/db2/keystore/keystore.sth /mnt/blumeta0/db2/keystore/keystore.sth_orig; cp /tmp/keystore/keystore.* /mnt/blumeta0/db2/keystore/; chown db2inst1.db2iadm1 /mnt/blumeta0/db2/keystore/keystore.*; chmod 600 /mnt/blumeta0/db2/keystore/keystore.*;" db2inst1 || exit $?
+
+
+              # Restore in standby
+              # echo ""
+              # echo "Restoring ${timestamp} in standby server"
+              # echo "--------------------------------------------------------------------------------"
+              # oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 drop db ${DB2_DBNAME}; db2 restore db ${DB2_DBNAME} taken at ${timestamp}" db2inst1 | | exit $?
 
               # # Start hadr in standby
               # echo ""

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -82,7 +82,7 @@ kind: Job
 metadata:
   # Suffix the Job name with a hash of all chart values
   # This is to ensure that ArgoCD will delete and recreate the job if (and only if) anything changes in the DB2 config
-  name: postsync-setup-hadr-{{ .Values.db2_instance_name }}-v1-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
+  name: postsync-setup-hadr-{{ .Values.db2_instance_name }}-v1
   namespace: "{{ .Values.db2_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "130"

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -235,7 +235,8 @@ spec:
 
               echo ""
               echo "Copying backup /mnt/backup/${backup_filename} from ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 to ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0 "
-              oc cp ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0:/mnt/backup/${backup_filename} ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/mnt/backup/${backup_filename}
+              oc cp ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0:/mnt/backup/${backup_filename} /tmp/${backup_filename}
+              oc cp /tmp/${backup_filename} ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/mnt/backup/${backup_filename}
 
               # # Start hadr in standby
               # echo ""

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -228,7 +228,7 @@ spec:
               oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "db2 backup db ${DB2_DBNAME} on all dbpartitionnums online to /mnt/backup | tee /tmp/dbbackup.log" db2inst1 || exit $?
 
               echo ""
-              timestamp=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "cat /tmp/dbbackup.log | grep 'timestamp' | awk '{print $NF}'" db2inst1`
+              timestamp=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "cat /tmp/dbbackup.log | grep 'timestamp' | rev | cut -d ' ' -f1 | rev" db2inst1`
               echo "Timestamp of backup is ${timestamp}"
               backup_filename=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "ls /mnt/backup | grep ${timestamp}" db2inst1`
               echo "Backup filename is ${backup_filename}"

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -211,11 +211,11 @@ spec:
               wait_for_resource "svc" "c-${DB2_INSTANCE_NAME:0:-4}-db2u-engn-svc" "${DB2_NAMESPACE}"
 
               # echo ""
-              echo "Creating /mnt/backup/MIRRORLOGPATH in c-${DB2_INSTANCE_NAME}-db2u-0"
-              echo "--------------------------------------------------------------------------------"
-              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0  -- su -lc "mkdir -p /mnt/backup/MIRRORLOGPATH" db2inst1 || exit $?
+              # echo "Creating /mnt/backup/MIRRORLOGPATH in c-${DB2_INSTANCE_NAME}-db2u-0"
+              # echo "--------------------------------------------------------------------------------"
+              # oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0  -- su -lc "mkdir -p /mnt/backup/MIRRORLOGPATH" db2inst1 || exit $?
 
-              Copy the backup from primary to standby
+              # Copy the backup from primary to standby
               echo ""
               echo "Taking backup on ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0"
               echo "--------------------------------------------------------------------------------"

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -32,12 +32,15 @@ rules:
     - pods
   verbs:
     - get
+    - list
+    - watch
 - apiGroups:
     - ""
   resources:
     - pods/exec
   verbs:
     - get
+    - list
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -211,40 +211,40 @@ spec:
               wait_for_resource "svc" "c-${DB2_INSTANCE_NAME:0:-4}-db2u-engn-svc" "${DB2_NAMESPACE}"
 
               # echo ""
-              # echo "Creating /mnt/backup/MIRRORLOGPATH in c-${DB2_INSTANCE_NAME}-db2u-0"
-              # echo "--------------------------------------------------------------------------------"
-              # oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0  -- su -lc "mkdir -p /mnt/backup/MIRRORLOGPATH" db2inst1 || exit $?
+              echo "Creating /mnt/backup/MIRRORLOGPATH in c-${DB2_INSTANCE_NAME}-db2u-0"
+              echo "--------------------------------------------------------------------------------"
+              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0  -- su -lc "mkdir -p /mnt/backup/MIRRORLOGPATH" db2inst1 || exit $?
 
-              # Copy the backup from primary to standby
-              # echo ""
-              # echo "Taking backup on ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0"
-              # echo "--------------------------------------------------------------------------------"
-              # oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "db2 backup db ${DB2_DBNAME} on all dbpartitionnums online to /mnt/backup | tee /tmp/dbbackup.log" db2inst1 || exit $?
+              Copy the backup from primary to standby
+              echo ""
+              echo "Taking backup on ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0"
+              echo "--------------------------------------------------------------------------------"
+              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "db2 backup db ${DB2_DBNAME} on all dbpartitionnums online to /mnt/backup | tee /tmp/dbbackup.log" db2inst1 || exit $?
 
-              # echo ""
-              # timestamp=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "cat /tmp/dbbackup.log | grep 'timestamp' | rev | cut -d ' ' -f1 | rev" db2inst1`
-              # echo "Timestamp of backup is ${timestamp}"
-              # backup_filename=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "ls /mnt/backup | grep ${timestamp}" db2inst1`
-              # echo "Backup filename is ${backup_filename}"
+              echo ""
+              timestamp=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "cat /tmp/dbbackup.log | grep 'timestamp' | rev | cut -d ' ' -f1 | rev" db2inst1`
+              echo "Timestamp of backup is ${timestamp}"
+              backup_filename=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "ls /mnt/backup | grep ${timestamp}" db2inst1`
+              echo "Backup filename is ${backup_filename}"
 
-              # echo ""
-              # echo "Copying backup /mnt/backup/${backup_filename} from ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 to ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0 "
-              # oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "cp /mnt/backup/${backup_filename} /tmp; chmod 777 /tmp/${backup_filename}" db2inst1 || exit $?
-              # oc cp ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0:/tmp/${backup_filename} /tmp/${backup_filename}
-              # oc cp /tmp/${backup_filename} ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/tmp/${backup_filename}
+              echo ""
+              echo "Copying backup /mnt/backup/${backup_filename} from ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 to ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0 "
+              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "cp /mnt/backup/${backup_filename} /tmp; chmod 777 /tmp/${backup_filename}" db2inst1 || exit $?
+              oc cp ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0:/tmp/${backup_filename} /tmp/${backup_filename}
+              oc cp /tmp/${backup_filename} ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/tmp/${backup_filename}
 
-              # echo ""
-              # echo "Copying keystore from primary to standby"
-              # oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "mkdir /tmp/keystore; cp /mnt/blumeta0/db2/keystore/* /tmp/keystore; chmod -R 777 /tmp/keystore" db2inst1 || exit $?
-              # oc rsync ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0:/tmp/keystore /tmp
-              # oc rsync /tmp/keystore ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/tmp
-              # oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "mv /mnt/blumeta0/db2/keystore/keystore.p12 /mnt/blumeta0/db2/keystore/keystore.p12_orig; mv /mnt/blumeta0/db2/keystore/keystore.sth /mnt/blumeta0/db2/keystore/keystore.sth_orig; cp /tmp/keystore/keystore.* /mnt/blumeta0/db2/keystore/; chown db2inst1.db2iadm1 /mnt/blumeta0/db2/keystore/keystore.*; chmod 600 /mnt/blumeta0/db2/keystore/keystore.*;" db2inst1 || exit $?
+              echo ""
+              echo "Copying keystore from primary to standby"
+              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "mkdir /tmp/keystore; cp /mnt/blumeta0/db2/keystore/* /tmp/keystore; chmod -R 777 /tmp/keystore" db2inst1 || exit $?
+              oc rsync ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0:/tmp/keystore /tmp
+              oc rsync /tmp/keystore ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/tmp
+              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "mv /mnt/blumeta0/db2/keystore/keystore.p12 /mnt/blumeta0/db2/keystore/keystore.p12_orig; mv /mnt/blumeta0/db2/keystore/keystore.sth /mnt/blumeta0/db2/keystore/keystore.sth_orig; cp /tmp/keystore/keystore.* /mnt/blumeta0/db2/keystore/; chown db2inst1.db2iadm1 /mnt/blumeta0/db2/keystore/keystore.*; chmod 600 /mnt/blumeta0/db2/keystore/keystore.*;" db2inst1 || exit $?
 
               # Restore in standby
-              # echo ""
-              # echo "Restoring ${timestamp} in standby server"
-              # echo "--------------------------------------------------------------------------------"
-              # oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 force applications all; db2 terminate; db2 deactivate db ${DB2_DBNAME}; db2 drop db ${DB2_DBNAME}; db2 restore db ${DB2_DBNAME} from /tmp taken at ${timestamp} with 15 buffers buffer 4096 parallelism 15 encrypt without prompting" db2inst1 || exit $?
+              echo ""
+              echo "Restoring ${timestamp} in standby server"
+              echo "--------------------------------------------------------------------------------"
+              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 force applications all; db2 terminate; db2 deactivate db ${DB2_DBNAME}; db2 drop db ${DB2_DBNAME}; db2 restore db ${DB2_DBNAME} from /tmp taken at ${timestamp} with 15 buffers buffer 4096 parallelism 15 encrypt without prompting" db2inst1 || exit $?
 
               echo ""
               echo "================================================================================"

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -82,7 +82,7 @@ kind: Job
 metadata:
   # Suffix the Job name with a hash of all chart values
   # This is to ensure that ArgoCD will delete and recreate the job if (and only if) anything changes in the DB2 config
-  name: postsync-setup-hadr-{{ .Values.db2_instance_name }}-v1
+  name: postsync-setup-hadr-{{ .Values.db2_instance_name }}-v1-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
   namespace: "{{ .Values.db2_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "130"
@@ -102,7 +102,7 @@ spec:
       serviceAccountName: "postsync-hadr-sa-{{ .Values.db2_instance_name }}"
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:latest
+          image: quay.io/ibmmas/cli:13.8.1-pre.hadr-replicadb-amd64
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -159,19 +159,50 @@ spec:
                 return 1
               }
 
-
-              # The Db2u operator is capable of automatically applying dbConfig, dbmConfig and registry configuration parameters specified on the Db2uInstance CR.
-              # However, certain parameters (e.g. MIRRORLOGPATH)  may reference paths on the db2u pod (e.g. /mnt/backup/MIRRORLOGPATH) that do not exist until 
-              # after the operator has already attemped to apply settings (which it will not subsequently reattempt if something went wrong).
-              # To work around this, we manually re-invoke this process again by calling the '/db2u/scripts/apply-db2cfg-settings.sh --setting all' script on the db2 pod.
-
-              # Moreover, the Db2u operator it does not give any indication on any CR if something went wrong while attempting to apply these settings (and no meaningful return code is provided by the apply-db2cfg-settings.sh script)
-              # For this reason, we are forced to perform our own verification that the settings on the Db2uInstance CR align with those active in DB2 
-              # This is done using the "mas-devops-db2-validate-config" command from the mas-devops library (see https://github.com/ibm-mas/python-devops)
               function db2apply {
-                echo ""
-                oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc '/db2u/scripts/apply-db2cfg-settings.sh --setting all | tee /tmp/apply-db2cfg-settings.log' db2inst1
-                # no useful info in return code of this script
+                RETRIES=${1:-5}
+                RETRY_DELAY_SECONDS=${2:-30}
+
+                mas-devops-db2-validate-config --mas-instance-id ${MAS_INSTANCE_ID} --mas-app-id ${MAS_APP_ID} --database-role standby --log-level DEBUG || rc=$?
+                if [[ "$rc" == "0" ]]; then
+                  echo "... db2 config already matches expected config, returning without calling apply-db2cfg-settings"
+                  return 0
+                fi
+
+                for (( c=1; c<="${RETRIES}"; c++ )); do
+                  echo ""
+                  echo "... attempt ${c} of ${RETRIES}"
+                  oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc '/db2u/scripts/apply-db2cfg-settings.sh --setting all | tee /tmp/apply-db2cfg-settings.log' db2inst1
+                  # no useful info in return code of this script
+
+                  rc=0
+                  mas-devops-db2-validate-config --mas-instance-id ${MAS_INSTANCE_ID} --mas-app-id ${MAS_APP_ID} --database-role standby --log-level DEBUG || rc=$?
+                  if [[ "$rc" == "0" ]]; then
+                    echo "...... success"
+
+                    # # Start hadr in standby
+                    echo ""
+                    echo "Starting HADR in standby"
+                    echo "--------------------------------------------------------------------------------"
+                    oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2stop force; db2start; db2 start hadr on db bludb as standby" db2inst1 || exit $?
+
+                    # # Start hadr in Primary
+                    echo ""
+                    echo "Starting HADR in primary"
+                    echo "--------------------------------------------------------------------------------"
+                    oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2stop force; db2start; db2 start hadr on db bludb as primary" db2inst1 || exit $?
+
+                    return 0
+                  fi
+
+                  if [[ "${c}" -lt "${RETRIES}" ]]; then
+                    echo "...... failed (rc: ${rc}), retry in ${RETRY_DELAY_SECONDS}s"
+                    sleep $RETRY_DELAY_SECONDS
+                  fi
+                done
+
+                echo "...... failed, no attempts remain"
+                return 1
               }
 
               PRIMARY_DB2_INSTANCE_NAME=${DB2_INSTANCE_NAME:0:-4}
@@ -263,15 +294,4 @@ spec:
               echo "================================================================================"
               db2apply || exit $?
 
-              # # Start hadr in standby
-              echo ""
-              echo "Starting HADR in standby"
-              echo "--------------------------------------------------------------------------------"
-              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2stop force; db2start; db2 start hadr on db bludb as standby" db2inst1 || exit $?
-
-              # # Start hadr in Primary
-              echo ""
-              echo "Starting HADR in primary"
-              echo "--------------------------------------------------------------------------------"
-              oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2stop force; db2start; db2 start hadr on db bludb as primary" db2inst1 || exit $?
 {{ end }}

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -166,36 +166,9 @@ spec:
               # For this reason, we are forced to perform our own verification that the settings on the Db2uInstance CR align with those active in DB2 
               # This is done using the "mas-devops-db2-validate-config" command from the mas-devops library (see https://github.com/ibm-mas/python-devops)
               function db2apply {
-                RETRIES=${1:-5}
-                RETRY_DELAY_SECONDS=${2:-30}
-
-                mas-devops-db2-validate-config --mas-instance-id ${MAS_INSTANCE_ID} --mas-app-id ${MAS_APP_ID} --log-level DEBUG || rc=$?
-                if [[ "$rc" == "0" ]]; then
-                  echo "... db2 config already matches expected config, returning without calling apply-db2cfg-settings"
-                  return 0
-                fi
-
-                for (( c=1; c<="${RETRIES}"; c++ )); do
-                  echo ""
-                  echo "... attempt ${c} of ${RETRIES}"
-                  oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc '/db2u/scripts/apply-db2cfg-settings.sh --setting all | tee /tmp/apply-db2cfg-settings.log' db2inst1
-                  # no useful info in return code of this script
-
-                  rc=0
-                  mas-devops-db2-validate-config --mas-instance-id ${MAS_INSTANCE_ID} --mas-app-id ${MAS_APP_ID} --log-level DEBUG || rc=$?
-                  if [[ "$rc" == "0" ]]; then
-                    echo "...... success"
-                    return 0
-                  fi
-
-                  if [[ "${c}" -lt "${RETRIES}" ]]; then
-                    echo "...... failed (rc: ${rc}), retry in ${RETRY_DELAY_SECONDS}s"
-                    sleep $RETRY_DELAY_SECONDS
-                  fi
-                done
-
-                echo "...... failed, no attempts remain"
-                return 1
+                echo ""
+                oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc '/db2u/scripts/apply-db2cfg-settings.sh --setting all | tee /tmp/apply-db2cfg-settings.log' db2inst1
+                # no useful info in return code of this script
               }
 
               echo ""

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -242,7 +242,7 @@ spec:
               echo ""
               echo "Copying keystore from primary to standby"
               oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "mkdir /tmp/keystore; cp /mnt/blumeta0/db2/keystore/* /tmp/keystore; chmod -R 777 /tmp/keystore" db2inst1 || exit $?
-              oc rsync ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0:/tmp/keystore/ /tmp
+              oc rsync ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0:/tmp/keystore /tmp
               oc rsync /tmp/keystore ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/tmp
               oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "mv /mnt/blumeta0/db2/keystore/keystore.p12 /mnt/blumeta0/db2/keystore/keystore.p12_orig; mv /mnt/blumeta0/db2/keystore/keystore.sth /mnt/blumeta0/db2/keystore/keystore.sth_orig; cp /tmp/keystore/keystore.* /mnt/blumeta0/db2/keystore/; chown db2inst1.db2iadm1 /mnt/blumeta0/db2/keystore/keystore.*; chmod 600 /mnt/blumeta0/db2/keystore/keystore.*;" db2inst1 || exit $?
 

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -120,6 +120,8 @@ spec:
               value: "{{ .Values.db2_namespace }}"
             - name: DB2_INSTANCE_NAME
               value: "{{ .Values.db2_instance_name }}"
+            - name: DB2_DBNAME
+              value: "{{ .Values.db2_dbname }}"
           command:
             - /bin/sh
             - -c
@@ -191,6 +193,24 @@ spec:
               wait_for_resource "svc" "c-${DB2_INSTANCE_NAME}-db2u-engn-svc" "${DB2_NAMESPACE}"
 
               echo ""
+              echo "================================================================================"
+              echo "Waiting for pod c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 to be present before continuing (timeout 300s)"
+              echo "================================================================================"
+              wait_for_resource "pod" "c-${DB2_INSTANCE_NAME:0:-4}-db2u-0" "${DB2_NAMESPACE}"
+
+              echo ""
+              echo "================================================================================"
+              echo "Waiting for pod c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 to report Ready=True before continuing (timeout 300s)"
+              echo "================================================================================"
+              oc wait --for=condition=Ready pod/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 --timeout 300s -n ${DB2_NAMESPACE}
+
+              echo ""
+              echo "================================================================================"
+              echo "Waiting for service c-${DB2_INSTANCE_NAME:0:-4}-db2u-engn-svc to be present before continuing (timeout 300s)"
+              echo "================================================================================"
+              wait_for_resource "svc" "c-${DB2_INSTANCE_NAME:0:-4}-db2u-engn-svc" "${DB2_NAMESPACE}"
+
+              echo ""
               echo "Creating /mnt/backup/MIRRORLOGPATH in c-${DB2_INSTANCE_NAME}-db2u-0"
               echo "--------------------------------------------------------------------------------"
               oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0  -- su -lc "mkdir -p /mnt/backup/MIRRORLOGPATH" db2inst1 || exit $?
@@ -200,8 +220,31 @@ spec:
               echo "Calling apply-db2cfg-settings.sh file on c-${DB2_INSTANCE_NAME}-db2u-0"
               echo "================================================================================"
               db2apply || exit $?
+
               # Copy the backup from primary and restore in standby
-              # Start hadr in standby
-              # Start hadr in Primary
+              echo ""
+              echo "Taking backup on ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0"
+              echo "--------------------------------------------------------------------------------"
+              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "db2 backup db ${DB2_DBNAME} on all dbpartitionnums online to /mnt/backup | tee /tmp/dbbackup.log" db2inst1 || exit $?
+
+              echo ""
+              timestamp=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "cat /tmp/dbbackup.log | grep timestamp | awk '{print $NF}'" db2inst1`
+              backup_filename=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "ls /mnt/backup | grep ${timestamp} " db2inst1`
+
+              echo ""
+              echo "Copying backup /mnt/backup/${backup_filename} from ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 to ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0 "
+              oc cp ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0:/mnt/backup/${backup_filename} ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/mnt/backup/${backup_filename}
+
+              # # Start hadr in standby
+              # echo ""
+              # echo "Starting HADR in standby"
+              # echo "--------------------------------------------------------------------------------"
+              # oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2stop force; db2start; db2 start hadr on db bludb as standby; | tee /tmp//start_hadr_standby.log" db2inst1 || exit $?
+
+              # # Start hadr in Primary
+              # echo ""
+              # echo "Starting HADR in standby"
+              # echo "--------------------------------------------------------------------------------"
+              # oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "db2stop force; db2start; db2 start hadr on db bludb as primary; | tee /tmp//start_hadr_primary.log" db2inst1 || exit $?
               exit 0
 {{ end }}

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -22,6 +22,7 @@ spec:
 {{ .Values.custom_labels | toYaml | indent 8 }}
 {{- end }}
     spec:
+      restartPolicy: Never
       containers:
         - name: run
           image: quay.io/ibmmas/cli:latest
@@ -42,7 +43,6 @@ spec:
               value: "{{ .Values.db2_namespace }}"
             - name: DB2_INSTANCE_NAME
               value: "{{ .Values.db2_instance_name }}"
-          restartPolicy: Never
           command:
             - /bin/sh
             - -c

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -174,6 +174,8 @@ spec:
                 # no useful info in return code of this script
               }
 
+              PRIMARY_DB2_INSTANCE_NAME=${DB2_INSTANCE_NAME:0:-4}
+
               echo ""
               echo "================================================================================"
               echo "Waiting for pod c-${DB2_INSTANCE_NAME}-db2u-0 to be present before continuing (timeout 300s)"
@@ -194,55 +196,55 @@ spec:
 
               echo ""
               echo "================================================================================"
-              echo "Waiting for pod c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 to be present before continuing (timeout 300s)"
+              echo "Waiting for pod c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 to be present before continuing (timeout 300s)"
               echo "================================================================================"
-              wait_for_resource "pod" "c-${DB2_INSTANCE_NAME:0:-4}-db2u-0" "${DB2_NAMESPACE}"
+              wait_for_resource "pod" "c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0" "${DB2_NAMESPACE}"
 
               echo ""
               echo "================================================================================"
-              echo "Waiting for pod c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 to report Ready=True before continuing (timeout 300s)"
+              echo "Waiting for pod c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 to report Ready=True before continuing (timeout 300s)"
               echo "================================================================================"
-              oc wait --for=condition=Ready pod/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 --timeout 300s -n ${DB2_NAMESPACE}
+              oc wait --for=condition=Ready pod/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 --timeout 300s -n ${DB2_NAMESPACE}
 
               echo ""
               echo "================================================================================"
-              echo "Waiting for service c-${DB2_INSTANCE_NAME:0:-4}-db2u-engn-svc to be present before continuing (timeout 300s)"
+              echo "Waiting for service c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-engn-svc to be present before continuing (timeout 300s)"
               echo "================================================================================"
-              wait_for_resource "svc" "c-${DB2_INSTANCE_NAME:0:-4}-db2u-engn-svc" "${DB2_NAMESPACE}"
+              wait_for_resource "svc" "c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-engn-svc" "${DB2_NAMESPACE}"
 
-              PRIMARY_ROLE=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "db2 get db cfg for BLUDB | grep role | cut -d'=' -f2 | tr -d ' '" db2inst1`
+              PRIMARY_ROLE=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 get db cfg for BLUDB | grep role | cut -d'=' -f2 | tr -d ' '" db2inst1`
               STANDBY_ROLE=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 get db cfg for BLUDB | grep role | cut -d'=' -f2 | tr -d ' '" db2inst1`
 
               if [[ ! ($PRIMARY_ROLE == 'PRIMARY' && $STANDBY_ROLE == 'STANDBY') ]]; then
                 # Copy the backup from primary to standby
+                # echo ""
+                # timestamp=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "cat /mnt/backup/standby/dbbackup.log | grep 'timestamp' | rev | cut -d ' ' -f1 | rev" db2inst1`
+                # echo "Timestamp of backup is ${timestamp}"
+
+                # if [[ -z ${timestamp} ]]; then
+                echo "Backup is not available in primary. Attempting to backup"
                 echo ""
-                timestamp=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "cat /mnt/backup/standby/dbbackup.log | grep 'timestamp' | rev | cut -d ' ' -f1 | rev" db2inst1`
+                echo "Taking backup on ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0"
+                echo "--------------------------------------------------------------------------------"
+                oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "mkdir -p /mnt/backup/standby; db2 backup db ${DB2_DBNAME} on all dbpartitionnums online to /mnt/backup/standby | tee /mnt/backup/standby/dbbackup.log" db2inst1 || exit $?
+                echo ""
+                timestamp=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "cat /mnt/backup/standby/dbbackup.log | grep 'timestamp' | rev | cut -d ' ' -f1 | rev" db2inst1`
                 echo "Timestamp of backup is ${timestamp}"
+                # fi
 
-                if [[ -z ${timestamp} ]]; then
-                  echo "Backup is not available in primary. Attempting to backup"
-                  echo ""
-                  echo "Taking backup on ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0"
-                  echo "--------------------------------------------------------------------------------"
-                  oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "mkdir -p /mnt/backup/standby; db2 backup db ${DB2_DBNAME} on all dbpartitionnums online to /mnt/backup/standby | tee /mnt/backup/standby/dbbackup.log" db2inst1 || exit $?
-                  echo ""
-                  timestamp=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "cat /mnt/backup/standby/dbbackup.log | grep 'timestamp' | rev | cut -d ' ' -f1 | rev" db2inst1`
-                  echo "Timestamp of backup is ${timestamp}"
-                fi
-
-                backup_filename=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "ls /mnt/backup/standby | grep ${timestamp}" db2inst1`
+                backup_filename=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "ls /mnt/backup/standby | grep ${timestamp}" db2inst1`
                 echo "Backup filename is ${backup_filename}"
 
                 echo ""
-                echo "Copying backup /mnt/backup/standby/${backup_filename} from ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 to ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0 "
-                oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "cp /mnt/backup/standby/${backup_filename} /tmp; chmod 777 /tmp/${backup_filename}" db2inst1 || exit $?
-                oc cp ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0:/tmp/${backup_filename} /tmp/${backup_filename}
+                echo "Copying backup /mnt/backup/standby/${backup_filename} from ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 to ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0 "
+                oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "cp /mnt/backup/standby/${backup_filename} /tmp; chmod 777 /tmp/${backup_filename}" db2inst1 || exit $?
+                oc cp ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0:/tmp/${backup_filename} /tmp/${backup_filename}
                 oc cp /tmp/${backup_filename} ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/tmp/${backup_filename}
 
                 echo ""
                 echo "Copying keystore from primary to standby"
-                oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "mkdir /tmp/keystore; cp /mnt/blumeta0/db2/keystore/* /tmp/keystore; chmod -R 777 /tmp/keystore" db2inst1 || exit $?
-                oc rsync ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0:/tmp/keystore /tmp
+                oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "mkdir /tmp/keystore; cp /mnt/blumeta0/db2/keystore/* /tmp/keystore; chmod -R 777 /tmp/keystore" db2inst1 || exit $?
+                oc rsync ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0:/tmp/keystore /tmp
                 oc rsync /tmp/keystore ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/tmp
                 oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "mv /mnt/blumeta0/db2/keystore/keystore.p12 /mnt/blumeta0/db2/keystore/keystore.p12_orig; mv /mnt/blumeta0/db2/keystore/keystore.sth /mnt/blumeta0/db2/keystore/keystore.sth_orig; cp /tmp/keystore/keystore.* /mnt/blumeta0/db2/keystore/; chown db2inst1.db2iadm1 /mnt/blumeta0/db2/keystore/keystore.*; chmod 600 /mnt/blumeta0/db2/keystore/keystore.*;" db2inst1 || exit $?
 
@@ -271,5 +273,5 @@ spec:
               echo ""
               echo "Starting HADR in primary"
               echo "--------------------------------------------------------------------------------"
-              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "db2stop force; db2start; db2 start hadr on db bludb as primary" db2inst1 || exit $?
+              oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2stop force; db2start; db2 start hadr on db bludb as primary" db2inst1 || exit $?
 {{ end }}

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -235,8 +235,9 @@ spec:
 
               echo ""
               echo "Copying backup /mnt/backup/${backup_filename} from ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 to ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0 "
-              oc cp ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0:/mnt/backup/${backup_filename} /tmp/${backup_filename}
-              oc cp /tmp/${backup_filename} ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/mnt/backup/${backup_filename}
+              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "cp /mnt/backup/${backup_filename} /tmp" db2inst1
+              oc cp ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0:/tmp/${backup_filename} /tmp/${backup_filename}
+              oc cp /tmp/${backup_filename} ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/tmp/${backup_filename}
 
               # # Start hadr in standby
               # echo ""

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -42,6 +42,7 @@ spec:
               value: "{{ .Values.db2_namespace }}"
             - name: DB2_INSTANCE_NAME
               value: "{{ .Values.db2_instance_name }}"
+          restartPolicy: Never
           command:
             - /bin/sh
             - -c

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -34,14 +34,116 @@ spec:
               cpu: 10m
               memory: 64Mi
           env:
-            - name: 
-              value: 
+            - name: MAS_INSTANCE_ID
+              value: {{ .Values.instance_id }}
+            - name: MAS_APP_ID
+              value: {{ .Values.mas_application_id}}
+            - name: DB2_NAMESPACE
+              value: "{{ .Values.db2_namespace }}"
+            - name: DB2_INSTANCE_NAME
+              value: "{{ .Values.db2_instance_name }}"
           command:
             - /bin/sh
             - -c
             - |
 
               set -e
+
+              source /mascli/functions/gitops_utils
+
+              function wait_for_resource {
+                RES_TYPE="$1"
+                RES_NAME="$2"
+                RES_NS="$3"
+                RETRIES=${4:-10}
+                RETRY_DELAY_SECONDS=${5:-30}
+
+                for (( c=1; c<="${RETRIES}"; c++ )); do
+
+                  echo "... attempt ${c} of ${RETRIES}"
+
+                  rc=0
+                  oc get "${RES_TYPE}/${RES_NAME}" -n "${RES_NAMESPACE}" || rc=$?
+                  if [[ "$rc" == "0" ]]; then
+                    echo "...... success"
+                    return 0
+                  fi
+
+                  if [[ "${c}" -lt "${RETRIES}" ]]; then
+                    echo "...... failed (rc: ${rc}), retry in ${RETRY_DELAY_SECONDS}s"
+                    sleep $RETRY_DELAY_SECONDS
+                  fi
+                done
+
+                echo "...... failed, no attempts remain"
+                return 1
+              }
+
+
+              # The Db2u operator is capable of automatically applying dbConfig, dbmConfig and registry configuration parameters specified on the Db2uInstance CR.
+              # However, certain parameters (e.g. MIRRORLOGPATH)  may reference paths on the db2u pod (e.g. /mnt/backup/MIRRORLOGPATH) that do not exist until 
+              # after the operator has already attemped to apply settings (which it will not subsequently reattempt if something went wrong).
+              # To work around this, we manually re-invoke this process again by calling the '/db2u/scripts/apply-db2cfg-settings.sh --setting all' script on the db2 pod.
+
+              # Moreover, the Db2u operator it does not give any indication on any CR if something went wrong while attempting to apply these settings (and no meaningful return code is provided by the apply-db2cfg-settings.sh script)
+              # For this reason, we are forced to perform our own verification that the settings on the Db2uInstance CR align with those active in DB2 
+              # This is done using the "mas-devops-db2-validate-config" command from the mas-devops library (see https://github.com/ibm-mas/python-devops)
+              function db2apply {
+                RETRIES=${1:-5}
+                RETRY_DELAY_SECONDS=${2:-30}
+
+                mas-devops-db2-validate-config --mas-instance-id ${MAS_INSTANCE_ID} --mas-app-id ${MAS_APP_ID} --log-level DEBUG || rc=$?
+                if [[ "$rc" == "0" ]]; then
+                  echo "... db2 config already matches expected config, returning without calling apply-db2cfg-settings"
+                  return 0
+                fi
+
+                for (( c=1; c<="${RETRIES}"; c++ )); do
+                  echo ""
+                  echo "... attempt ${c} of ${RETRIES}"
+                  oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc '/db2u/scripts/apply-db2cfg-settings.sh --setting all | tee /tmp/apply-db2cfg-settings.log' db2inst1
+                  # no useful info in return code of this script
+
+                  rc=0
+                  mas-devops-db2-validate-config --mas-instance-id ${MAS_INSTANCE_ID} --mas-app-id ${MAS_APP_ID} --log-level DEBUG || rc=$?
+                  if [[ "$rc" == "0" ]]; then
+                    echo "...... success"
+                    return 0
+                  fi
+
+                  if [[ "${c}" -lt "${RETRIES}" ]]; then
+                    echo "...... failed (rc: ${rc}), retry in ${RETRY_DELAY_SECONDS}s"
+                    sleep $RETRY_DELAY_SECONDS
+                  fi
+                done
+
+                echo "...... failed, no attempts remain"
+                return 1
+              }
+
+              echo ""
+              echo "================================================================================"
+              echo "Waiting for pod c-${DB2_INSTANCE_NAME}-db2u-0 to be present before continuing (timeout 300s)"
+              echo "================================================================================"
+              wait_for_resource "pod" "c-${DB2_INSTANCE_NAME}-db2u-0" "${DB2_NAMESPACE}"
+
+              echo ""
+              echo "================================================================================"
+              echo "Waiting for pod c-${DB2_INSTANCE_NAME}-db2u-0 to report Ready=True before continuing (timeout 300s)"
+              echo "================================================================================"
+              oc wait --for=condition=Ready pod/c-${DB2_INSTANCE_NAME}-db2u-0 --timeout 300s -n ${DB2_NAMESPACE}
+
+              echo ""
+              echo "================================================================================"
+              echo "Waiting for service c-${DB2_INSTANCE_NAME}-db2u-engn-svc to be present before continuing (timeout 300s)"
+              echo "================================================================================"
+              wait_for_resource "svc" "c-${DB2_INSTANCE_NAME}-db2u-engn-svc" "${DB2_NAMESPACE}"
+
+              echo ""
+              echo "================================================================================"
+              echo "Calling apply-db2cfg-settings.sh file on c-${DB2_INSTANCE_NAME}-db2u-0"
+              echo "================================================================================"
+              db2apply || exit $?
               # Copy the backup from primary and restore in standby
               # Start hadr in standby
               # Start hadr in Primary

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -216,19 +216,14 @@ spec:
               if [[ ! ($PRIMARY_ROLE == 'PRIMARY' && $STANDBY_ROLE == 'STANDBY') ]]; then
                 # Copy the backup from primary to standby
                 echo ""
-                echo "Taking backup on ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0"
-                echo "--------------------------------------------------------------------------------"
-                oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "db2 backup db ${DB2_DBNAME} on all dbpartitionnums online to /mnt/backup | tee /tmp/dbbackup.log" db2inst1 || exit $?
-
-                echo ""
-                timestamp=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "cat /tmp/dbbackup.log | grep 'timestamp' | rev | cut -d ' ' -f1 | rev" db2inst1`
+                timestamp=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "cat /mnt/backup/standby/dbbackup.log | grep 'timestamp' | rev | cut -d ' ' -f1 | rev" db2inst1`
                 echo "Timestamp of backup is ${timestamp}"
-                backup_filename=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "ls /mnt/backup | grep ${timestamp}" db2inst1`
+                backup_filename=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "ls /mnt/backup/standby | grep ${timestamp}" db2inst1`
                 echo "Backup filename is ${backup_filename}"
 
                 echo ""
-                echo "Copying backup /mnt/backup/${backup_filename} from ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 to ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0 "
-                oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "cp /mnt/backup/${backup_filename} /tmp; chmod 777 /tmp/${backup_filename}" db2inst1 || exit $?
+                echo "Copying backup /mnt/backup/standby/${backup_filename} from ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 to ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0 "
+                oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "cp /mnt/backup/standby/${backup_filename} /tmp; chmod 777 /tmp/${backup_filename}" db2inst1 || exit $?
                 oc cp ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME:0:-4}-db2u-0:/tmp/${backup_filename} /tmp/${backup_filename}
                 oc cp /tmp/${backup_filename} ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/tmp/${backup_filename}
 

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -256,11 +256,11 @@ spec:
               echo ""
               echo "Starting HADR in standby"
               echo "--------------------------------------------------------------------------------"
-              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2stop force; db2start; db2 start hadr on db bludb as standby; | tee /tmp//start_hadr_standby.log" db2inst1 || exit $?
+              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2stop force; db2start; db2 start hadr on db bludb as standby | tee /tmp//start_hadr_standby.log" db2inst1 || exit $?
 
               # # Start hadr in Primary
               echo ""
               echo "Starting HADR in standby"
               echo "--------------------------------------------------------------------------------"
-              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "db2stop force; db2start; db2 start hadr on db bludb as primary; | tee /tmp//start_hadr_primary.log" db2inst1 || exit $?
+              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "db2stop force; db2start; db2 start hadr on db bludb as primary | tee /tmp//start_hadr_primary.log" db2inst1 || exit $?
 {{ end }}

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -41,6 +41,18 @@ rules:
   verbs:
     - get
     - list
+- apiGroups:
+    - ""
+  resources:
+    - services
+  verbs:
+    - "get"
+- apiGroups:
+    - db2u.databases.ibm.com
+  resources:
+    - db2uinstances
+  verbs:
+    - "get"
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -256,11 +256,11 @@ spec:
               echo ""
               echo "Starting HADR in standby"
               echo "--------------------------------------------------------------------------------"
-              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2stop force; db2start; db2 start hadr on db bludb as standby | tee /tmp//start_hadr_standby.log" db2inst1 || exit $?
+              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2stop force; db2start; db2 start hadr on db bludb as standby" db2inst1 || exit $?
 
               # # Start hadr in Primary
               echo ""
               echo "Starting HADR in primary"
               echo "--------------------------------------------------------------------------------"
-              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "db2stop force; db2start; db2 start hadr on db bludb as primary | tee /tmp//start_hadr_primary.log" db2inst1 || exit $?
+              oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME:0:-4}-db2u-0 -- su -lc "db2stop force; db2start; db2 start hadr on db bludb as primary" db2inst1 || exit $?
 {{ end }}

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -1,0 +1,49 @@
+{{ if and (default .Values.replica_db false) (contains "sdb" .Values.db2_instance_name) }}
+---
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  # Suffix the Job name with a hash of all chart values
+  # This is to ensure that ArgoCD will delete and recreate the job if (and only if) anything changes in the DB2 config
+  name: postsync-setup-hadr-{{ .Values.db2_instance_name }}-v1-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
+  namespace: "{{ .Values.db2_namespace }}"
+  annotations:
+    argocd.argoproj.io/sync-wave: "130"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+spec:
+  template:
+{{- if .Values.custom_labels }}
+    metadata:
+      labels:
+{{ .Values.custom_labels | toYaml | indent 8 }}
+{{- end }}
+    spec:
+      containers:
+        - name: run
+          image: quay.io/ibmmas/cli:latest
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 10m
+              memory: 64Mi
+          env:
+            - name: 
+              value: 
+          command:
+            - /bin/sh
+            - -c
+            - |
+
+              set -e
+              # Copy the backup from primary and restore in standby
+              # Start hadr in standby
+              # Start hadr in Primary
+              exit 0
+{{ end }}

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -102,7 +102,7 @@ spec:
       serviceAccountName: "postsync-hadr-sa-{{ .Values.db2_instance_name }}"
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:13.8.1-pre.hadr-replicadb-amd64
+          image: quay.io/ibmmas/cli:latest
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -247,13 +247,6 @@ spec:
               STANDBY_ROLE=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 get db cfg for BLUDB | grep role | cut -d'=' -f2 | tr -d ' '" db2inst1`
 
               if [[ ! ($PRIMARY_ROLE == 'PRIMARY' && $STANDBY_ROLE == 'STANDBY') ]]; then
-                # Copy the backup from primary to standby
-                # echo ""
-                # timestamp=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "cat /mnt/backup/standby/dbbackup.log | grep 'timestamp' | rev | cut -d ' ' -f1 | rev" db2inst1`
-                # echo "Timestamp of backup is ${timestamp}"
-
-                # if [[ -z ${timestamp} ]]; then
-                echo "Backup is not available in primary. Attempting to backup"
                 echo ""
                 echo "Taking backup on ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0"
                 echo "--------------------------------------------------------------------------------"
@@ -261,7 +254,6 @@ spec:
                 echo ""
                 timestamp=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "cat /mnt/backup/standby/dbbackup.log | grep 'timestamp' | rev | cut -d ' ' -f1 | rev" db2inst1`
                 echo "Timestamp of backup is ${timestamp}"
-                # fi
 
                 backup_filename=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "ls /mnt/backup/standby | grep ${timestamp}" db2inst1`
                 echo "Backup filename is ${backup_filename}"

--- a/root-applications/ibm-mas-instance-root/templates/120-db2-databases-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-db2-databases-app.yaml
@@ -17,7 +17,11 @@ metadata:
     instance: '{{ $.Values.instance.id }}'
     appId: '{{ $value.mas_application_id }}'
   annotations:
+{{ if not (contains "sdb" $value.db2_instance_name) }}
     argocd.argoproj.io/sync-wave: "120"
+{{ else }}
+    argocd.argoproj.io/sync-wave: "121"
+{{ end }}
     {{- if and $.Values.notifications $.Values.notifications.slack_channel_id }}
     notifications.argoproj.io/subscribe.on-sync-failed.workspace1: {{ $.Values.notifications.slack_channel_id }}
     notifications.argoproj.io/subscribe.on-sync-succeeded.workspace1: {{ $.Values.notifications.slack_channel_id }}


### PR DESCRIPTION
Issue: [MASCORE-5741](https://jsw.ibm.com/browse/MASCORE-5741)

## Description
1. Creates HADR service for both primary and standby if replica_db is enabled
2. Creates post sync hadr job that copies backup from primary to standby, restores the database and applies configuration on standby db2 pod. It then starts HADR on standby and primary
3. We also stop HADR in primary in case replica_db is disabled (Otherwise it will lead to database in inconsistent state)

## Testing
Tested in noble4 ajw0111 instance

### Logs of Post sync HADR job
```

================================================================================
Waiting for pod c-db2wh-ajw0111-manage-sdb-db2u-0 to be present before continuing (timeout 300s)
================================================================================
... attempt 1 of 10
NAME                                READY   STATUS    RESTARTS   AGE
c-db2wh-ajw0111-manage-sdb-db2u-0   1/1     Running   0          11m
...... success

================================================================================
Waiting for pod c-db2wh-ajw0111-manage-sdb-db2u-0 to report Ready=True before continuing (timeout 300s)
================================================================================
pod/c-db2wh-ajw0111-manage-sdb-db2u-0 condition met

================================================================================
Waiting for service c-db2wh-ajw0111-manage-sdb-db2u-engn-svc to be present before continuing (timeout 300s)
================================================================================
... attempt 1 of 10
NAME                                       TYPE       CLUSTER-IP     EXTERNAL-IP   PORT(S)           AGE
c-db2wh-ajw0111-manage-sdb-db2u-engn-svc   NodePort   172.30.66.85   <none>        50001:30019/TCP   12m
...... success

================================================================================
Waiting for pod c-db2wh-ajw0111-manage-db2u-0 to be present before continuing (timeout 300s)
================================================================================
... attempt 1 of 10
NAME                            READY   STATUS    RESTARTS   AGE
c-db2wh-ajw0111-manage-db2u-0   1/1     Running   0          44m
...... success

================================================================================
Waiting for pod c-db2wh-ajw0111-manage-db2u-0 to report Ready=True before continuing (timeout 300s)
================================================================================
pod/c-db2wh-ajw0111-manage-db2u-0 condition met

================================================================================
Waiting for service c-db2wh-ajw0111-manage-db2u-engn-svc to be present before continuing (timeout 300s)
================================================================================
... attempt 1 of 10
NAME                                   TYPE       CLUSTER-IP      EXTERNAL-IP   PORT(S)           AGE
c-db2wh-ajw0111-manage-db2u-engn-svc   NodePort   172.30.75.183   <none>        50001:30998/TCP   44m
...... success
Defaulted container "db2u" out of: db2u, instdb (init), init-labels (init), init-kernel (init)
Defaulted container "db2u" out of: db2u, instdb (init), init-labels (init), init-kernel (init)

Defaulted container "db2u" out of: db2u, instdb (init), init-labels (init), init-kernel (init)
Timestamp of backup is 20250226122454
Defaulted container "db2u" out of: db2u, instdb (init), init-labels (init), init-kernel (init)
Backup filename is BLUDB.0.db2inst1.DBPART000.20250226122454.001

Copying backup /mnt/backup/standby/BLUDB.0.db2inst1.DBPART000.20250226122454.001 from db2u-ajw0111/c-db2wh-ajw0111-manage-db2u-0 to db2u-ajw0111/c-db2wh-ajw0111-manage-sdb-db2u-0 
Defaulted container "db2u" out of: db2u, instdb (init), init-labels (init), init-kernel (init)
Defaulted container "db2u" out of: db2u, instdb (init), init-labels (init), init-kernel (init)
tar: Removing leading `/' from member names
Defaulted container "db2u" out of: db2u, instdb (init), init-labels (init), init-kernel (init)

Copying keystore from primary to standby
Defaulted container "db2u" out of: db2u, instdb (init), init-labels (init), init-kernel (init)
receiving incremental file list
keystore/
keystore/keystore.p12
keystore/keystore.sth

sent 66 bytes  received 7,229 bytes  2,918.00 bytes/sec
total size is 7,039  speedup is 0.96
Defaulted container "db2u" out of: db2u, instdb (init), init-labels (init), init-kernel (init)
sending incremental file list
keystore/
keystore/keystore.p12
keystore/keystore.sth

sent 7,233 bytes  received 58 bytes  2,916.40 bytes/sec
total size is 7,039  speedup is 0.97
Defaulted container "db2u" out of: db2u, instdb (init), init-labels (init), init-kernel (init)
Defaulted container "db2u" out of: db2u, instdb (init), init-labels (init), init-kernel (init)

Restoring 20250226122454 in standby server
--------------------------------------------------------------------------------
Defaulted container "db2u" out of: db2u, instdb (init), init-labels (init), init-kernel (init)
DB20000I  The FORCE APPLICATION command completed successfully.
DB21024I  This command is asynchronous and may not be effective immediately.

DB20000I  The TERMINATE command completed successfully.
DB20000I  The DEACTIVATE DATABASE command completed successfully.
DB20000I  The DROP DATABASE command completed successfully.
DB20000I  The RESTORE DATABASE command completed successfully.

================================================================================
Calling apply-db2cfg-settings.sh file on c-db2wh-ajw0111-manage-sdb-db2u-0
================================================================================

Defaulted container "db2u" out of: db2u, instdb (init), init-labels (init), init-kernel (init)
Waiting for up to 180 sec until a change is detected in the relevant configmaps... change not detected, continuing anyways
Applying all settings
(*) Applying Db2 dbm cfg parameters
update dbm cfg using  AGENT_STACK_SZ 1024 AUTHENTICATION SERVER_ENCRYPT CONN_ELAPSE 60 DIAGPATH '/mnt/blumeta0/db2/log $N' DIAGSIZE 300 DISCOVER DISABLE DISCOVER_INST DISABLE FENCED_POOL 50 HEALTH_MON OFF INSTANCE_USAGE DASHDB JDK_PATH /mnt/blumeta0/home/db2inst1/sqllib/java/jdk64 KEEPFENCED NO MAX_CONNRETRIES 5 MON_HEAP_SZ AUTOMATIC NUMDB 1 PYTHON_PATH /usr/bin/python RQRIOBLK 65535
DB20000I  The UPDATE DATABASE MANAGER CONFIGURATION command completed 
successfully.

DB20000I  The TERMINATE command completed successfully.
(*) Applying Db2 db cfg parameters for BLUDB
update db cfg for BLUDB using  APPLHEAPSZ 8192 AUTOMATIC AUTHN_CACHE_DURATION 10 AUTHN_CACHE_USERS 100 AUTO_DB_BACKUP OFF AUTO_DEL_REC_OBJ ON AUTO_MAINT ON AUTO_REORG OFF AUTO_REVAL DEFERRED AUTO_RUNSTATS ON AUTO_TBL_MAINT ON CATALOGCACHE_SZ 800 CHNGPGS_THRESH 40 CUR_COMMIT ON DATABASE_MEMORY AUTOMATIC DBHEAP AUTOMATIC DDL_CONSTRAINT_DEF YES DEC_TO_CHAR_FMT NEW DFT_DEGREE ANY DFT_QUERYOPT 5 DFT_SCHEMAS_DCC NO DFT_TABLE_ORG ROW EXTBL_LOCATION /mnt/blumeta0/db2/load;/mnt/blumeta0/home;/mnt/bludata0/scratch;/mnt/external;/mnt/backup EXTBL_STRICT_IO NO HADR_LOCAL_HOST c-db2wh-ajw0111-manage-sdb-db2u-0|c-db2wh-ajw0111-manage-sdb-db2u-0.c-db2wh-ajw0111-manage-sdb-db2u-internal.db2u-ajw0111.svc.cluster.local HADR_LOCAL_SVC 60007|60007 HADR_REMOTE_HOST c-db2wh-ajw0111-manage-db2u-0.c-db2wh-ajw0111-manage-db2u-internal.db2u-ajw0111.svc.cluster.local HADR_REMOTE_INST db2inst1 HADR_REMOTE_SVC 60006 HADR_SYNCMODE NEARSYNC HADR_TARGET_LIST c-db2wh-ajw0111-manage-db2u-0.c-db2wh-ajw0111-manage-db2u-internal.db2u-ajw0111.svc.cluster.local:60006 INDEXREC ACCESS LOCKLIST AUTOMATIC LOCKTIMEOUT 300 LOGARCHMETH1 DISK:/mnt/logs/archive LOGBUFSZ 1024 LOGFILSIZ 32768 LOGINDEXBUILD ON LOGPRIMARY 100 LOGSECOND 156 LOG_APPL_INFO NO LOG_DDL_STMTS NO MAXFILOP 61440 MIRRORLOGPATH /mnt/backup/MIRRORLOGPATH NUM_DB_BACKUPS 60 NUM_IOCLEANERS AUTOMATIC NUM_IOSERVERS AUTOMATIC PCKCACHESZ AUTOMATIC REC_HIS_RETENTN 60 SHEAPTHRES_SHR automatic SOFTMAX 0 SORTHEAP automatic STAT_HEAP_SZ AUTOMATIC STMTHEAP 20000 STMT_CONC LITERALS TRACKMOD YES WLM_ADMISSION_CTRL NO
DB20000I  The UPDATE DATABASE CONFIGURATION command completed successfully.

Wolverine HA management state was disabled successfully.
Running db2stop force
02/26/2025 12:45:39     0   0   SQL1064N  DB2STOP processing was successful.
SQL1064N  DB2STOP processing was successful.
 
Application ipclean: Removing all IPC resources for db2inst1(500)
c-db2wh-ajw0111-manage-sdb-db2u-0.c-db2wh-ajw0111-manage-sdb-db2u-internal: ipclean -a completed ok
Running db2start
02/26/2025 12:45:54     0   0   SQL1063N  DB2START processing was successful.
SQL1063N  DB2START processing was successful.
Db2 was started successfully
Wolverine HA management state was enabled successfully.

Starting HADR in standby
--------------------------------------------------------------------------------
Defaulted container "db2u" out of: db2u, instdb (init), init-labels (init), init-kernel (init)
02/26/2025 12:46:07     0   0   SQL1064N  DB2STOP processing was successful.
SQL1064N  DB2STOP processing was successful.
02/26/2025 12:46:11     0   0   SQL1063N  DB2START processing was successful.
SQL1063N  DB2START processing was successful.
DB20000I  The START HADR ON DATABASE command completed successfully.

Starting HADR in primary
--------------------------------------------------------------------------------
Defaulted container "db2u" out of: db2u, instdb (init), init-labels (init), init-kernel (init)
02/26/2025 12:46:22     0   0   SQL1064N  DB2STOP processing was successful.
SQL1064N  DB2STOP processing was successful.
02/26/2025 12:46:27     0   0   SQL1063N  DB2START processing was successful.
SQL1063N  DB2START processing was successful.
DB20000I  The START HADR ON DATABASE command completed successfully.

```