### PR TITLE
HADR setup bug fixes

### DIFF
--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -82,7 +82,7 @@ kind: Job
 metadata:
   # Suffix the Job name with a hash of all chart values
   # This is to ensure that ArgoCD will delete and recreate the job if (and only if) anything changes in the DB2 config
-  name: postsync-setup-hadr-{{ .Values.db2_instance_name }}-v1-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
+  name: postsync-setup-hadr-{{ .Values.db2_instance_name }}-v2-{{ omit .Values "junitreporter" | toYaml | adler32sum }}
   namespace: "{{ .Values.db2_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "130"
@@ -278,7 +278,7 @@ spec:
 
                 echo ""
                 echo "Copying keystore from primary to standby"
-                label=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 -x \"select MASTER_KEY_LABEL from TABLE(SYSPROC.ADMIN_GET_ENCRYPTION_INFO()) where OBJECT_NAME=${DB2_DBNAME} and OBJECT_TYPE='DATABASE'\"" db2inst1`
+                label=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 connect to ${DB2_DBNAME}; db2 -x \"select MASTER_KEY_LABEL from TABLE(SYSPROC.ADMIN_GET_ENCRYPTION_INFO()) where OBJECT_NAME='${DB2_DBNAME}' and OBJECT_TYPE='DATABASE'\"" db2inst1`
                 oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "gsk8capicmd_64 -cert -export -db /mnt/blumeta0/db2/keystore/keystore.p12  -stashed -label ${label} -target /mnt/blumeta0/home/db2inst1/migrate_hadr.p12 -target_pw 'CDS0n&Up'" db2inst1 || exit $?
                 oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "mkdir /tmp/keystore; cp /mnt/blumeta0/home/db2inst1/migrate_hadr.p12 /tmp/keystore; chmod -R 777 /tmp/keystore" db2inst1 || exit $?
                 oc rsync ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0:/tmp/keystore /tmp

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -182,23 +182,23 @@ spec:
                 RETRIES=${3:-5}
                 RETRY_DELAY_SECONDS=${4:-30}
 
-                mas-devops-db2-validate-config --mas-instance-id ${MAS_INSTANCE_ID} --mas-app-id ${MAS_APP_ID} --database-role standby --log-level DEBUG || rc1=$?
-                echo "rc1 - $rc1"
-                if [[ "$rc1" == "0" && $PRIMARY_ROLE == 'PRIMARY' && $STANDBY_ROLE == 'STANDBY' ]]; then
+                mas-devops-db2-validate-config --mas-instance-id ${MAS_INSTANCE_ID} --mas-app-id ${MAS_APP_ID} --database-role standby --log-level DEBUG || rc=$?
+                echo "rc1 - $rc"
+                if [[ "$rc" == "0" && $PRIMARY_ROLE == 'PRIMARY' && $STANDBY_ROLE == 'STANDBY' ]]; then
                   echo "... db2 config already matches expected config, returning without calling apply-db2cfg-settings"
                   return 0
                 fi
 
-                if [[ "$rc1" != "0" ]]; then
+                if [[ "$rc" != "0" ]]; then
                   for (( c=1; c<="${RETRIES}"; c++ )); do
                     echo ""
                     echo "... attempt ${c} of ${RETRIES}"
                     oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc '/db2u/scripts/apply-db2cfg-settings.sh --setting all | tee /tmp/apply-db2cfg-settings.log' db2inst1
                     # no useful info in return code of this script
 
-                    rc2=0
-                    mas-devops-db2-validate-config --mas-instance-id ${MAS_INSTANCE_ID} --mas-app-id ${MAS_APP_ID} --database-role standby --log-level DEBUG || rc2=$?
-                    if [[ "$rc2" == "0" ]]; then
+                    rc=0
+                    mas-devops-db2-validate-config --mas-instance-id ${MAS_INSTANCE_ID} --mas-app-id ${MAS_APP_ID} --database-role standby --log-level DEBUG || rc=$?
+                    if [[ "$rc" == "0" ]]; then
                       echo "...... configs applied successfully"
                       return 1
                       restart_hadr
