### PR TITLE
[minor] Generic add-on for non-shared clusters

### DIFF
--- a/instance-applications/130-ibm-mas-suite/templates/07-non-shared-cluster-addon.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/07-non-shared-cluster-addon.yaml
@@ -1,0 +1,21 @@
+---
+{{- if (eq .Values.non_shared_cluster_addon_enabled "true") }}
+apiVersion: addons.mas.ibm.com/v1
+kind: GenericAddon
+metadata:
+  name: "{{ .Values.instance_id }}-addons-non-shared-cluster"
+  annotations:
+    argocd.argoproj.io/sync-wave: "134" # CRD is in ibm-mas operator
+  labels:
+    mas.ibm.com/configScope: system # correct ???
+    mas.ibm.com/instanceId: {{ .Values.instance_id }}
+{{- if .Values.custom_labels }}
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+spec:
+  displayName: Non-Shared Cluster
+  addonType: non-shared-cluster
+  config:
+    instances:
+      - name: {{ MAS Application ID }} # TODO what goes here?
+{{- end }}

--- a/instance-applications/130-ibm-mas-suite/values.yaml
+++ b/instance-applications/130-ibm-mas-suite/values.yaml
@@ -1,3 +1,4 @@
 ---
 instance_id: xxx
 ibm_entitlement_key: xxxx
+non_shared_cluster_addon_enabled: "false"

--- a/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-app.yaml
@@ -42,6 +42,7 @@ spec:
             region_id: "{{ .Values.region.id }}"
             cluster_id: "{{ .Values.cluster.id }}"
             instance_id: "{{ .Values.instance.id }}"
+            non_shared_cluster_addon_enabled: "{{ .Values.cluster.is_non_shared_cluster }}"
             sm_aws_access_key_id: "{{ .Values.sm.aws_access_key_id }}"
             sm_aws_secret_access_key: "{{ .Values.sm.aws_secret_access_key }}"
             sm_aws_region: "{{ .Values.region.id }}"


### PR DESCRIPTION
MASCORE-5932

## Description
* Installs a CR of kind `GenericAddon` for the "non-shared cluster add-on" if the cluster is flagged as being non-shared. The CRD is within the `ibm-mas` operator so the CR lives within the `ibm-mas-suite` app.
* Although the "non-shared cluster add-on" is associated with a specific MAS instance, the property `is_non_shared_cluster` should be defined under cluster config as shown below. This facilitates future automation improvements whereby deployments to clusters with this flag set to "true" can be blocked if they already contain an instance.
```
cluster:
   is_non_shared_cluster: "true"
```