### PR TITLE
[patch] fix junit reporter scope

### DIFF
--- a/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-configs-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-configs-app.yaml
@@ -55,7 +55,7 @@ spec:
             {{- end }}
             {{ $value | toYaml | nindent 12 }}
             junitreporter:
-              reporter_name: "{{ $value.mas_config_chart }}-{{ $.Values.instance.id }}"
+              reporter_name: "{{ $value.mas_config_chart }}-{{ $value.mas_config_scope }}-{{ $.Values.instance.id }}"
               cluster_id: "{{ $.Values.cluster.id }}"
               devops_mongo_uri: "{{ $.Values.devops.mongo_uri }}"
               devops_build_number: "{{ $.Values.devops.build_number }}"


### PR DESCRIPTION
Fixes an issue where the junit reporter name was being overused when two of the same configs are being created at the same time but at different scopes i.e. jdbc config at system and wsapp scope. The fixe is to add the scope to the reportername which gets used to create the resources.