@@ -206,7 +206,7 @@ spec:
                     fi
 
                     if [[ "${c}" -lt "${RETRIES}" ]]; then
-                      echo "...... failed (rc: ${rc2}), retry in ${RETRY_DELAY_SECONDS}s"
+                      echo "...... failed (rc: ${rc}), retry in ${RETRY_DELAY_SECONDS}s"
                       sleep $RETRY_DELAY_SECONDS
                     fi
                   done

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -199,6 +199,7 @@ spec:
                     mas-devops-db2-validate-config --mas-instance-id ${MAS_INSTANCE_ID} --mas-app-id ${MAS_APP_ID} --database-role standby --log-level DEBUG || rc2=$?
                     if [[ "$rc2" == "0" ]]; then
                       echo "...... configs applied successfully"
+                      return 1
                       restart_hadr
                       return 0
                     fi
@@ -282,9 +283,13 @@ spec:
 
                 cat > ${KEYSTORE_GENERATION_SCRIPT} << EOF
                   #!/bin/bash
-                  LABEL_SQL="/tmp/.label.log"
                   db2 connect to ${DB2_DBNAME};
-                  db2 -x "select MASTER_KEY_LABEL from TABLE(SYSPROC.ADMIN_GET_ENCRYPTION_INFO()) where OBJECT_NAME='${DB2_DBNAME}' and OBJECT_TYPE='DATABASE'" >\$LABEL_SQL
+                  if [ \$? != 0 ]; then
+                    echo "Failed to connect to database!"
+                    exit 1
+                  fi
+                  label=$(db2 -x "select MASTER_KEY_LABEL from TABLE(SYSPROC.ADMIN_GET_ENCRYPTION_INFO()) where OBJECT_NAME='${DB2_DBNAME}' and OBJECT_TYPE='DATABASE'")
+                  gsk8capicmd_64 -cert -export -db /mnt/blumeta0/db2/keystore/keystore.p12  -stashed -label ${label} -target /mnt/blumeta0/home/db2inst1/migrate_hadr.p12 -target_pw 'CDS0n&Up'
 
               EOF
 
@@ -299,9 +304,9 @@ spec:
                 echo "--------------------------------------------------------------------------------"
                 oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "${KEYSTORE_GENERATION_SCRIPT} | tee /tmp/keystoregeneration.log" db2inst1 || exit $?
                 # label=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 connect to ${DB2_DBNAME}; db2 -x \"select MASTER_KEY_LABEL from TABLE(SYSPROC.ADMIN_GET_ENCRYPTION_INFO()) where OBJECT_NAME='${DB2_DBNAME}' and OBJECT_TYPE='DATABASE'\"" db2inst1`
-                label=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "cat /tmp/.label.log" db2inst1`
-                echo "Label is ${label}"
-                oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "gsk8capicmd_64 -cert -export -db /mnt/blumeta0/db2/keystore/keystore.p12  -stashed -label ${label} -target /mnt/blumeta0/home/db2inst1/migrate_hadr.p12 -target_pw 'CDS0n&Up'" db2inst1 || exit $?
+                # label=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "cat /tmp/.label.log" db2inst1`
+                # echo "Label is ${label}"
+                # oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "gsk8capicmd_64 -cert -export -db /mnt/blumeta0/db2/keystore/keystore.p12  -stashed -label ${label} -target /mnt/blumeta0/home/db2inst1/migrate_hadr.p12 -target_pw 'CDS0n&Up'" db2inst1 || exit $?
                 oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "mkdir -p /tmp/keystore; cp /mnt/blumeta0/home/db2inst1/migrate_hadr.p12 /tmp/keystore; chmod -R 777 /tmp/keystore" db2inst1 || exit $?
                 oc rsync ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0:/tmp/keystore /tmp
                 oc rsync /tmp/keystore ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/tmp

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -183,6 +183,7 @@ spec:
                 RETRY_DELAY_SECONDS=${4:-30}
 
                 mas-devops-db2-validate-config --mas-instance-id ${MAS_INSTANCE_ID} --mas-app-id ${MAS_APP_ID} --database-role standby --log-level DEBUG || rc1=$?
