### PR TITLE
[patch] Cpd presync job needs to run in sync-job to ensure secrets are populated

### DIFF
--- a/instance-applications/010-ibm-sync-jobs/templates/00-ibm-cp4d-olm-480.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/00-ibm-cp4d-olm-480.yaml
@@ -1,0 +1,1037 @@
+{{- if eq .Values.cpd_product_version "4.8.0" }}
+---
+# This config map is created via cpd-cli manage apply-cr command: https://www.ibm.com/docs/en/cloud-paks/cp-data/4.6.x?topic=si-installing-components
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: olm-utils-cm
+  namespace: mas-{{ .Values.instance_id }}-syncres
+  annotations:
+    argocd.argoproj.io/sync-wave: "00"
+  labels:
+    app.kubernetes.io/name: olm-utils
+{{- if .Values.custom_labels }}
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+data:
+  release_components_meta: |
+    analyticsengine:
+        case_version: 8.0.0
+        cr_version: 4.8.0
+        csv_version: 5.0.0
+        sub_channel: v5.0
+    bigsql:
+        case_version: 10.0.0
+        cr_version: 7.6.0
+        csv_version: 10.0.0
+        sub_channel: v10.0
+    canvasbase:
+        case_version: 8.0.0
+        cr_version: 8.0.0
+        csv_version: 8.0.0
+        sub_channel: v8.0
+    ccs:
+        case_version: 8.0.0
+        cr_version: 8.0.0
+        csv_version: 8.0.0
+        sub_channel: v8.0
+    cognos_analytics:
+        case_version: 25.0.0
+        cr_version: 25.0.0
+        csv_version: 25.0.0
+        sub_channel: v25.0
+    cpd_platform:
+        case_version: 4.0.0
+        cr_version: 4.8.0
+        csv_version: 5.0.0
+        sub_channel: v5.0
+    cpfs:
+        case_version: 4.3.0
+        csv_version: 4.3.0
+        sub_channel: v4.3
+    dashboard:
+        case_version: 2.0.0
+        cr_version: 4.8.0
+        csv_version: 2.0.0
+        sub_channel: v2.0
+    data_governor:
+        case_version: 4.0.4
+        csv_version: 4.0.4
+        sub_channel: v4.0
+    datagate:
+        case_version: 7.0.0
+        cr_version: 5.0.0
+        csv_version: 5.0.0
+        sub_channel: v5.0
+    datarefinery:
+        case_version: 8.0.0
+        cr_version: 8.0.0
+        csv_version: 8.0.0
+        sub_channel: v8.0
+    datastage_ent:
+        case_version: 7.0.0
+        cr_version: 4.8.0
+        csv_version: 5.0.0
+        sub_channel: v5.0
+    datastage_ent_plus:
+        case_version: 7.0.0
+        cr_version: 4.8.0
+        csv_version: 5.0.0
+        sub_channel: v5.0
+    db2aaservice:
+        case_version: 4.8.0
+        cr_version: 4.8.0
+        csv_version: 5.0.0
+        sub_channel: v5.0
+    db2oltp:
+        case_version: 4.8.0
+        cr_version: 4.8.0
+        csv_version: 5.0.0
+        sub_channel: v5.0
+    db2u:
+        case_version: 5.5.0
+        csv_version: 5.0.0
+        sub_channel: v5.0
+    db2wh:
+        case_version: 4.8.0
+        cr_version: 4.8.0
+        csv_version: 5.0.0
+        sub_channel: v5.0
+    dfo:
+        case_version: 1.0.0
+        cr_version: 1.0.0
+        csv_version: 1.0.0
+        sub_channel: beta
+    dmc:
+        case_version: 7.0.0
+        cr_version: 4.8.0
+        csv_version: 4.0.0
+        sub_channel: v4.0
+    dods:
+        case_version: 8.0.0
+        cr_version: 8.0.0
+        csv_version: 8.0.0
+        sub_channel: v8.0
+    dp:
+        case_version: 8.0.0
+        cr_version: 4.8.0
+        csv_version: 8.0.0
+        sub_channel: v8.0
+    dpra:
+        case_version: 1.12.0
+        cr_version: 1.12.0
+        csv_version: 1.12.0
+        sub_channel: v1.12
+    dv:
+        case_version: 4.0.0
+        cr_version: 2.2.0
+        csv_version: 4.0.0
+        sub_channel: v4.0
+    edb_cp4d:
+        case_version: 4.18.0
+        cr_version: 4.18.0
+        csv_version: 4.18.0
+        sub_channel: v4.18
+    estap:
+        case_version: 1.1.0
+        cr_version: 1.1.0
+        csv_version: 1.1.0
+        sub_channel: v1.1
+    factsheet:
+        case_version: 3.0.0
+        cr_version: 4.8.0
+        csv_version: 3.0.0
+        sub_channel: v3.0
+    fdb_k8s:
+        csv_version: 3.1.5
+        sub_channel: v3.1
+    hee:
+        case_version: 4.8.0
+        cr_version: 4.8.0
+        csv_version: 4.80.0
+        sub_channel: v4.80
+    ibm-cert-manager:
+        case_version: 4.2.1
+        csv_version: 4.2.1
+        sub_channel: v4.2
+    ibm-licensing:
+        case_version: 4.2.3
+        csv_version: 4.2.3
+        sub_channel: v4.2
+    ibm_events_operator:
+        case_version: 4.8.0
+        csv_version: 4.8.0
+        sub_channel: v3
+    ibm_redis_cp:
+        case_version: 1.1.3
+        csv_version: 1.1.3
+        sub_channel: v1.1
+    informix:
+        case_version: 7.0.0
+        csv_version: 7.0.0
+        sub_channel: v7.0
+    informix_cp4d:
+        case_version: 7.0.0
+        cr_version: 7.0.0
+        csv_version: 7.0.0
+        sub_channel: v7.0
+    mantaflow:
+        case_version: 1.15.0
+        cr_version: 42.0.5
+        csv_version: 1.15.0
+        sub_channel: v1.15
+    match360:
+        case_version: 3.3.0
+        cr_version: 3.3.15
+        csv_version: 3.3.0
+        sub_channel: v3.3
+    model_train:
+        case_version: 1.2.11
+        csv_version: 1.1.13
+        sub_channel: v1.1
+    mongodb:
+        case_version: 4.18.0
+        csv_version: 1.22.0
+        sub_channel: stable
+    mongodb_cp4d:
+        case_version: 4.18.0
+        cr_version: 4.18.0
+        csv_version: 4.18.0
+        sub_channel: v4.18
+    opencontent_auditwebhook:
+        case_version: 1.0.24
+        csv_version: 0.3.1
+    opencontent_elasticsearch:
+        case_version: 1.1.1845
+        cr_version: 1.1.1845
+        csv_version: 1.1.1845
+        sub_channel: v1.1
+    opencontent_etcd:
+        case_version: 2.0.31
+        csv_version: 1.0.22
+    opencontent_fdb:
+        case_version: 3.1.5
+        cr_version: 3.1.5
+        csv_version: 3.1.5
+        sub_channel: v3.1
+    opencontent_minio:
+        case_version: 1.0.23
+        csv_version: 1.0.18
+    opencontent_rabbitmq:
+        case_version: 1.0.31
+        csv_version: 1.0.22
+        sub_channel: v1.0
+    opencontent_redis:
+        case_version: 1.6.11
+        csv_version: 1.6.11
+        sub_channel: v1.6
+    openpages:
+        case_version: 6.0.0
+        cr_version: 9.000.1
+        csv_version: 6.0.0
+        sub_channel: v6.0
+    openpages_instance:
+        cr_version: 9.000.1
+    openscale:
+        case_version: 6.0.0
+        cr_version: 4.8.0
+        csv_version: 5.0.0
+        sub_channel: v5.0
+    planning_analytics:
+        case_version: 4.8.0
+        cr_version: 4.8.0
+        csv_version: 4.8.0
+        sub_channel: v7.0
+    postgresql:
+        case_version: 4.18.0
+        csv_version: 1.18.7
+        sub_channel: stable
+    productmaster:
+        case_version: 5.0.0
+        cr_version: 5.0.0
+        csv_version: 5.0.0
+        sub_channel: v5.0
+    productmaster_instance:
+        cr_version: 5.0.0
+    replication:
+        case_version: 4.8.0
+        cr_version: 4.8.0
+        csv_version: 3.0.0
+        licenses_urls:
+            IDRC: https://ibm.biz/BdSZ39
+            IDRM: https://ibm.biz/BdSZ33
+            IIDRC: https://ibm.biz/BdSZ3C
+            IIDRM: https://ibm.biz/BdSZ3T
+        sub_channel: v3.0
+    rstudio:
+        case_version: 8.0.0
+        cr_version: 8.0.0
+        csv_version: 8.0.0
+        sub_channel: v8.0
+    scheduler:
+        case_version: 1.18.0
+        cr_version: 1.18.0
+        csv_version: 1.18.0
+        sub_channel: v1.18
+    spss:
+        case_version: 8.0.0
+        cr_version: 8.0.0
+        csv_version: 8.0.0
+        sub_channel: v8.0
+    syntheticdata:
+        case_version: 8.0.0
+        cr_version: 8.0.0
+        csv_version: 8.0.0
+        sub_channel: v8.0
+    voice_gateway:
+        case_version: 1.3.6
+        cr_version: 1.3.6
+        csv_version: 1.3.6
+        sub_channel: v1.36
+    watson_assistant:
+        case_version: 4.21.0
+        cr_version: 4.8.0
+        csv_version: 4.21.0
+        sub_channel: v4.21
+    watson_discovery:
+        case_version: 7.0.0
+        cr_version: 4.8.0
+        csv_version: 7.0.0
+        sub_channel: v7.0
+    watson_gateway:
+        case_version: 2.0.27
+        csv_version: 1.0.22
+    watson_speech:
+        case_version: 7.0.1
+        cr_version: 4.8.0
+        csv_version: 7.0.1
+        sub_channel: v7.0
+    watsonx_ai:
+        case_version: 8.0.0
+        cr_version: 8.0.0
+        csv_version: 8.0.0
+        licenses_urls:
+            WX: https://ibm.biz/BdSR6v
+        sub_channel: v8.0
+    watsonx_ai_ifm:
+        case_version: 8.0.0
+        cr_version: 8.0.0
+        csv_version: 8.0.0
+        licenses_urls:
+            WX: https://ibm.biz/BdSR6v
+        sub_channel: v8.0
+    watsonx_data:
+        case_version: 2.0.0
+        cr_version: 1.1.0
+        csv_version: 2.0.0
+        licenses_urls:
+            WX: https://ibm.biz/BdSuVk
+        sub_channel: v2.0
+        support_online_upgrade: false
+    wkc:
+        case_version: 4.8.0
+        cr_version: 4.8.0
+        csv_version: 1.8.0
+        rules:
+        -   apiGroups:
+            - zen.cpd.ibm.com
+            resources:
+            - zenextensions/status
+            verbs:
+            - get
+        -   apiGroups:
+            - zen.cpd.ibm.com
+            resources:
+            - zenextension
+            - zenextensions
+            verbs:
+            - create
+            - delete
+            - list
+            - watch
+            - get
+            - patch
+            - update
+        -   apiGroups:
+            - ''
+            - batch
+            - extensions
+            - apps
+            - policy
+            - rbac.authorization.k8s.io
+            - autoscaling
+            - route.openshift.io
+            - authorization.openshift.io
+            - networking.k8s.io
+            - metrics.k8s.io
+            - project.openshift.io
+            resources:
+            - pods
+            - pods/log
+            - poddisruptionbudgets
+            - secrets
+            - jobs
+            - configmaps
+            - deployments
+            - deployments/scale
+            - daemonsets
+            - projects
+            - statefulsets
+            - statefulsets/scale
+            - replicasets
+            - services
+            - services/finalizers
+            - persistentvolumeclaims
+            - cronjobs
+            - pods/exec
+            - pods/portforward
+            - serviceaccounts
+            - namespaces
+            - roles
+            - rolebindings
+            - horizontalpodautoscalers
+            - routes
+            - routes/custom-host
+            - ingresses
+            - endpoints
+            - cronjob
+            - networkpolicies
+            - events
+            - jobs/status
+            - pods/status
+            - resourcequotas
+            - resourcequotas/status
+            verbs:
+            - apply
+            - create
+            - get
+            - delete
+            - watch
+            - update
+            - edit
+            - exec
+            - list
+            - patch
+            - deletecollection
+        -   apiGroups:
+            - cpd.ibm.com
+            resources:
+            - cpdinstalls
+            - cpdinstalls/spec
+            - cpdinstalls/status
+            verbs:
+            - apply
+            - create
+            - delete
+            - edit
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - build.openshift.io
+            resources:
+            - buildconfigs
+            - buildconfigs/instantiate
+            - buildconfigs/instantiatebinary
+            - buildconfigs/webhooks
+            - buildlogs
+            - builds
+            - builds/clone
+            - builds/details
+            - builds/log
+            verbs:
+            - create
+            - delete
+            - list
+            - watch
+            - get
+            - patch
+            - update
+        -   apiGroups:
+            - image.openshift.io
+            resources:
+            - imagestreams
+            - imagestreams/layers
+            - imagestreams/secrets
+            - imagestreams/status
+            - imagestreamimages
+            - imagestreamimports
+            - imagestreammappings
+            - imagestreamtags
+            verbs:
+            - create
+            - delete
+            - list
+            - watch
+            - get
+            - patch
+            - update
+        -   apiGroups:
+            - ''
+            resources:
+            - pods
+            verbs:
+            - get
+        -   apiGroups:
+            - apps
+            resources:
+            - replicasets
+            - deployments
+            verbs:
+            - get
+        -   apiGroups:
+            - wkc.cpd.ibm.com
+            resources:
+            - wkc
+            - wkc/spec
+            - wkc/status
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - zen.cpd.ibm.com
+            resources:
+            - zenservices
+            - zenservices/spec
+            - zenservices/status
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - ccs.cpd.ibm.com
+            resources:
+            - ccs
+            - ccs/spec
+            - ccs/status
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - ae.cpd.ibm.com
+            resources:
+            - analyticsengines
+            - analyticsengines/spec
+            - analyticsengines/status
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - ds.cpd.ibm.com
+            resources:
+            - datastages
+            - datastages/spec
+            - datastages/status
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - datarefinery.cpd.ibm.com
+            resources:
+            - datarefinery
+            - datarefinery/spec
+            - datarefinery/status
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - databases.cpd.ibm.com
+            resources:
+            - db2aaserviceservices
+            - db2aaserviceservices/spec
+            - db2aaserviceservices/status
+            - db2aaserviceservices/finalizers
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - db2u.databases.ibm.com
+            resources:
+            - db2uclusters
+            - db2uclusters/spec
+            - db2uclusters/status
+            - db2uclusters/finalizers
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - iis.cpd.ibm.com
+            resources:
+            - iis
+            - iis/spec
+            - iis/status
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - ug.wkc.cpd.ibm.com
+            resources:
+            - ug
+            - ug/spec
+            - ug/status
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - operator.ibm.com
+            resources:
+            - operandrequests
+            - operandregistries
+            - operandconfigs
+            - operandbindinfos
+            verbs:
+            - create
+            - get
+            - list
+            - patch
+            - update
+            - watch
+            - delete
+            - use
+        -   apiGroups:
+            - apps.foundationdb.org
+            resources:
+            - foundationdbclusters
+            - foundationdbbackups
+            - foundationdbrestores
+            verbs:
+            - get
+            - list
+            - watch
+            - create
+            - update
+            - patch
+            - delete
+        -   apiGroups:
+            - apps.foundationdb.org
+            resources:
+            - foundationdbclusters/status
+            - foundationdbbackups/status
+            verbs:
+            - get
+            - update
+            - patch
+        -   apiGroups:
+            - foundationdb.opencontent.ibm.com
+            resources:
+            - fdbclusters
+            verbs:
+            - get
+            - list
+            - watch
+            - create
+            - update
+            - patch
+            - delete
+        -   apiGroups:
+            - foundationdb.opencontent.ibm.com
+            resources:
+            - fdbclusters/finalizers
+            verbs:
+            - update
+        -   apiGroups:
+            - foundationdb.opencontent.ibm.com
+            resources:
+            - fdbclusters/status
+            verbs:
+            - get
+            - patch
+            - update
+        -   apiGroups:
+            - certmanager.k8s.io
+            resources:
+            - issuers
+            - issuers/status
+            - issuers/finalizers
+            - certificates
+            - certificates/status
+            - certificates/finalizers
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - ibmcpcs.ibm.com
+            resources:
+            - secretshares
+            verbs:
+            - get
+            - list
+            - watch
+            - create
+            - update
+            - patch
+            - delete
+        sub_channel: v5.0
+    wml:
+        case_version: 8.0.0
+        cr_version: 4.8.0
+        csv_version: 5.0.0
+        sub_channel: v5.0
+    wml_accelerator:
+        case_version: 4.8.0
+        cr_version: 4.8.0
+        csv_version: 5.0.0
+        sub_channel: v5.0
+    ws:
+        case_version: 8.0.0
+        cr_version: 8.0.0
+        csv_version: 8.0.0
+        sub_channel: v8.0
+    ws_pipelines:
+        case_version: 8.0.0
+        cr_version: 4.8.0
+        csv_version: 8.0.0
+        sub_channel: v8.0
+    ws_runtimes:
+        case_version: 8.0.0
+        cr_version: 8.0.0
+        csv_version: 8.0.0
+        sub_channel: v8.0
+    wxd_optimizerplus:
+        component_dependencies:
+        - db2u
+    zen:
+        cr_version: 5.1.0
+        csv_version: 5.1.0
+        rules:
+        -   apiGroups:
+            - ''
+            - batch
+            - extensions
+            - apps
+            - policy
+            - rbac.authorization.k8s.io
+            - autoscaling
+            - route.openshift.io
+            - authorization.openshift.io
+            - networking.k8s.io
+            - metrics.k8s.io
+            - project.openshift.io
+            - template.openshift.io
+            - autoscaling.k8s.io
+            resources:
+            - pods
+            - pods/log
+            - pods/eviction
+            - poddisruptionbudgets
+            - projects
+            - secrets
+            - jobs
+            - configmaps
+            - deployments
+            - deployments/scale
+            - daemonsets
+            - statefulsets
+            - statefulsets/scale
+            - replicasets
+            - replicationcontrollers
+            - services
+            - services/finalizers
+            - persistentvolumes
+            - persistentvolumeclaims
+            - cronjobs
+            - pods/exec
+            - pods/portforward
+            - serviceaccounts
+            - namespaces
+            - roles
+            - rolebindings
+            - horizontalpodautoscalers
+            - verticalpodautoscalers
+            - routes
+            - routes/custom-host
+            - ingresses
+            - endpoints
+            - cronjob
+            - networkpolicies
+            - events
+            - jobs/status
+            - pods/status
+            - resourcequotas
+            - resourcequotas/status
+            - processedtemplates
+            verbs:
+            - create
+            - get
+            - delete
+            - watch
+            - update
+            - list
+            - patch
+            - deletecollection
+        -   apiGroups:
+            - cpd.ibm.com
+            resources:
+            - cpdinstalls
+            - cpdinstalls/spec
+            - cpdinstalls/status
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - build.openshift.io
+            resources:
+            - buildconfigs
+            - buildconfigs/instantiate
+            - buildconfigs/instantiatebinary
+            - buildconfigs/webhooks
+            - buildlogs
+            - builds
+            - builds/clone
+            - builds/details
+            - builds/log
+            verbs:
+            - create
+            - delete
+            - list
+            - watch
+            - get
+            - patch
+            - update
+        -   apiGroups:
+            - image.openshift.io
+            resources:
+            - imagestreams
+            - imagestreams/layers
+            - imagestreams/secrets
+            - imagestreams/status
+            - imagestreamimages
+            - imagestreamimports
+            - imagestreammappings
+            - imagestreamtags
+            verbs:
+            - create
+            - delete
+            - list
+            - watch
+            - get
+            - patch
+            - update
+        -   apiGroups:
+            - apps
+            resourceNames:
+            - cpd-zen-operator
+            resources:
+            - deployments/finalizers
+            verbs:
+            - update
+        -   apiGroups:
+            - zen.cpd.ibm.com
+            resources:
+            - zenservice
+            - zenservices
+            - zenservice/status
+            - zenservices/status
+            - zenextension
+            - zenextensions
+            - zenextension/status
+            - zenextensions/status
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - ibm.com
+            resources:
+            - paralleljob
+            - paralleljobs
+            - paralleljob/status
+            - paralleljobs/status
+            verbs:
+            - get
+            - list
+        -   apiGroups:
+            - operator.ibm.com
+            resources:
+            - commonservices
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - certmanager.k8s.io
+            resources:
+            - issuers
+            - issuers/status
+            - issuers/finalizers
+            - certificates
+            - certificates/status
+            - certificates/finalizers
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - cert-manager.io
+            resources:
+            - issuers
+            - issuers/status
+            - issuers/finalizers
+            - certificates
+            - certificates/status
+            - certificates/finalizers
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - oidc.security.ibm.com
+            resources:
+            - client
+            - clients
+            verbs:
+            - create
+            - get
+            - list
+            - patch
+            - update
+            - watch
+            - delete
+            - use
+        -   apiGroups:
+            - operator.ibm.com
+            resources:
+            - operandrequest
+            - operandrequests
+            verbs:
+            - create
+            - get
+            - list
+            - patch
+            - update
+            - watch
+            - delete
+            - use
+        -   apiGroups:
+            - operators.coreos.com
+            resources:
+            - clusterserviceversions
+            verbs:
+            - get
+            - list
+            - watch
+        -   apiGroups:
+            - operators.coreos.com
+            resources:
+            - operatorconditions
+            - operatorconditions/status
+            verbs:
+            - get
+            - list
+            - watch
+            - update
+            - patch
+        -   apiGroups:
+            - monitoring.coreos.com
+            resources:
+            - servicemonitors
+            verbs:
+            - get
+            - create
+        -   apiGroups:
+            - ibm.com
+            resources:
+            - resourceplans
+            - resourcematches
+            verbs:
+            - get
+            - list
+            - watch
+            - update
+            - patch
+            - create
+            - delete
+            - deletecollection
+        -   apiGroups:
+            - networking.k8s.io
+            resources:
+            - networkpolicies
+            verbs:
+            - create
+            - get
+            - list
+            - patch
+            - update
+            - watch
+            - delete
+            - use
+  release_version: 4.8.0
+
+{{- end }}

