### PR TITLE
[minor] Add ignore for ManageWorkspace CR spec mode option

### DIFF
--- a/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
@@ -147,8 +147,8 @@ spec:
     kind: ServiceAccount
     jsonPointers:
       - /imagePullSecrets
-  - group: 'marketplace.redhat.com/v1alpha1'
-    kind: MarketplaceConfig
+  - group: 'apps.mas.ibm.com/v1'
+    kind: ManageWorkspace
     jsonPointers:
-      - /spec
+    - /spec/settings/deployment/mode 
 {{- end }}

--- a/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
@@ -147,7 +147,7 @@ spec:
     kind: ServiceAccount
     jsonPointers:
       - /imagePullSecrets
-  - group: 'apps.mas.ibm.com/v1'
+  - group: 'apps.mas.ibm.com'
     kind: ManageWorkspace
     jsonPointers:
     - /spec/settings/deployment/mode 


### PR DESCRIPTION
Adds an ignore in Argo for the ManageWorkspace CR specs `mode` option that is part of the `deployment`. This allows the CR to be updated on the cluster so that the `mode` can be toggled between `up` and `down` without having to go via gitops and wait for Argo and the pipelines to pass through this change.

This mode is a state variable rather than a configuration variable and so we shouldn't keep state in gitops. This is the only change that will be allowed. If any other change is made to the CR then it will be reverted by Argo.

Tested in development env:


First with no mode at all in gitops:
![image- 2025-03-27 at 15 03 51@2x](https://github.com/user-attachments/assets/c8e26d24-c11d-4787-998a-4cf7da2b5020)

Then with a mode present in gitops that is different to the live manifest:
![image- 2025-03-27 at 16 07 00@2x](https://github.com/user-attachments/assets/03de589f-8fa2-4400-beb8-292d7c26265c)

In both cases there is no diff from argo, and argo keeps the live manifest as it is:
![image- 2025-03-27 at 16 07 07@2x](https://github.com/user-attachments/assets/19333b2c-0075-49d2-9126-e3cd1c282be4)

![image- 2025-03-27 at 16 06 45@2x](https://github.com/user-attachments/assets/647e7a65-87ff-45f6-a4a6-1f5fd0c7e2c5)