+                echo "rc1 - $rc1"
                 if [[ "$rc1" == "0" && $PRIMARY_ROLE == 'PRIMARY' && $STANDBY_ROLE == 'STANDBY' ]]; then
                   echo "... db2 config already matches expected config, returning without calling apply-db2cfg-settings"
                   return 0

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -277,7 +277,7 @@ spec:
 
                 echo ""
                 echo "Copying keystore from primary to standby"
-                label=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 -x "select MASTER_KEY_LABEL from TABLE(SYSPROC.ADMIN_GET_ENCRYPTION_INFO()) where OBJECT_NAME=${DB2_DBNAME} and OBJECT_TYPE='DATABASE'"" db2inst1`
+                label=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 -x \"select MASTER_KEY_LABEL from TABLE(SYSPROC.ADMIN_GET_ENCRYPTION_INFO()) where OBJECT_NAME=${DB2_DBNAME} and OBJECT_TYPE='DATABASE'\"" db2inst1`
                 oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "gsk8capicmd_64 -cert -export -db /mnt/blumeta0/db2/keystore/keystore.p12  -stashed -label ${label} -target /mnt/blumeta0/home/db2inst1/migrate_hadr.p12 -target_pw 'CDS0n&Up'" db2inst1 || exit $?
                 oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "mkdir /tmp/keystore; cp /mnt/blumeta0/home/db2inst1/migrate_hadr.p12 /tmp/keystore; chmod -R 777 /tmp/keystore" db2inst1 || exit $?
                 oc rsync ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0:/tmp/keystore /tmp

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -288,7 +288,7 @@ spec:
                     echo "Failed to connect to database!"
                     exit 1
                   fi
-                  label=$(db2 -x "select MASTER_KEY_LABEL from TABLE(SYSPROC.ADMIN_GET_ENCRYPTION_INFO()) where OBJECT_NAME='${DB2_DBNAME}' and OBJECT_TYPE='DATABASE'")
+                  label=\$(db2 -x "select MASTER_KEY_LABEL from TABLE(SYSPROC.ADMIN_GET_ENCRYPTION_INFO()) where OBJECT_NAME='${DB2_DBNAME}' and OBJECT_TYPE='DATABASE'")
                   gsk8capicmd_64 -cert -export -db /mnt/blumeta0/db2/keystore/keystore.p12  -stashed -label ${label} -target /mnt/blumeta0/home/db2inst1/migrate_hadr.p12 -target_pw 'CDS0n&Up'
 
               EOF

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -159,47 +159,58 @@ spec:
                 return 1
               }
 
-              function db2apply {
-                RETRIES=${1:-5}
-                RETRY_DELAY_SECONDS=${2:-30}
+              function restart_hadr {
+                # # Start hadr in standby
+                echo ""
+                echo "Starting HADR in standby"
+                echo "--------------------------------------------------------------------------------"
+                oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2stop force; db2start; db2 start hadr on db bludb as standby" db2inst1 || exit $?
 
-                mas-devops-db2-validate-config --mas-instance-id ${MAS_INSTANCE_ID} --mas-app-id ${MAS_APP_ID} --database-role standby --log-level DEBUG || rc=$?
-                if [[ "$rc" == "0" ]]; then
+                # # Start hadr in Primary
+                echo ""
+                echo "Starting HADR in primary"
+                echo "--------------------------------------------------------------------------------"
+                oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2stop force; db2start; db2 start hadr on db bludb as primary" db2inst1 || exit $?
+
+                echo "...... HADR services are started successfully""
+              }
+
+              function db2apply() {
+                PRIMARY_ROLE=${1}
+                STANDBY_ROLE=${2}
+                RETRIES=${3:-5}
+                RETRY_DELAY_SECONDS=${4:-30}
+
+                mas-devops-db2-validate-config --mas-instance-id ${MAS_INSTANCE_ID} --mas-app-id ${MAS_APP_ID} --database-role standby --log-level DEBUG || rc1=$?
+                if [[ "$rc1" == "0" && $PRIMARY_ROLE == 'PRIMARY' && $STANDBY_ROLE == 'STANDBY' ]]; then
                   echo "... db2 config already matches expected config, returning without calling apply-db2cfg-settings"
                   return 0
                 fi
 
-                for (( c=1; c<="${RETRIES}"; c++ )); do
-                  echo ""
-                  echo "... attempt ${c} of ${RETRIES}"
-                  oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc '/db2u/scripts/apply-db2cfg-settings.sh --setting all | tee /tmp/apply-db2cfg-settings.log' db2inst1
-                  # no useful info in return code of this script
-
-                  rc=0
-                  mas-devops-db2-validate-config --mas-instance-id ${MAS_INSTANCE_ID} --mas-app-id ${MAS_APP_ID} --database-role standby --log-level DEBUG || rc=$?
-                  if [[ "$rc" == "0" ]]; then
-                    echo "...... success"
-
-                    # # Start hadr in standby
+                if [[ "$rc1" != "0" ]]; then
+                  for (( c=1; c<="${RETRIES}"; c++ )); do
                     echo ""
-                    echo "Starting HADR in standby"
-                    echo "--------------------------------------------------------------------------------"
-                    oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2stop force; db2start; db2 start hadr on db bludb as standby" db2inst1 || exit $?
+                    echo "... attempt ${c} of ${RETRIES}"
+                    oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc '/db2u/scripts/apply-db2cfg-settings.sh --setting all | tee /tmp/apply-db2cfg-settings.log' db2inst1
+                    # no useful info in return code of this script
 
-                    # # Start hadr in Primary
-                    echo ""
-                    echo "Starting HADR in primary"
-                    echo "--------------------------------------------------------------------------------"
-                    oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2stop force; db2start; db2 start hadr on db bludb as primary" db2inst1 || exit $?
+                    rc2=0
+                    mas-devops-db2-validate-config --mas-instance-id ${MAS_INSTANCE_ID} --mas-app-id ${MAS_APP_ID} --database-role standby --log-level DEBUG || rc2=$?
+                    if [[ "$rc2" == "0" ]]; then
+                      echo "...... configs applied successfully"
+                      restart_hadr
+                      return 0
+                    fi
 
-                    return 0
-                  fi
-
-                  if [[ "${c}" -lt "${RETRIES}" ]]; then
-                    echo "...... failed (rc: ${rc}), retry in ${RETRY_DELAY_SECONDS}s"
-                    sleep $RETRY_DELAY_SECONDS
-                  fi
-                done
+                    if [[ "${c}" -lt "${RETRIES}" ]]; then
+                      echo "...... failed (rc: ${rc2}), retry in ${RETRY_DELAY_SECONDS}s"
+                      sleep $RETRY_DELAY_SECONDS
+                    fi
+                  done
+                else
+                  restart_hadr
+                  return 0
+                fi
 
                 echo "...... failed, no attempts remain"
                 return 1
@@ -266,10 +277,15 @@ spec:
 
                 echo ""
                 echo "Copying keystore from primary to standby"
-                oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "mkdir /tmp/keystore; cp /mnt/blumeta0/db2/keystore/* /tmp/keystore; chmod -R 777 /tmp/keystore" db2inst1 || exit $?
+                label=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 -x "select MASTER_KEY_LABEL from TABLE(SYSPROC.ADMIN_GET_ENCRYPTION_INFO()) where OBJECT_NAME=${DB2_DBNAME} and OBJECT_TYPE='DATABASE'"" db2inst1`
+                oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "gsk8capicmd_64 -cert -export -db /mnt/blumeta0/db2/keystore/keystore.p12  -stashed -label ${label} -target /mnt/blumeta0/home/db2inst1/migrate_hadr.p12 -target_pw 'CDS0n&Up'" db2inst1 || exit $?
+                oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "mkdir /tmp/keystore; cp /mnt/blumeta0/home/db2inst1/migrate_hadr.p12 /tmp/keystore; chmod -R 777 /tmp/keystore" db2inst1 || exit $?
                 oc rsync ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0:/tmp/keystore /tmp