--- a/instance-applications/010-ibm-sync-jobs/templates/00-ibm-cp4d-olm-481.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/00-ibm-cp4d-olm-481.yaml
@@ -1,0 +1,1035 @@
+{{- if eq .Values.cpd_product_version "4.8.1" }}
+---
+# This config map is created via cpd-cli manage apply-cr command: https://www.ibm.com/docs/en/cloud-paks/cp-data/4.6.x?topic=si-installing-components
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: olm-utils-cm
+  namespace: mas-{{ .Values.instance_id }}-syncres
+  annotations:
+    argocd.argoproj.io/sync-wave: "00"
+  labels:
+    app.kubernetes.io/name: olm-utils
+{{- if .Values.custom_labels }}
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+data:
+  release_components_meta: |
+    analyticsengine:
+        case_version: 8.1.0
+        cr_version: 4.8.1
+        csv_version: 5.1.0
+        sub_channel: v5.1
+    bigsql:
+        case_version: 10.0.0
+        cr_version: 7.6.0
+        csv_version: 10.0.0
+        sub_channel: v10.0
+    canvasbase:
+        case_version: 8.1.0
+        cr_version: 8.1.0
+        csv_version: 8.1.0
+        sub_channel: v8.1
+    ccs:
+        case_version: 8.1.0
+        cr_version: 8.1.0
+        csv_version: 8.1.0
+        sub_channel: v8.1
+    cognos_analytics:
+        case_version: 25.0.0
+        cr_version: 25.0.0
+        csv_version: 25.0.0
+        sub_channel: v25.0
+    cpd_platform:
+        case_version: 4.1.0
+        cr_version: 4.8.1
+        csv_version: 5.1.0
+        sub_channel: v5.1
+    cpfs:
+        case_version: 4.3.0
+        csv_version: 4.3.0
+        sub_channel: v4.3
+    dashboard:
+        case_version: 2.1.0
+        cr_version: 4.8.1
+        csv_version: 2.1.0
+        sub_channel: v2.1
+    data_governor:
+        case_version: 4.1.0
+        csv_version: 4.1.0
+        sub_channel: v4.1
+    datagate:
+        case_version: 7.1.0
+        cr_version: 5.1.0
+        csv_version: 5.1.0
+        sub_channel: v5.1
+    datarefinery:
+        case_version: 8.1.0
+        cr_version: 8.1.0
+        csv_version: 8.1.0
+        sub_channel: v8.1
+    datastage_ent:
+        case_version: 7.1.0
+        cr_version: 4.8.1
+        csv_version: 5.1.0
+        sub_channel: v5.1
+    datastage_ent_plus:
+        case_version: 7.1.0
+        cr_version: 4.8.1
+        csv_version: 5.1.0
+        sub_channel: v5.1
+    db2aaservice:
+        case_version: 4.8.0
+        cr_version: 4.8.0
+        csv_version: 5.0.0
+        sub_channel: v5.0
+    db2oltp:
+        case_version: 4.8.0
+        cr_version: 4.8.0
+        csv_version: 5.0.0
+        sub_channel: v5.0
+    db2u:
+        case_version: 5.5.0
+        csv_version: 5.0.0
+        sub_channel: v5.0
+    db2wh:
+        case_version: 4.8.0
+        cr_version: 4.8.0
+        csv_version: 5.0.0
+        sub_channel: v5.0
+    dfo:
+        case_version: 1.0.0
+        cr_version: 1.0.0
+        csv_version: 1.0.0
+        sub_channel: beta
+    dmc:
+        case_version: 7.0.0
+        cr_version: 4.8.0
+        csv_version: 4.0.0
+        sub_channel: v4.0
+    dods:
+        case_version: 8.1.0
+        cr_version: 8.1.0
+        csv_version: 8.1.0
+        sub_channel: v8.1
+    dp:
+        case_version: 8.1.0
+        cr_version: 4.8.1
+        csv_version: 8.1.0
+        sub_channel: v8.1
+    dpra:
+        case_version: 1.13.0
+        cr_version: 1.13.0
+        csv_version: 1.13.0
+        sub_channel: v1.13
+    dv:
+        case_version: 4.0.0
+        cr_version: 2.2.0
+        csv_version: 4.0.0
+        sub_channel: v4.0
+    edb_cp4d:
+        case_version: 4.19.0
+        cr_version: 4.19.0
+        csv_version: 4.19.0
+        sub_channel: v4.19
+    estap:
+        case_version: 1.1.0
+        cr_version: 1.1.0
+        csv_version: 1.1.0
+        sub_channel: v1.1
+    factsheet:
+        case_version: 3.1.0
+        cr_version: 4.8.1
+        csv_version: 3.1.0
+        sub_channel: v3.1
+    fdb_k8s:
+        csv_version: 3.1.6
+        sub_channel: v3.1
+    hee:
+        case_version: 4.8.1
+        cr_version: 4.8.1
+        csv_version: 4.81.0
+        sub_channel: v4.81
+    ibm-cert-manager:
+        case_version: 4.2.1
+        csv_version: 4.2.1
+        sub_channel: v4.2
+    ibm-licensing:
+        case_version: 4.2.3
+        csv_version: 4.2.3
+        sub_channel: v4.2
+    ibm_events_operator:
+        case_version: 4.9.0
+        csv_version: 4.9.0
+        sub_channel: v3
+    ibm_redis_cp:
+        case_version: 1.1.4
+        csv_version: 1.1.4
+        sub_channel: v1.1
+    informix:
+        case_version: 7.0.0
+        csv_version: 7.0.0
+        sub_channel: v7.0
+    informix_cp4d:
+        case_version: 7.0.0
+        cr_version: 7.0.0
+        csv_version: 7.0.0
+        sub_channel: v7.0
+    mantaflow:
+        case_version: 1.16.0
+        cr_version: 42.1.0
+        csv_version: 1.16.0
+        sub_channel: v1.16
+    match360:
+        case_version: 3.4.0
+        cr_version: 3.4.36
+        csv_version: 3.4.0
+        sub_channel: v3.4
+    model_train:
+        case_version: 1.2.11
+        csv_version: 1.1.13
+        sub_channel: v1.1
+    mongodb:
+        case_version: 4.19.0
+        csv_version: 1.23.0
+        sub_channel: stable
+    mongodb_cp4d:
+        case_version: 4.19.0
+        cr_version: 4.19.0
+        csv_version: 4.19.0
+        sub_channel: v4.19
+    opencontent_auditwebhook:
+        case_version: 1.0.24
+        csv_version: 0.3.1
+    opencontent_elasticsearch:
+        case_version: 1.1.1845
+        cr_version: 1.1.1845
+        csv_version: 1.1.1845
+        sub_channel: v1.1
+    opencontent_etcd:
+        case_version: 2.0.31
+        csv_version: 1.0.22
+    opencontent_fdb:
+        case_version: 3.1.6
+        cr_version: 3.1.6
+        csv_version: 3.1.6
+        sub_channel: v3.1
+    opencontent_minio:
+        case_version: 1.0.23
+        csv_version: 1.0.18
+    opencontent_rabbitmq:
+        case_version: 1.0.31
+        csv_version: 1.0.22
+        sub_channel: v1.0
+    opencontent_redis:
+        case_version: 1.6.11
+        csv_version: 1.6.11
+        sub_channel: v1.6
+    openpages:
+        case_version: 6.0.0
+        cr_version: 9.000.1
+        csv_version: 6.0.0
+        sub_channel: v6.0
+    openpages_instance:
+        cr_version: 9.000.1
+    openscale:
+        case_version: 6.0.0
+        cr_version: 4.8.0
+        csv_version: 5.0.0
+        sub_channel: v5.0
+    planning_analytics:
+        case_version: 4.8.1
+        cr_version: 4.8.1
+        csv_version: 4.8.1
+        sub_channel: v7.1
+    postgresql:
+        case_version: 4.18.0
+        csv_version: 1.18.7
+        sub_channel: stable
+    productmaster:
+        case_version: 5.1.0
+        cr_version: 5.1.0
+        csv_version: 5.1.0
+        sub_channel: v5.1
+    productmaster_instance:
+        cr_version: 5.1.0
+    replication:
+        case_version: 4.8.1
+        cr_version: 4.8.1
+        csv_version: 3.1.0
+        licenses_urls:
+            IDRC: https://ibm.biz/BdSZ39
+            IDRM: https://ibm.biz/BdSZ33
+            IIDRC: https://ibm.biz/BdSZ3C
+            IIDRM: https://ibm.biz/BdSZ3T
+        sub_channel: v3.1
+    rstudio:
+        case_version: 8.1.0
+        cr_version: 8.1.0
+        csv_version: 8.1.0
+        sub_channel: v8.1
+    scheduler:
+        case_version: 1.19.0
+        cr_version: 1.19.0
+        csv_version: 1.19.0
+        sub_channel: v1.19
+    spss:
+        case_version: 8.1.0
+        cr_version: 8.1.0
+        csv_version: 8.1.0
+        sub_channel: v8.1
+    syntheticdata:
+        case_version: 8.1.0
+        cr_version: 8.1.0
+        csv_version: 8.1.0
+        sub_channel: v8.1
+    voice_gateway:
+        case_version: 1.3.6
+        cr_version: 1.3.6
+        csv_version: 1.3.6
+        sub_channel: v1.36
+    watson_assistant:
+        case_version: 4.21.0
+        cr_version: 4.8.0
+        csv_version: 4.21.0
+        sub_channel: v4.21
+    watson_discovery:
+        case_version: 7.0.0
+        cr_version: 4.8.0
+        csv_version: 7.0.0
+        sub_channel: v7.0
+    watson_gateway:
+        case_version: 2.0.27
+        csv_version: 1.0.22
+    watson_speech:
+        case_version: 7.0.1
+        cr_version: 4.8.0
+        csv_version: 7.0.1
+        sub_channel: v7.0
+    watsonx_ai:
+        case_version: 8.1.0
+        cr_version: 8.1.0
+        csv_version: 8.1.0
+        licenses_urls:
+            WX: https://ibm.biz/BdSV76
+        sub_channel: v8.1
+    watsonx_ai_ifm:
+        case_version: 8.1.0
+        cr_version: 8.1.0
+        csv_version: 8.1.0
+        licenses_urls:
+            WX: https://ibm.biz/BdSV76
+        sub_channel: v8.1
+    watsonx_data:
+        case_version: 2.1.0
+        cr_version: 1.1.1
+        csv_version: 2.1.0
+        licenses_urls:
+            WX: https://ibm.biz/BdSJxS
+        sub_channel: v2.1
+    wkc:
+        case_version: 4.8.1
+        cr_version: 4.8.1
+        csv_version: 1.8.1
+        rules:
+        -   apiGroups:
+            - zen.cpd.ibm.com
+            resources:
+            - zenextensions/status
+            verbs:
+            - get
+        -   apiGroups:
+            - zen.cpd.ibm.com
+            resources:
+            - zenextension
+            - zenextensions
+            verbs:
+            - create
+            - delete
+            - list
+            - watch
+            - get
+            - patch
+            - update
+        -   apiGroups:
+            - ''
+            - batch
+            - extensions
+            - apps
+            - policy
+            - rbac.authorization.k8s.io
+            - autoscaling
+            - route.openshift.io
+            - authorization.openshift.io
+            - networking.k8s.io
+            - metrics.k8s.io
+            - project.openshift.io
+            resources:
+            - pods
+            - pods/log
+            - poddisruptionbudgets
+            - secrets
+            - jobs
+            - configmaps
+            - deployments
+            - deployments/scale
+            - daemonsets
+            - projects
+            - statefulsets
+            - statefulsets/scale
+            - replicasets
+            - services
+            - services/finalizers
+            - persistentvolumeclaims
+            - cronjobs
+            - pods/exec
+            - pods/portforward
+            - serviceaccounts
+            - namespaces
+            - roles
+            - rolebindings
+            - horizontalpodautoscalers
+            - routes
+            - routes/custom-host
+            - ingresses
+            - endpoints
+            - cronjob
+            - networkpolicies
+            - events
+            - jobs/status
+            - pods/status
+            - resourcequotas
+            - resourcequotas/status
+            verbs:
+            - apply
+            - create
+            - get
+            - delete
+            - watch
+            - update
+            - edit
+            - exec
+            - list
+            - patch
+            - deletecollection
+        -   apiGroups:
+            - cpd.ibm.com
+            resources:
+            - cpdinstalls
+            - cpdinstalls/spec
+            - cpdinstalls/status
+            verbs:
+            - apply
+            - create
+            - delete
+            - edit
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - build.openshift.io
+            resources:
+            - buildconfigs
+            - buildconfigs/instantiate
+            - buildconfigs/instantiatebinary
+            - buildconfigs/webhooks
+            - buildlogs
+            - builds
+            - builds/clone
+            - builds/details
+            - builds/log
+            verbs:
+            - create
+            - delete
+            - list
+            - watch
+            - get
+            - patch
+            - update
+        -   apiGroups:
+            - image.openshift.io
+            resources:
+            - imagestreams
+            - imagestreams/layers
+            - imagestreams/secrets
+            - imagestreams/status
+            - imagestreamimages
+            - imagestreamimports
+            - imagestreammappings
+            - imagestreamtags
+            verbs:
+            - create
+            - delete
+            - list
+            - watch
+            - get
+            - patch
+            - update
+        -   apiGroups:
+            - ''
+            resources:
+            - pods
+            verbs:
+            - get
+        -   apiGroups:
+            - apps
+            resources:
+            - replicasets
+            - deployments
+            verbs:
+            - get
+        -   apiGroups:
+            - wkc.cpd.ibm.com
+            resources:
+            - wkc
+            - wkc/spec
+            - wkc/status
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - zen.cpd.ibm.com
+            resources:
+            - zenservices
+            - zenservices/spec
+            - zenservices/status
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - ccs.cpd.ibm.com
+            resources:
+            - ccs
+            - ccs/spec
+            - ccs/status
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - ae.cpd.ibm.com
+            resources:
+            - analyticsengines
+            - analyticsengines/spec
+            - analyticsengines/status
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - ds.cpd.ibm.com
+            resources:
+            - datastages
+            - datastages/spec
+            - datastages/status
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - datarefinery.cpd.ibm.com
+            resources:
+            - datarefinery
+            - datarefinery/spec
+            - datarefinery/status
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - databases.cpd.ibm.com
+            resources:
+            - db2aaserviceservices
+            - db2aaserviceservices/spec
+            - db2aaserviceservices/status
+            - db2aaserviceservices/finalizers
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - db2u.databases.ibm.com
+            resources:
+            - db2uclusters
+            - db2uclusters/spec
+            - db2uclusters/status
+            - db2uclusters/finalizers
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - iis.cpd.ibm.com
+            resources:
+            - iis
+            - iis/spec
+            - iis/status
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - ug.wkc.cpd.ibm.com
+            resources:
+            - ug
+            - ug/spec
+            - ug/status
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - operator.ibm.com
+            resources:
+            - operandrequests
+            - operandregistries
+            - operandconfigs
+            - operandbindinfos
+            verbs:
+            - create
+            - get
+            - list
+            - patch
+            - update
+            - watch
+            - delete
+            - use
+        -   apiGroups:
+            - apps.foundationdb.org
+            resources:
+            - foundationdbclusters
+            - foundationdbbackups
+            - foundationdbrestores
+            verbs:
+            - get
+            - list
+            - watch
+            - create
+            - update
+            - patch
+            - delete
+        -   apiGroups:
+            - apps.foundationdb.org
+            resources:
+            - foundationdbclusters/status
+            - foundationdbbackups/status
+            verbs:
+            - get
+            - update
+            - patch
+        -   apiGroups:
+            - foundationdb.opencontent.ibm.com
+            resources:
+            - fdbclusters
+            verbs:
+            - get
+            - list
+            - watch
+            - create
+            - update
+            - patch
+            - delete
+        -   apiGroups:
+            - foundationdb.opencontent.ibm.com
+            resources:
+            - fdbclusters/finalizers
+            verbs:
+            - update
+        -   apiGroups:
+            - foundationdb.opencontent.ibm.com
+            resources:
+            - fdbclusters/status
+            verbs:
+            - get
+            - patch
+            - update
+        -   apiGroups:
+            - certmanager.k8s.io
+            resources:
+            - issuers
+            - issuers/status
+            - issuers/finalizers
+            - certificates
+            - certificates/status
+            - certificates/finalizers
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - ibmcpcs.ibm.com
+            resources:
+            - secretshares
+            verbs:
+            - get
+            - list
+            - watch
+            - create
+            - update
+            - patch
+            - delete
+        sub_channel: v5.1
+    wml:
+        case_version: 8.1.0
+        cr_version: 4.8.1
+        csv_version: 5.1.0
+        sub_channel: v5.1
+    wml_accelerator:
+        case_version: 4.8.1
+        cr_version: 4.8.1
+        csv_version: 5.1.0
+        sub_channel: v5.1
+    ws:
+        case_version: 8.1.0
+        cr_version: 8.1.0
+        csv_version: 8.1.0
+        sub_channel: v8.1
+    ws_pipelines:
+        case_version: 8.1.0
+        cr_version: 4.8.1
+        csv_version: 8.1.0
+        sub_channel: v8.1
+    ws_runtimes:
+        case_version: 8.1.0
+        cr_version: 8.1.0
+        csv_version: 8.1.0
+        sub_channel: v8.1
+    wxd_optimizerplus:
+        component_dependencies:
+        - db2u
+    zen:
+        cr_version: 5.1.0
+        csv_version: 5.1.0
+        rules:
+        -   apiGroups:
+            - ''
+            - batch
+            - extensions
+            - apps
+            - policy
+            - rbac.authorization.k8s.io
+            - autoscaling
+            - route.openshift.io
+            - authorization.openshift.io
+            - networking.k8s.io
+            - metrics.k8s.io
+            - project.openshift.io
+            - template.openshift.io
+            - autoscaling.k8s.io
+            resources:
+            - pods
+            - pods/log
+            - pods/eviction
+            - poddisruptionbudgets
+            - projects
+            - secrets
+            - jobs
+            - configmaps
+            - deployments
+            - deployments/scale
+            - daemonsets
+            - statefulsets
+            - statefulsets/scale
+            - replicasets
+            - replicationcontrollers
+            - services
+            - services/finalizers
+            - persistentvolumes
+            - persistentvolumeclaims
+            - cronjobs
+            - pods/exec
+            - pods/portforward
+            - serviceaccounts
+            - namespaces
+            - roles
+            - rolebindings
+            - horizontalpodautoscalers
+            - verticalpodautoscalers
+            - routes
+            - routes/custom-host
+            - ingresses
+            - endpoints
+            - cronjob
+            - networkpolicies
+            - events
+            - jobs/status
+            - pods/status
+            - resourcequotas
+            - resourcequotas/status
+            - processedtemplates
+            verbs:
+            - create
+            - get
+            - delete
+            - watch
+            - update
+            - list
+            - patch
+            - deletecollection
+        -   apiGroups:
+            - cpd.ibm.com
+            resources:
+            - cpdinstalls
+            - cpdinstalls/spec
+            - cpdinstalls/status
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - build.openshift.io
+            resources:
+            - buildconfigs
+            - buildconfigs/instantiate
+            - buildconfigs/instantiatebinary
+            - buildconfigs/webhooks
+            - buildlogs
+            - builds
+            - builds/clone
+            - builds/details
+            - builds/log
+            verbs:
+            - create
+            - delete
+            - list
+            - watch
+            - get
+            - patch
+            - update
+        -   apiGroups:
+            - image.openshift.io
+            resources:
+            - imagestreams
+            - imagestreams/layers
+            - imagestreams/secrets
+            - imagestreams/status
+            - imagestreamimages
+            - imagestreamimports
+            - imagestreammappings
+            - imagestreamtags
+            verbs:
+            - create
+            - delete
+            - list
+            - watch
+            - get
+            - patch
+            - update
+        -   apiGroups:
+            - apps
+            resourceNames:
+            - cpd-zen-operator
+            resources:
+            - deployments/finalizers
+            verbs:
+            - update
+        -   apiGroups:
+            - zen.cpd.ibm.com
+            resources:
+            - zenservice
+            - zenservices
+            - zenservice/status
+            - zenservices/status
+            - zenextension
+            - zenextensions
+            - zenextension/status
+            - zenextensions/status
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - ibm.com
+            resources:
+            - paralleljob
+            - paralleljobs
+            - paralleljob/status
+            - paralleljobs/status
+            verbs:
+            - get
+            - list
+        -   apiGroups:
+            - operator.ibm.com
+            resources:
+            - commonservices
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - certmanager.k8s.io
+            resources:
+            - issuers
+            - issuers/status
+            - issuers/finalizers
+            - certificates
+            - certificates/status
+            - certificates/finalizers
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - cert-manager.io
+            resources:
+            - issuers
+            - issuers/status
+            - issuers/finalizers
+            - certificates
+            - certificates/status
+            - certificates/finalizers
+            verbs:
+            - create
+            - delete
+            - get
+            - list
+            - patch
+            - update
+            - watch
+        -   apiGroups:
+            - oidc.security.ibm.com
+            resources:
+            - client
+            - clients
+            verbs:
+            - create
+            - get
+            - list
+            - patch
+            - update
+            - watch
+            - delete
+            - use
+        -   apiGroups:
+            - operator.ibm.com
+            resources:
+            - operandrequest
+            - operandrequests
+            verbs:
+            - create
+            - get
+            - list
+            - patch
+            - update
+            - watch
+            - delete
+            - use
+        -   apiGroups:
+            - operators.coreos.com
+            resources:
+            - clusterserviceversions
+            verbs:
+            - get
+            - list
+            - watch
+        -   apiGroups:
+            - operators.coreos.com
+            resources:
+            - operatorconditions
+            - operatorconditions/status
+            verbs:
+            - get
+            - list
+            - watch
+            - update
+            - patch
+        -   apiGroups:
+            - monitoring.coreos.com
+            resources:
+            - servicemonitors
+            verbs:
+            - get
+            - create
+        -   apiGroups:
+            - ibm.com
+            resources:
+            - resourceplans
+            - resourcematches
+            verbs:
+            - get
+            - list
+            - watch
+            - update
+            - patch
+            - create
+            - delete
+            - deletecollection
+        -   apiGroups:
+            - networking.k8s.io
+            resources:
+            - networkpolicies
+            verbs:
+            - create
+            - get
+            - list
+            - patch
+            - update
+            - watch
+            - delete
+            - use
+  release_version: 4.8.1
+{{- end }}

