### PR TITLE
[minor] Add support for SMTP disabledTemplates

### DIFF
--- a/instance-applications/130-ibm-mas-smtp-config/templates/02-ibm-mas_SmtpCfg.yaml
+++ b/instance-applications/130-ibm-mas-smtp-config/templates/02-ibm-mas_SmtpCfg.yaml
@@ -31,5 +31,6 @@ spec:
     credentials:
       secretName: "{{ .Values.mas_config_name }}-credentials"
 {{- if .Values.suite_smtp_disabled_templates }}
-    disabledTemplates: {{ .Values.suite_smtp_disabled_templates }}
+    disabledTemplates:
+      {{ .Values.suite_smtp_disabled_templates | toYaml | nindent 6 }}
 {{- end }}

--- a/instance-applications/130-ibm-mas-smtp-config/templates/02-ibm-mas_SmtpCfg.yaml
+++ b/instance-applications/130-ibm-mas-smtp-config/templates/02-ibm-mas_SmtpCfg.yaml
@@ -30,3 +30,6 @@ spec:
     defaultShouldEmailPasswords: {{ .Values.suite_smtp_default_should_email_passwords }}
     credentials:
       secretName: "{{ .Values.mas_config_name }}-credentials"
+{{- if .Values.suite_smtp_disabled_templates }}
+    disabledTemplates: {{ .Values.suite_smtp_disabled_templates }}
+{{- end }}


### PR DESCRIPTION
# Description

Renders new `smtp.disabled_templates` param into Suite SMTPCfg CR spec.

https://jsw.ibm.com/browse/MASCORE-5439


# Associated PRs

https://github.ibm.com/maximoappsuite/saas-tekton/pull/101
https://github.ibm.com/maximoappsuite/saas-deploy-py/pull/155
https://github.com/ibm-mas/cli/pull/1491
https://github.ibm.com/maximoappsuite/saas-envs-starter/pull/55
https://github.ibm.com/maximoappsuite/saas-task/pull/6

# Testing
See https://github.ibm.com/maximoappsuite/saas-tekton/pull/101 for test results