-                oc rsync /tmp/keystore ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/tmp
-                oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "mv /mnt/blumeta0/db2/keystore/keystore.p12 /mnt/blumeta0/db2/keystore/keystore.p12_orig; mv /mnt/blumeta0/db2/keystore/keystore.sth /mnt/blumeta0/db2/keystore/keystore.sth_orig; cp /tmp/keystore/keystore.* /mnt/blumeta0/db2/keystore/; chown db2inst1.db2iadm1 /mnt/blumeta0/db2/keystore/keystore.*; chmod 600 /mnt/blumeta0/db2/keystore/keystore.*;" db2inst1 || exit $?
+                oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "gsk8capicmd_64 -cert -import -db /tmp/keystore/migrate_hadr.p12 -pw 'CDS0n&Up' -target /mnt/blumeta0/db2/keystore/keystore.p12 -target_stashed" db2inst1 || exit $?
+                # oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "mkdir /tmp/keystore; cp /mnt/blumeta0/db2/keystore/* /tmp/keystore; chmod -R 777 /tmp/keystore" db2inst1 || exit $?
+                # oc rsync ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0:/tmp/keystore /tmp
+                # oc rsync /tmp/keystore ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/tmp
+                # oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "mv /mnt/blumeta0/db2/keystore/keystore.p12 /mnt/blumeta0/db2/keystore/keystore.p12_orig; mv /mnt/blumeta0/db2/keystore/keystore.sth /mnt/blumeta0/db2/keystore/keystore.sth_orig; cp /tmp/keystore/keystore.* /mnt/blumeta0/db2/keystore/; chown db2inst1.db2iadm1 /mnt/blumeta0/db2/keystore/keystore.*; chmod 600 /mnt/blumeta0/db2/keystore/keystore.*;" db2inst1 || exit $?
 
                 # Restore in standby
                 echo ""