--- a/instance-applications/010-ibm-sync-jobs/templates/00-ibm-cp4d-olm-500.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/00-ibm-cp4d-olm-500.yaml
@@ -1,0 +1,503 @@
+{{- if eq .Values.cpd_product_version "5.0.0" }}
+---
+# This config map is created via cpd-cli manage apply-cr command: https://www.ibm.com/docs/en/cloud-paks/cp-data/4.6.x?topic=si-installing-components
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: olm-utils-cm
+  namespace: mas-{{ .Values.instance_id }}-syncres
+  annotations:
+    argocd.argoproj.io/sync-wave: "00"
+  labels:
+    app.kubernetes.io/name: olm-utils
+{{- if .Values.custom_labels }}
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+data:
+  release_components_meta: |
+    scheduler:
+        case_version: 1.25.0
+        sub_channel: "v1.25"
+        csv_version: 1.25.0
+        cr_version: 1.25.0
+
+    cpfs:
+        csv_version: 4.7.0
+        case_version: 4.7.0
+        sub_channel: "v4.7"
+
+    ibm-cert-manager:
+        csv_version: 4.2.4
+        case_version: 4.2.4
+        sub_channel: "v4.2"
+
+    ibm_events_operator:
+        case_version: 5.0.1
+        sub_channel: "v3"
+        csv_version: 5.0.1
+
+    ibm-licensing:
+        csv_version: 4.2.4
+        case_version: 4.2.4
+        sub_channel: "v4.2"
+
+    cpd_platform:
+        case_version: 5.0.0
+        csv_version: 6.0.0
+        sub_channel: "v6.0"
+        cr_version: 5.0.0 #should be the same as release_version
+
+    zen:
+        case_version: 6.0.1
+        sub_channel: "v6.0" # TODO: this is a temporary workaround. need to update it to formal channel later
+        csv_version: 6.0.1
+        cr_version: 6.0.1
+
+
+    analyticsengine:
+        case_version: 9.0.0
+        sub_channel: v6.0
+        csv_version: 6.0.0
+        cr_version: 5.0.0
+
+    cognos_analytics:
+        case_version: 26.0.0
+        sub_channel: "v26.0"
+        cr_version: 26.0.0
+        csv_version: 26.0.0
+
+    ccs:
+        case_version: 9.0.0
+        sub_channel: "v9.0"
+        csv_version: 9.0.0
+        cr_version: 9.0.0
+
+    dashboard:
+        case_version: 3.0.0
+        sub_channel: "v3.0"
+        csv_version: 3.0.0
+        cr_version: 5.0.0
+
+    datarefinery:
+        case_version: 9.0.0
+        csv_version: 9.0.0
+        sub_channel: "v9.0"
+        cr_version: 9.0.0
+
+    canvasbase:
+        case_version: 9.0.0
+        sub_channel: "v9.0"
+        csv_version: 9.0.0
+        cr_version: 9.0.0
+
+    spss:
+        case_version: 9.0.0
+        csv_version: 9.0.0
+        sub_channel: "v9.0"
+        cr_version: 9.0.0
+
+    syntheticdata:
+        licenses_urls:
+            WXAI: https://ibm.biz/BdmsCi
+        case_version: 9.0.0
+        sub_channel: "v9.0"
+        csv_version: 9.0.0
+        cr_version: 9.0.0
+
+    datastage_ent:
+        case_version: 8.0.0
+        csv_version: 6.0.0
+        cr_version: 5.0.0
+        sub_channel: "v6.0"
+
+    datastage_ent_plus:
+        case_version: 8.0.0
+        csv_version: 6.0.0
+        cr_version: 5.0.0
+        sub_channel: "v6.0"
+
+    informix:
+        case_version: 8.0.0
+        sub_channel: "v8.0"
+        csv_version: 8.0.0
+
+    informix_cp4d:
+        case_version: 8.0.0
+        sub_channel: "v8.0"
+        csv_version: 8.0.0
+        cr_version: 8.0.0
+
+    openscale:
+        case_version: 7.0.0
+        sub_channel: "v6.0"
+        csv_version: 6.0.0
+        cr_version: 5.0.0
+
+    ws:
+        case_version: 9.0.0
+        sub_channel: "v9.0"
+        csv_version: 9.0.0
+        cr_version: 9.0.0
+
+    ws_runtimes:
+        case_version: 9.0.0
+        sub_channel: "v9.0"
+        csv_version: 9.0.0
+        cr_version: 9.0.0
+
+    db2aaservice:
+        case_version: 5.0.0
+        sub_channel: "v6.0"
+        csv_version: 6.0.0
+        cr_version: 5.0.0
+
+    db2oltp:
+        licenses_urls:
+            DB2CE: https://ibm.biz/BdmpYX
+            DB2SE: https://ibm.biz/BdmpYd
+            DB2AE: https://ibm.biz/BdmpZ5
+        case_version: 5.0.0
+        sub_channel: "v6.0"
+        csv_version: 6.0.0
+        cr_version: 5.0.0
+
+    db2wh:
+        case_version: 5.0.0
+        sub_channel: "v6.0"
+        csv_version: 6.0.0
+        cr_version: 5.0.0
+
+    db2u:
+        case_version: 6.0.0
+        sub_channel: "v6.0"
+        csv_version: 6.0.0
+        multi_arch_images: cpopen/db2u-operator,cpopen/db2u-day2-operator
+
+    datagate:
+        licenses_urls:
+            DGWXD: https://ibm.biz/Bdmepq
+        case_version: 8.0.0
+        sub_channel: "v6.0"
+        csv_version: 6.0.0
+        cr_version: 6.0.0
+
+    dods:
+        case_version: 9.0.0
+        sub_channel: "v9.0"
+        csv_version: 9.0.0
+        cr_version: 9.0.0
+
+    hee:
+        case_version: 5.0.0
+        sub_channel: "v5.0"
+        csv_version: 5.0.0
+        cr_version: 5.0.0
+
+    dv:
+        case_version: 5.0.0
+        sub_channel: "v5.0"
+        csv_version: 5.0.0
+        cr_version: 3.0.0
+
+    bigsql:
+        case_version: 11.0.0
+        sub_channel: "v11.0"
+        csv_version: 11.0.0
+        cr_version: 7.7.0
+
+    planning_analytics:
+        case_version: 5.0.0
+        sub_channel: "v8.0"
+        csv_version: 5.0.0
+        cr_version: 5.0.0
+
+    rstudio:
+        case_version: 9.0.0
+        sub_channel: "v9.0"
+        csv_version: 9.0.0
+        cr_version: 9.0.0
+
+    watson_assistant:
+        case_version: 5.0.0
+        sub_channel: "v5.0"
+        csv_version: 5.0.0
+        cr_version: "5.0.0"
+
+    watson_discovery:
+        case_version: 8.0.0
+        sub_channel: "v8.0"
+        csv_version: 8.0.0
+        cr_version: 5.0.0
+
+    watson_speech:
+        case_version: 8.0.1
+        sub_channel: "v8.0"
+        csv_version: 8.0.1
+        cr_version: 5.0.0
+
+    wkc:
+        case_version: 5.0.0
+        sub_channel: "v6.0"
+        csv_version: 2.0.0
+        cr_version: 5.0.0
+
+    ikc_standard:
+        case_version: 5.0.0
+        sub_channel: "v5.0"
+        csv_version: 5.0.0
+        cr_version: 5.0.0
+
+    ikc_premium:
+        case_version: 5.0.0
+        sub_channel: "v5.0"
+        csv_version: 5.0.0
+        cr_version: 5.0.0
+
+    productmaster:
+        case_version: 6.0.0
+        csv_version: 6.0.0
+        sub_channel: "v6.0"
+        cr_version: 6.0.0
+
+    dataproduct:
+        case_version: 5.0.0
+        sub_channel: "v5.0"
+        csv_version: 1.0.0
+        cr_version: 5.0.0
+
+    productmaster_instance:
+        cr_version: 6.0.0
+
+    dp:
+        case_version: 8.6.0
+        csv_version: 8.6.0
+        sub_channel: "v8.6"
+        cr_version: 5.0.0
+
+    wml:
+        case_version: 9.0.0
+        sub_channel: "v6.0"
+        csv_version: 6.0.0
+        cr_version: 5.0.0
+
+    wml_accelerator:
+        case_version: 5.0.0
+        sub_channel: "v6.0"
+        csv_version: 6.0.0
+        cr_version: 5.0.0
+
+    dmc:
+        case_version: 8.0.0
+        csv_version: 5.0.0
+        cr_version: 5.0.0
+        sub_channel: "v5.0"
+
+    openpages:
+        case_version: 7.0.0
+        csv_version: 7.0.0
+        cr_version: 9.002.1
+        sub_channel: "v7.0"
+
+    openpages_instance:
+        cr_version: 9.002.1
+
+    mantaflow:
+        case_version: 1.21.0
+        sub_channel: "v1.21"
+        csv_version: 1.21.0
+        cr_version: 42.5.5
+
+    match360:
+        case_version: 4.0.0
+        csv_version: 4.0.0
+        cr_version: 4.0.23
+        sub_channel: "v4.0"
+
+    opencontent_elasticsearch:
+        case_version: 1.1.2153
+        csv_version: 1.1.2153
+        cr_version: 1.1.2153
+        sub_channel: "v1.1"
+
+    opencontent_redis:
+        case_version: 1.6.11
+        csv_version: 1.6.11
+        sub_channel: "v1.6"
+
+    ibm_redis_cp:
+        case_version: 1.1.9
+        csv_version: 1.1.9
+        sub_channel: "v1.1"
+
+    opencontent_rabbitmq:
+        case_version: 1.0.36
+        csv_version: 1.0.27
+        sub_channel: "v1.0"
+
+    opencontent_fdb:
+        case_version: 5.0.0
+        csv_version: 5.0.0
+        cr_version: 5.0.0
+        sub_channel: "v5.0"
+
+    fdb_k8s:
+        csv_version: 5.0.0
+        sub_channel: "v5.0"
+
+    opencontent_minio:
+        case_version: 1.0.23
+        csv_version: 1.0.18
+
+    opencontent_etcd:
+        case_version: 2.0.36
+        csv_version: 1.0.27
+
+    opencontent_auditwebhook:
+        case_version: 1.0.24
+        csv_version: 0.3.1
+
+    watson_gateway:
+        case_version: 2.0.32
+        csv_version: 1.0.27
+
+    data_governor:
+        case_version: 5.0.4
+        csv_version: 5.0.4
+        sub_channel: v5.0
+
+    model_train:
+        case_version: 1.2.14
+        csv_version: 2.0.0
+        sub_channel: v2.0
+
+    ws_pipelines:
+        case_version: 9.0.0
+        sub_channel: "v9.0"
+        csv_version: 9.0.0
+        cr_version: 5.0.0
+
+    postgresql:
+        case_version: 4.25.0
+        sub_channel: "stable"
+        csv_version: 1.18.12
+        #operands_supported: "12.18, 13.14, 14.11, 15.6, 16.2"
+
+    edb_cp4d:
+        case_version: 4.25.0
+        sub_channel: "v4.25"
+        csv_version: 4.25.0
+        cr_version: 4.25.0
+
+    mongodb:
+        case_version: 4.25.0
+        sub_channel: "stable"
+        csv_version: 1.24.0
+        # MongoDB_Ops_Manager: "6.0.20"
+        # Mongodb_server: "5.0.23, 6.0.12"
+
+    mongodb_cp4d:
+        case_version: 4.25.0
+        sub_channel: "v4.25"
+        csv_version: 4.25.0
+        cr_version: 4.25.0
+
+    estap:
+        case_version: 1.1.0
+        sub_channel: "v1.1"
+        csv_version: 1.1.0
+        cr_version: 1.1.0
+
+    dpra:
+        case_version: 1.15.0
+        sub_channel: "v1.15"
+        csv_version: 1.15.0
+        cr_version: 1.15.0
+
+    factsheet:
+        case_version: 4.0.0
+        csv_version: 4.0.0
+        sub_channel: "v4.0"
+        cr_version: 5.0.0
+
+    replication:
+        licenses_urls:
+            IDRC: https://ibm.biz/Bdmf2H
+            IIDRC: https://ibm.biz/Bdmf24
+            IDRM: https://ibm.biz/Bdmf2r
+            IIDRM: https://ibm.biz/Bdmf2s
+        case_version: 5.0.0
+        csv_version: 4.0.0
+        cr_version: 5.0.0
+        sub_channel: "v4.0"
+
+    dfo:
+        case_version: 1.0.0
+        sub_channel: "beta"
+        csv_version: 1.0.0
+        cr_version: 1.0.0
+
+    voice_gateway:
+        case_version: 1.4.0
+        csv_version: 1.4.0
+        sub_channel: v1.4
+        cr_version: 1.4.0
+
+    watsonx_data:
+        licenses_urls:
+            WXD: https://ibm.biz/BdmbAW
+        case_version: 3.0.0
+        sub_channel: "v3.0"
+        csv_version: 3.0.0
+        cr_version: 2.0.0
+
+    wxd_query_optimizer:
+        component_dependencies:
+        - db2u
+
+    watsonx_ai:
+        licenses_urls:
+            WXAI: https://ibm.biz/BdmsCi
+        case_version: 9.0.0
+        csv_version: 9.0.0
+        sub_channel: v9.0
+        cr_version: 9.0.0
+
+    watsonx_ai_ifm:
+        licenses_urls:
+            WXAI: https://ibm.biz/BdmsCi
+        case_version: 9.0.0
+        csv_version: 9.0.0
+        sub_channel: v9.0
+        cr_version: 9.0.0
+
+    wca_ansible:
+        case_version: 1.0.1
+        csv_version: 1.0.1
+        sub_channel: v1.0
+        cr_version: 5.0.0
+
+    wca_z:
+        case_version: 1.0.1
+        csv_version: 1.0.1
+        sub_channel: v1.0
+        cr_version: 5.0.0
+
+    ibm_neo4j:
+        case_version: 1.0.0
+        sub_channel: "v1.0"
+        csv_version: 1.0.0
+        cr_version: 1.0.0
+
+    watsonx_governance:
+        case_version: 2.0.0
+        sub_channel: "v2.0"
+        csv_version: 2.0.0
+        cr_version: 2.0.0
+
+    watsonx_orchestrate:
+        case_version: 2.0.0
+        sub_channel: "v2.0"
+        csv_version: 2.0.0
+        cr_version: "2.0.0"
+  release_version: 5.0.0
+{{- end }}