@@ -284,6 +300,6 @@ spec:
               echo "================================================================================"
               echo "Calling apply-db2cfg-settings.sh file on c-${DB2_INSTANCE_NAME}-db2u-0"
               echo "================================================================================"
-              db2apply || exit $?
+              db2apply ${PRIMARY_ROLE} ${STANDBY_ROLE}  || exit $?
 
 {{ end }}

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -279,13 +279,15 @@ spec:
                 echo ""
                 echo "Copying keystore from primary to standby"
                 KEYSTORE_GENERATION_SCRIPT='/tmp/keystore_generation.sh'
+
                 cat > ${KEYSTORE_GENERATION_SCRIPT} << EOF
                   #!/bin/bash
-                  db2 connect to ${DB2_DBNAME}
-                  label=`db2 -x "select MASTER_KEY_LABEL from TABLE(SYSPROC.ADMIN_GET_ENCRYPTION_INFO()) where OBJECT_NAME='${DB2_DBNAME}' and OBJECT_TYPE='DATABASE'"`
-                  echo "Label is ${label}"
-                  gsk8capicmd_64 -cert -export -db /mnt/blumeta0/db2/keystore/keystore.p12  -stashed -label ${label} -target /mnt/blumeta0/home/db2inst1/migrate_hadr.p12 -target_pw 'CDS0n&Up'
-                EOF
+                  LABEL_SQL="/tmp/.label.log"
+                  db2 connect to ${DB2_DBNAME};
+                  db2 -x "select MASTER_KEY_LABEL from TABLE(SYSPROC.ADMIN_GET_ENCRYPTION_INFO()) where OBJECT_NAME='${DB2_DBNAME}' and OBJECT_TYPE='DATABASE'" >\$LABEL_SQL
+
+              EOF
+
                 chmod +x ${KEYSTORE_GENERATION_SCRIPT}
                 echo ""
                 echo "Copy ${KEYSTORE_GENERATION_SCRIPT} to ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0"
@@ -297,9 +299,12 @@ spec:
                 echo "--------------------------------------------------------------------------------"
                 oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "${KEYSTORE_GENERATION_SCRIPT} | tee /tmp/keystoregeneration.log" db2inst1 || exit $?
                 # label=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 connect to ${DB2_DBNAME}; db2 -x \"select MASTER_KEY_LABEL from TABLE(SYSPROC.ADMIN_GET_ENCRYPTION_INFO()) where OBJECT_NAME='${DB2_DBNAME}' and OBJECT_TYPE='DATABASE'\"" db2inst1`
-                # oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "gsk8capicmd_64 -cert -export -db /mnt/blumeta0/db2/keystore/keystore.p12  -stashed -label ${label} -target /mnt/blumeta0/home/db2inst1/migrate_hadr.p12 -target_pw 'CDS0n&Up'" db2inst1 || exit $?
-                oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "mkdir /tmp/keystore; cp /mnt/blumeta0/home/db2inst1/migrate_hadr.p12 /tmp/keystore; chmod -R 777 /tmp/keystore" db2inst1 || exit $?
+                label=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "cat /tmp/.label.log" db2inst1`
+                echo "Label is ${label}"
+                oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "gsk8capicmd_64 -cert -export -db /mnt/blumeta0/db2/keystore/keystore.p12  -stashed -label ${label} -target /mnt/blumeta0/home/db2inst1/migrate_hadr.p12 -target_pw 'CDS0n&Up'" db2inst1 || exit $?
+                oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "mkdir -p /tmp/keystore; cp /mnt/blumeta0/home/db2inst1/migrate_hadr.p12 /tmp/keystore; chmod -R 777 /tmp/keystore" db2inst1 || exit $?
                 oc rsync ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0:/tmp/keystore /tmp
+                oc rsync /tmp/keystore ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/tmp
                 oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "gsk8capicmd_64 -cert -import -db /tmp/keystore/migrate_hadr.p12 -pw 'CDS0n&Up' -target /mnt/blumeta0/db2/keystore/keystore.p12 -target_stashed" db2inst1 || exit $?
                 # oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "mkdir /tmp/keystore; cp /mnt/blumeta0/db2/keystore/* /tmp/keystore; chmod -R 777 /tmp/keystore" db2inst1 || exit $?
                 # oc rsync ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0:/tmp/keystore /tmp

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -259,7 +259,7 @@ spec:
               PRIMARY_ROLE=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 get db cfg for BLUDB | grep role | cut -d'=' -f2 | tr -d ' '" db2inst1`
               STANDBY_ROLE=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 get db cfg for BLUDB | grep role | cut -d'=' -f2 | tr -d ' '" db2inst1`
 
-              if [[ ! ($PRIMARY_ROLE == 'PRIMARY' && $STANDBY_ROLE == 'STANDBY') ]]; then
+              if [[  ($PRIMARY_ROLE == 'PRIMARY' && $STANDBY_ROLE == 'STANDBY') ]]; then
                 echo ""
                 echo "Taking backup on ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0"
                 echo "--------------------------------------------------------------------------------"

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -183,7 +183,6 @@ spec:
                 RETRY_DELAY_SECONDS=${4:-30}
 
                 mas-devops-db2-validate-config --mas-instance-id ${MAS_INSTANCE_ID} --mas-app-id ${MAS_APP_ID} --database-role standby --log-level DEBUG || rc=$?
-                echo "rc1 - $rc"
                 if [[ "$rc" == "0" && $PRIMARY_ROLE == 'PRIMARY' && $STANDBY_ROLE == 'STANDBY' ]]; then
                   echo "... db2 config already matches expected config, returning without calling apply-db2cfg-settings"
                   return 0
@@ -200,7 +199,6 @@ spec:
                     mas-devops-db2-validate-config --mas-instance-id ${MAS_INSTANCE_ID} --mas-app-id ${MAS_APP_ID} --database-role standby --log-level DEBUG || rc=$?
                     if [[ "$rc" == "0" ]]; then
                       echo "...... configs applied successfully"
-                      return 1
                       restart_hadr
                       return 0
                     fi
@@ -260,7 +258,7 @@ spec:
               PRIMARY_ROLE=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 get db cfg for BLUDB | grep role | cut -d'=' -f2 | tr -d ' '" db2inst1`
               STANDBY_ROLE=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 get db cfg for BLUDB | grep role | cut -d'=' -f2 | tr -d ' '" db2inst1`
 