--- a/instance-applications/010-ibm-sync-jobs/templates/00-ibm-cp4d-olm-510.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/00-ibm-cp4d-olm-510.yaml
@@ -1,0 +1,527 @@
+{{- if eq .Values.cpd_product_version "5.1.0" }}
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: olm-utils-cm
+  namespace: mas-{{ .Values.instance_id }}-syncres
+  annotations:
+    argocd.argoproj.io/sync-wave: "00"
+  labels:
+    app.kubernetes.io/name: olm-utils
+{{- if .Values.custom_labels }}
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+data:
+  release_components_meta: |
+    scheduler:
+      case_version: 1.40.0
+      sub_channel: "v1.40"
+      csv_version: 1.40.0
+      cr_version: 1.40.0
+
+    cpfs:
+      csv_version: 4.10.0
+      case_version: 4.10.0
+      sub_channel: "v4.10"
+
+    ibm-cert-manager:
+      csv_version: 4.2.10  # TODO: pick the latest version up for 5.10
+      case_version: 4.2.10
+      sub_channel: "v4.2"
+
+    ibm_events_operator:
+      case_version: 5.0.1
+      sub_channel: "v3"
+      csv_version: 5.0.1
+
+    ibm-licensing:
+      csv_version: 4.2.10 # TODO: pick the latest version up for 5.10
+      case_version: 4.2.10
+      sub_channel: "v4.2"
+
+    cpd_platform:
+      case_version: 5.1.0
+      csv_version: 6.1.0
+      sub_channel: "v6.1"
+      cr_version: 5.1.0 #should be the same as release_version
+
+    ibm_swhcc:
+      case_version: 5.1.0
+      csv_version: 5.1.0
+      sub_channel: "v5.1"
+      cr_version: 5.1.0
+
+    zen:
+      case_version: 6.1.0
+      sub_channel: "v6.1"
+      csv_version: 6.1.0
+      cr_version: 6.1.0
+
+
+    analyticsengine:
+      case_version: 10.0.0
+      sub_channel: "v7.0"
+      csv_version: 7.0.0
+      cr_version: 5.1.0
+
+    cognos_analytics:
+      case_version: 27.0.0
+      sub_channel: "v27.0"
+      cr_version: 27.0.0
+      csv_version: 27.0.0
+
+    ccs:
+      case_version: 10.0.0
+      sub_channel: "v10.0"
+      csv_version: 10.0.0
+      cr_version: 10.0.0
+
+    dashboard:
+      case_version: 3.3.0
+      sub_channel: "v3.3"
+      csv_version: 3.3.0
+      cr_version: 5.1.0
+
+    datarefinery:
+      case_version: 10.0.0
+      csv_version: 10.0.0
+      sub_channel: "v10.0"
+      cr_version: 10.0.0
+
+    canvasbase:
+      case_version: 10.0.0
+      sub_channel: "v10.0"
+      csv_version: 10.0.0
+      cr_version: 10.0.0
+
+    spss:
+      case_version: 10.0.0
+      sub_channel: "v10.0"
+      csv_version: 10.0.0
+      cr_version: 10.0.0
+
+    syntheticdata:
+      licenses_urls:
+        WXAI: https://ibm.biz/BdabQY
+      case_version: 10.0.0
+      sub_channel: "v10.0"
+      csv_version: 10.0.0
+      cr_version: 10.0.0
+
+    datastage_ent:
+      case_version: 9.0.0
+      csv_version: 7.0.0
+      cr_version: 5.1.0
+      sub_channel: "v7.0"
+
+    datastage_ent_plus:
+      case_version: 9.0.0
+      csv_version: 7.0.0
+      cr_version: 5.1.0
+      sub_channel: "v7.0"
+
+    informix:
+      case_version: 8.2.0
+      sub_channel: "v8.2"
+      csv_version: 8.2.0
+
+    informix_cp4d:
+      case_version: 8.2.0
+      sub_channel: "v8.2"
+      csv_version: 8.2.0
+      cr_version: 8.2.0
+
+    openscale:
+      case_version: 8.0.0
+      sub_channel: "v7.0"
+      csv_version: 7.0.0
+      cr_version: 5.1.0
+
+    ws:
+      case_version: 10.0.0
+      sub_channel: "v10.0"
+      csv_version: 10.0.0
+      cr_version: 10.0.0
+
+    ws_runtimes:
+      case_version: 10.0.0
+      sub_channel: "v10.0"
+      csv_version: 10.0.0
+      cr_version: 10.0.0
+
+    db2aaservice:
+      case_version: 5.1.0
+      sub_channel: "v7.0"
+      csv_version: 7.0.0
+      cr_version: 5.1.0
+
+    db2oltp:
+      licenses_urls:
+        DB2CE: https://ibm.biz/BdmpYX
+        DB2SE: https://ibm.biz/BdmpYd
+        DB2AE: https://ibm.biz/BdmpZ5
+      case_version: 5.1.0
+      sub_channel: "v7.0"
+      csv_version: 7.0.0
+      cr_version: 5.1.0
+
+    db2wh:
+      case_version: 5.1.0
+      sub_channel: "v7.0"
+      csv_version: 7.0.0
+      cr_version: 5.1.0
+
+    db2u:
+      case_version: 7.1.0
+      sub_channel: "v7.1"
+      csv_version: 7.1.0
+
+    datagate:
+      case_version: 9.0.0
+      sub_channel: "v7.0"
+      csv_version: 7.0.0
+      cr_version: 7.0.0
+
+    dods:
+      case_version: 10.0.0
+      sub_channel: "v10.0"
+      csv_version: 10.0.0
+      cr_version: 10.0.0
+
+    hee:
+      case_version: 5.1.0
+      sub_channel: "v5.10"
+      csv_version: 5.1.0
+      cr_version: 5.1.0
+
+    dv:
+      case_version: 6.0.0
+      sub_channel: "v6.0"
+      csv_version: 6.0.0
+      cr_version: 3.1.0
+
+    bigsql:
+      case_version: 12.0.0
+      sub_channel: "v12.0"
+      csv_version: 12.0.0
+      cr_version: 7.8.0
+
+    planning_analytics:
+      case_version: 5.1.0
+      sub_channel: "v9.0"
+      csv_version: 5.1.0
+      cr_version: 5.1.0
+
+    rstudio:
+      case_version: 10.0.0
+      sub_channel: "v10.0"
+      csv_version: 10.0.0
+      cr_version: 10.0.0
+
+    watson_assistant:
+      case_version: 5.3.0
+      sub_channel: "v5.3"
+      csv_version: 5.3.0
+      cr_version: "5.1.0"
+
+    watson_discovery:
+      case_version: 9.0.0
+      sub_channel: "v9.0"
+      csv_version: 9.0.0
+      cr_version: 5.1.0
+
+    watson_speech:
+      case_version: 9.0.0
+      sub_channel: "v9.0"
+      csv_version: 9.0.0
+      cr_version: 5.1.0
+
+    wkc:
+      case_version: 5.1.0
+      sub_channel: "v7.0"
+      csv_version: 2.1.0
+      cr_version: 5.1.0
+
+    ikc_standard:
+      licenses_urls:
+        IKCS: https://ibm.biz/Bdmm4V
+      case_version: 5.1.0
+      sub_channel: "v6.0"
+      csv_version: 5.1.0
+      cr_version: 5.1.0
+
+    ikc_premium:
+      licenses_urls:
+        IKCP: https://ibm.biz/Bdmm4J
+      case_version: 5.1.0
+      sub_channel: "v6.0"
+      csv_version: 5.1.0
+      cr_version: 5.1.0
+
+    datalineage:
+      case_version: 5.1.0
+      sub_channel: "v5.1"
+      csv_version: 5.1.0
+      cr_version: 5.1.0
+
+    productmaster:
+      case_version: 7.0.0
+      csv_version: 7.0.0
+      sub_channel: "v7.0"
+      cr_version: 7.0.0
+
+    dataproduct:
+      case_version: 5.1.0
+      sub_channel: "v6.0"
+      csv_version: 1.1.0
+      cr_version: 5.1.0
+
+    productmaster_instance:
+      cr_version: 7.0.0
+
+    dp:
+      case_version: 9.0.0
+      csv_version: 9.0.0
+      sub_channel: "v9.0"
+      cr_version: 5.1.0
+
+    wml:
+      case_version: 10.0.0
+      sub_channel: "v7.0"
+      csv_version: 7.0.0
+      cr_version: 5.1.0
+
+    dmc:
+      case_version: 8.4.0
+      csv_version: 5.4.0
+      cr_version: 5.1.0
+      sub_channel: "v5.4"
+
+    openpages:
+      case_version: 8.0.0
+      csv_version: 8.0.0
+      cr_version: 9.4.0
+      sub_channel: "v8.0"
+
+    openpages_instance:
+      cr_version: 9.4.0
+
+    mantaflow:
+      case_version: 1.25.0
+      sub_channel: "v1.25"
+      csv_version: 1.25.0
+      cr_version: 42.8.5
+
+    match360:
+      case_version: 4.3.0
+      csv_version: 4.3.0
+      cr_version: 4.3.49
+      sub_channel: "v4.3"
+
+    opencontent_opensearch:
+      case_version: 1.1.1030
+      csv_version: 1.1.1030
+      cr_version: 1.1.1030
+      sub_channel: "v1.1"
+
+    opencontent_elasticsearch:
+      case_version: 1.1.2470
+      csv_version: 1.1.2470
+      cr_version: 1.1.2470
+      sub_channel: "v1.1"
+
+    opencontent_redis:
+      case_version: 1.6.11
+      csv_version: 1.6.11
+      sub_channel: "v1.6"
+
+    ibm_redis_cp:
+      case_version: 1.2.3
+      csv_version: 1.2.3
+      sub_channel: "v1.2"
+
+    opencontent_rabbitmq:
+      case_version: 1.0.42
+      csv_version: 1.0.33
+      sub_channel: "v1.0"
+
+    opencontent_fdb:
+      case_version: 5.1.0
+      csv_version: 5.1.0
+      cr_version: 5.1.0
+      sub_channel: "v5.1"
+
+    fdb_k8s:
+      csv_version: 5.1.0
+      sub_channel: "v5.1"
+
+    opencontent_minio:
+      case_version: 1.0.23
+      csv_version: 1.0.18
+
+    opencontent_etcd:
+      case_version: 2.0.43
+      csv_version: 1.0.34
+
+    opencontent_auditwebhook:
+      case_version: 1.0.24
+      csv_version: 0.3.1
+
+    watson_gateway:
+      case_version: 2.0.37
+      csv_version: 1.0.35
+
+    data_governor:
+      case_version: 6.0.2
+      csv_version: 6.0.2
+      sub_channel: v6.0
+
+    ws_pipelines:
+      case_version: 10.0.0
+      sub_channel: "v10.0"
+      csv_version: 10.0.0
+      cr_version: 5.1.0
+
+    postgresql:
+      case_version: 4.30.0
+      sub_channel: "stable-v1.22"
+      csv_version: 1.22.7
+      #operands_supported: "12.20, 13.16, 14.13, 15.8, 16.4"
+
+    edb_cp4d:
+      case_version: 5.10.0
+      sub_channel: "v5.10"
+      csv_version: 5.10.0
+      cr_version: 5.10.0
+      #operands_supported: "12.20, 13.16, 14.13, 15.8, 16.4"
+
+    mongodb:
+      case_version: 5.10.0
+      sub_channel: "stable"
+      csv_version: 1.28.0
+      # MongoDB_Ops_Manager: "7.0.11, 8.0.0"
+      # Mongodb_server: "8.0.0-ent, 7.0.14-ent"
+
+    mongodb_cp4d:
+      case_version: 5.10.0
+      sub_channel: "v5.10"
+      csv_version: 5.10.0
+      cr_version: 5.10.0
+
+    estap:
+      case_version: 1.1.0
+      sub_channel: "v1.1"
+      csv_version: 1.1.0
+      cr_version: 1.1.0
+
+    dpra:
+      case_version: 1.18.0
+      sub_channel: "v1.18"
+      csv_version: 1.18.0
+      cr_version: 1.18.0
+
+    factsheet:
+      case_version: 5.0.0
+      csv_version: 5.0.0
+      sub_channel: "v5.0"
+      cr_version: 5.1.0
+
+    replication:
+      licenses_urls:
+        IDRC: https://ibm.biz/BdanUi
+        IIDRC: https://ibm.biz/BdanUZ
+        IDRM: https://ibm.biz/BdagqW
+        IIDRM: https://ibm.biz/Bdagfc
+        IDRZOS: https://ibm.biz/BdanUY
+        IIDRWXTO: https://ibm.biz/BdanU2
+        IIDRWXAO: https://ibm.biz/BdanUz
+      case_version: 5.1.0
+      csv_version: 5.0.0
+      cr_version: 5.1.0
+      sub_channel: "v5.0"
+
+    dfo:
+      case_version: 1.0.0
+      sub_channel: "beta"
+      csv_version: 1.0.0
+      cr_version: 1.0.0
+
+    voice_gateway:
+      case_version: 1.6.0
+      csv_version: 1.6.0
+      sub_channel: v1.6
+      cr_version: 1.6.0
+
+    watsonx_data:
+      licenses_urls:
+        WXD: https://ibm.biz/BdaJCy
+      case_version: 4.0.0
+      sub_channel: "v4.0"
+      csv_version: 4.0.0
+      cr_version: 2.1.0
+
+    wxd_query_optimizer:
+      component_dependencies:
+      - db2u
+
+    watsonx_ai:
+      licenses_urls:
+        WXAI: https://ibm.biz/BdabQY
+      case_version: 10.0.0
+      csv_version: 10.0.0
+      sub_channel: v10.0
+      cr_version: 10.0.0
+      osai_min_version: 2.13.0
+
+    watsonx_ai_ifm:
+      licenses_urls:
+        WXAI: https://ibm.biz/BdabQY
+      case_version: 10.0.0
+      csv_version: 10.0.0
+      sub_channel: v10.0
+      cr_version: 10.0.0
+
+    wca_ansible:
+      case_version: 2.0.0
+      csv_version: 2.0.0
+      sub_channel: v2.0
+      cr_version: 5.1.0
+
+    wca:
+      case_version: 1.0.0
+      csv_version: 1.0.0
+      sub_channel: v1.0
+      cr_version: 5.1.0
+
+    wca_z:
+      case_version: 2.0.0
+      csv_version: 2.0.0
+      sub_channel: v2.0
+      cr_version: 5.1.0
+
+    wca_base:
+      case_version: 2.0.0
+      csv_version: 2.0.0
+      sub_channel: v2.0
+      cr_version: 5.1.0
+
+    ibm_neo4j:
+      case_version: 1.1.0
+      sub_channel: "v2.0"
+      csv_version: 1.1.0
+      cr_version: 1.1.0
+
+    watsonx_governance:
+      case_version: 3.0.0
+      sub_channel: "v3.0"
+      csv_version: 3.0.0
+      cr_version: 2.1.0
+
+    watsonx_orchestrate:
+      case_version: 5.1.0
+      sub_channel: "v5.1"
+      csv_version: 5.1.0
+      cr_version: "5.1.0"
+  release_version: 5.1.0
+{{- end }}