-              if [[  ($PRIMARY_ROLE == 'PRIMARY' && $STANDBY_ROLE == 'STANDBY') ]]; then
+              if [[ ! ($PRIMARY_ROLE == 'PRIMARY' && $STANDBY_ROLE == 'STANDBY') ]]; then
                 echo ""
                 echo "Taking backup on ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0"
                 echo "--------------------------------------------------------------------------------"
@@ -304,18 +302,10 @@ spec:
                 echo "Executing ${KEYSTORE_GENERATION_SCRIPT} file on ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0"
                 echo "--------------------------------------------------------------------------------"
                 oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "${KEYSTORE_GENERATION_SCRIPT} | tee /tmp/keystoregeneration.log" db2inst1 || exit $?
-                # label=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 connect to ${DB2_DBNAME}; db2 -x \"select MASTER_KEY_LABEL from TABLE(SYSPROC.ADMIN_GET_ENCRYPTION_INFO()) where OBJECT_NAME='${DB2_DBNAME}' and OBJECT_TYPE='DATABASE'\"" db2inst1`
-                # label=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "cat /tmp/.label.log" db2inst1`
-                # echo "Label is ${label}"
-                # oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "gsk8capicmd_64 -cert -export -db /mnt/blumeta0/db2/keystore/keystore.p12  -stashed -label ${label} -target /mnt/blumeta0/home/db2inst1/migrate_hadr.p12 -target_pw 'CDS0n&Up'" db2inst1 || exit $?
                 oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "mkdir -p /tmp/keystore; cp /mnt/blumeta0/home/db2inst1/migrate_hadr.p12 /tmp/keystore; chmod -R 777 /tmp/keystore" db2inst1 || exit $?
                 oc rsync ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0:/tmp/keystore /tmp
                 oc rsync /tmp/keystore ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/tmp
                 oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "gsk8capicmd_64 -cert -import -db /tmp/keystore/migrate_hadr.p12 -pw 'CDS0n&Up' -target /mnt/blumeta0/db2/keystore/keystore.p12 -target_stashed" db2inst1 || exit $?