--- a/instance-applications/010-ibm-sync-jobs/templates/00-ibm-cp4d-presync.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/00-ibm-cp4d-presync.yaml
@@ -1,26 +1,10 @@
----
-kind: Secret
-apiVersion: v1
-metadata:
-  name: aws
-  namespace: {{ .Values.cpd_instance_namespace }}
-  annotations:
-    argocd.argoproj.io/sync-wave: "000"
-{{- if .Values.custom_labels }}
-  labels:
-{{ .Values.custom_labels | toYaml | indent 4 }}
-{{- end }}
-stringData:
-  aws_access_key_id: {{ .Values.sm_aws_access_key_id }}
-  aws_secret_access_key: {{ .Values.sm_aws_secret_access_key }}
-type: Opaque
-
+{{- if not (empty .Values.cpd_product_version) }}
 ---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: presync-cpd-olm-sa
-  namespace: {{ .Values.cpd_instance_namespace }}
+  namespace: mas-{{ .Values.instance_id }}-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "001"
 {{- if .Values.custom_labels }}
@@ -70,7 +54,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: presync-cpd-olm-sa
-    namespace: {{ .Values.cpd_instance_namespace }}
+    namespace: mas-{{ .Values.instance_id }}-syncres
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -86,7 +70,7 @@ metadata:
   # The job is idempotent and quick so no real harm in running it when we don't actually need to.
   # The v1 in the name allows use to change this if there is a modification needed that is not in the yaml
   name: presync-cpd-olm-job-v4-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
-  namespace: {{ .Values.cpd_instance_namespace }}
+  namespace: mas-{{ .Values.instance_id }}-syncres
   annotations:
     argocd.argoproj.io/sync-wave: "003"
 {{- if .Values.custom_labels }}
@@ -430,3 +414,5 @@ spec:
             defaultMode: 420
             optional: false
   backoffLimit: 4
+
+{{- end }}

--- a/root-applications/ibm-mas-instance-root/templates/010-ibm-sync-jobs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/010-ibm-sync-jobs.yaml
@@ -45,6 +45,9 @@ spec:
             sm_aws_access_key_id: "{{ .Values.sm.aws_access_key_id }}"
             sm_aws_secret_access_key: "{{ .Values.sm.aws_secret_access_key }}"
             sm_aws_region: "{{ .Values.region.id }}"
+            {{- if not (empty .Values.ibm_cp4d) }}
+            cpd_product_version: "{{ .Values.ibm_cp4d.cpd_product_version }}"
+            {{- end }}
             {{- if not (empty .Values.ibm_sls) }}
             {{- if eq .Values.ibm_sls.mongodb_provider "aws" }}
             docdb:

--- a/root-applications/ibm-mas-instance-root/templates/110-ibm-cp4d-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/110-ibm-cp4d-app.yaml
@@ -47,11 +47,6 @@ spec:
         - name: {{ .Values.avp.values_varname }}
           value: |
             argo_namespace: "{{ .Values.argo.namespace }}"
-            account_id: "{{ .Values.account.id }}"
-            region_id: "{{ .Values.region.id }}"
-            cluster_id: "{{ .Values.cluster.id }}"
-            sm_aws_access_key_id: "{{ .Values.sm.aws_access_key_id }}"
-            sm_aws_secret_access_key: "{{ .Values.sm.aws_secret_access_key }}"
             instance_id: "{{ .Values.instance.id }}"
             ibm_entitlement_key: "{{ .Values.ibm_cp4d.ibm_entitlement_key }}"
             cpd_operators_namespace: "{{ .Values.ibm_cp4d.cpd_operators_namespace }}"


### PR DESCRIPTION
Pipeline is breaking because the presync job that puts the values in secret manager has not run before cp4d so moving the job back to the sync-job app. 

Tested in fvtsaas, and CP4D gets installed with this change.