-                # oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "mkdir /tmp/keystore; cp /mnt/blumeta0/db2/keystore/* /tmp/keystore; chmod -R 777 /tmp/keystore" db2inst1 || exit $?
-                # oc rsync ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0:/tmp/keystore /tmp
-                # oc rsync /tmp/keystore ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/tmp
-                # oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "mv /mnt/blumeta0/db2/keystore/keystore.p12 /mnt/blumeta0/db2/keystore/keystore.p12_orig; mv /mnt/blumeta0/db2/keystore/keystore.sth /mnt/blumeta0/db2/keystore/keystore.sth_orig; cp /tmp/keystore/keystore.* /mnt/blumeta0/db2/keystore/; chown db2inst1.db2iadm1 /mnt/blumeta0/db2/keystore/keystore.*; chmod 600 /mnt/blumeta0/db2/keystore/keystore.*;" db2inst1 || exit $?
 
                 # Restore in standby
                 echo ""

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -160,6 +160,7 @@ spec:
               }
 
               function restart_hadr {
+                PRIMARY_DB2_INSTANCE_NAME=${DB2_INSTANCE_NAME:0:-4}
                 # # Start hadr in standby
                 echo ""
                 echo "Starting HADR in standby"
@@ -172,12 +173,12 @@ spec:
                 echo "--------------------------------------------------------------------------------"
                 oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2stop force; db2start; db2 start hadr on db bludb as primary" db2inst1 || exit $?
 
-                echo "...... HADR services are started successfully""
+                echo "...... HADR services are started successfully"
               }
 
               function db2apply() {
-                PRIMARY_ROLE=${1}
-                STANDBY_ROLE=${2}
+                PRIMARY_ROLE="$1"
+                STANDBY_ROLE="$2"
                 RETRIES=${3:-5}
                 RETRY_DELAY_SECONDS=${4:-30}
 

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -278,8 +278,26 @@ spec:
 
                 echo ""
                 echo "Copying keystore from primary to standby"
-                label=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 connect to ${DB2_DBNAME}; db2 -x \"select MASTER_KEY_LABEL from TABLE(SYSPROC.ADMIN_GET_ENCRYPTION_INFO()) where OBJECT_NAME='${DB2_DBNAME}' and OBJECT_TYPE='DATABASE'\"" db2inst1`
-                oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "gsk8capicmd_64 -cert -export -db /mnt/blumeta0/db2/keystore/keystore.p12  -stashed -label ${label} -target /mnt/blumeta0/home/db2inst1/migrate_hadr.p12 -target_pw 'CDS0n&Up'" db2inst1 || exit $?
+                KEYSTORE_GENERATION_SCRIPT='/tmp/keystore_generation.sh'
+                cat > ${KEYSTORE_GENERATION_SCRIPT} << EOF
+                  #!/bin/bash
+                  db2 connect to ${DB2_DBNAME}
+                  label=`db2 -x "select MASTER_KEY_LABEL from TABLE(SYSPROC.ADMIN_GET_ENCRYPTION_INFO()) where OBJECT_NAME='${DB2_DBNAME}' and OBJECT_TYPE='DATABASE'"`
+                  echo "Label is ${label}"
+                  gsk8capicmd_64 -cert -export -db /mnt/blumeta0/db2/keystore/keystore.p12  -stashed -label ${label} -target /mnt/blumeta0/home/db2inst1/migrate_hadr.p12 -target_pw 'CDS0n&Up'
+                EOF
+                chmod +x ${KEYSTORE_GENERATION_SCRIPT}
+                echo ""
+                echo "Copy ${KEYSTORE_GENERATION_SCRIPT} to ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0"
+                echo "--------------------------------------------------------------------------------"
+                oc cp ${KEYSTORE_GENERATION_SCRIPT} ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0:${KEYSTORE_GENERATION_SCRIPT} -c db2u || exit $?
+
+                echo ""
+                echo "Executing ${KEYSTORE_GENERATION_SCRIPT} file on ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0"
+                echo "--------------------------------------------------------------------------------"
+                oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "${KEYSTORE_GENERATION_SCRIPT} | tee /tmp/keystoregeneration.log" db2inst1 || exit $?
+                # label=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 connect to ${DB2_DBNAME}; db2 -x \"select MASTER_KEY_LABEL from TABLE(SYSPROC.ADMIN_GET_ENCRYPTION_INFO()) where OBJECT_NAME='${DB2_DBNAME}' and OBJECT_TYPE='DATABASE'\"" db2inst1`
+                # oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "gsk8capicmd_64 -cert -export -db /mnt/blumeta0/db2/keystore/keystore.p12  -stashed -label ${label} -target /mnt/blumeta0/home/db2inst1/migrate_hadr.p12 -target_pw 'CDS0n&Up'" db2inst1 || exit $?
                 oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "mkdir /tmp/keystore; cp /mnt/blumeta0/home/db2inst1/migrate_hadr.p12 /tmp/keystore; chmod -R 777 /tmp/keystore" db2inst1 || exit $?
                 oc rsync ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0:/tmp/keystore /tmp
                 oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "gsk8capicmd_64 -cert -import -db /tmp/keystore/migrate_hadr.p12 -pw 'CDS0n&Up' -target /mnt/blumeta0/db2/keystore/keystore.p12 -target_stashed" db2inst1 || exit $?


### PR DESCRIPTION
Issue: [MASCORE-6234](https://jsw.ibm.com/browse/MASCORE-6234)

## Description
1. Problem: Currently if the hadr job fails due to some temporary issue after the configurations are applied, the next job execution compares the config and doesn't start the HADR service on primary and standby. 
   Solution: We restart hadr services if roles are not set to primary and standby
2. Problem: There was one occurrence of master key label not available in the keystore file from primary. Current approach was to overwrite the standby keystore with the one from primary. 
    Solution: Exporting the keystore using gsk8capicmd_64 command in primary and importing the keystore in standby will avoid this issue