### PR TITLE
[patch] Set instance_id in junit reporter for gitops

### DIFF
--- a/root-applications/ibm-mas-cluster-root/templates/099-instance-appset.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/099-instance-appset.yaml
@@ -197,10 +197,6 @@ spec:
                 value: "{{ .Values.avp.values_varname }}"
               - name: auto_delete
                 value: "{{ .Values.auto_delete }}"
-              - name: devops.mongo_uri
-                value: "{{ .Values.devops.mongo_uri }}"
-              - name: devops.build_number
-                value: "{{ .Values.devops.build_number }}"
       destination:
         server: 'https://kubernetes.default.svc'
         namespace: {{ .Values.argo.namespace }}

--- a/root-applications/ibm-mas-cluster-root/templates/099-instance-appset.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/099-instance-appset.yaml
@@ -197,6 +197,8 @@ spec:
                 value: "{{ .Values.avp.values_varname }}"
               - name: auto_delete
                 value: "{{ .Values.auto_delete }}"
+              - name: devops.mongo_uri
+                value: "{{ .Values.devops.mongo_uri }}"
       destination:
         server: 'https://kubernetes.default.svc'
         namespace: {{ .Values.argo.namespace }}

--- a/root-applications/ibm-mas-cluster-root/templates/099-instance-appset.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/099-instance-appset.yaml
@@ -199,6 +199,8 @@ spec:
                 value: "{{ .Values.auto_delete }}"
               - name: devops.mongo_uri
                 value: "{{ .Values.devops.mongo_uri }}"
+              - name: devops.build_number
+                value: "{{ .Values.devops.build_number }}"
       destination:
         server: 'https://kubernetes.default.svc'
         namespace: {{ .Values.argo.namespace }}

--- a/root-applications/ibm-mas-instance-root/templates/000-ibm-sync-resources.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/000-ibm-sync-resources.yaml
@@ -86,6 +86,7 @@ spec:
             junitreporter:
               reporter_name: "ibm-sync-resources-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
+              instance_id: "{{ .Values.instance.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"
               gitops_version: "{{ .Values.source.revision }}"

--- a/root-applications/ibm-mas-instance-root/templates/010-ibm-sync-jobs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/010-ibm-sync-jobs.yaml
@@ -93,6 +93,7 @@ spec:
             junitreporter:
               reporter_name: "ibm-sync-jobs-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
+              instance_id: "{{ .Values.instance.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"
               gitops_version: "{{ .Values.source.revision }}"

--- a/root-applications/ibm-mas-instance-root/templates/100-ibm-sls-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/100-ibm-sls-app.yaml
@@ -61,6 +61,7 @@ spec:
             junitreporter:
               reporter_name: "ibm-sls-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
+              instance_id: "{{ .Values.instance.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"
               gitops_version: "{{ .Values.source.revision }}"

--- a/root-applications/ibm-mas-instance-root/templates/110-ibm-cp4d-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/110-ibm-cp4d-app.yaml
@@ -99,6 +99,7 @@ spec:
             junitreporter:
               reporter_name: "ibm-cp4d-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
+              instance_id: "{{ .Values.instance.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"
               gitops_version: "{{ .Values.source.revision }}"

--- a/root-applications/ibm-mas-instance-root/templates/110-ibm-cp4d-operator-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/110-ibm-cp4d-operator-app.yaml
@@ -91,6 +91,7 @@ spec:
             junitreporter:
               reporter_name: "ibm-cp4d-operator-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
+              instance_id: "{{ .Values.instance.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"
               gitops_version: "{{ .Values.source.revision }}"

--- a/root-applications/ibm-mas-instance-root/templates/110-ibm-cs-control-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/110-ibm-cs-control-app.yaml
@@ -90,6 +90,7 @@ spec:
             junitreporter:
               reporter_name: "ibm-cs-control-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
+              instance_id: "{{ .Values.instance.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"
               gitops_version: "{{ .Values.source.revision }}"

--- a/root-applications/ibm-mas-instance-root/templates/110-ibm-db2u-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/110-ibm-db2u-app.yaml
@@ -45,6 +45,7 @@ spec:
             junitreporter:
               reporter_name: "ibm-db2u-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
+              instance_id: "{{ .Values.instance.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"
               gitops_version: "{{ .Values.source.revision }}"

--- a/root-applications/ibm-mas-instance-root/templates/120-db2-databases-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-db2-databases-app.yaml
@@ -54,6 +54,7 @@ spec:
             junitreporter:
               reporter_name: db2-db-{{ $.Values.instance.id }}-{{ $value.db2_instance_name | replace (cat "db2wh-" $.Values.instance.id "-" | replace " " "") "" }}
               cluster_id: "{{ $.Values.cluster.id }}"
+              instance_id: "{{ $.Values.instance.id }}"
               devops_mongo_uri: "{{ $.Values.devops.mongo_uri }}"
               devops_build_number: "{{ $.Values.devops.build_number }}"
               gitops_version: "{{ $.Values.source.revision }}"

--- a/root-applications/ibm-mas-instance-root/templates/120-ibm-spark-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-ibm-spark-app.yaml
@@ -54,6 +54,7 @@ spec:
             junitreporter:
               reporter_name: "ibm-spark-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
+              instance_id: "{{ .Values.instance.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"
               gitops_version: "{{ .Values.source.revision }}"

--- a/root-applications/ibm-mas-instance-root/templates/120-ibm-spss-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-ibm-spss-app.yaml
@@ -57,6 +57,7 @@ spec:
             junitreporter:
               reporter_name: "ibm-spss-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
+              instance_id: "{{ .Values.instance.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"
               gitops_version: "{{ .Values.source.revision }}"

--- a/root-applications/ibm-mas-instance-root/templates/120-ibm-wml-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-ibm-wml-app.yaml
@@ -54,6 +54,7 @@ spec:
             junitreporter:
               reporter_name: "ibm-wml-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
+              instance_id: "{{ .Values.instance.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"
               gitops_version: "{{ .Values.source.revision }}"

--- a/root-applications/ibm-mas-instance-root/templates/120-ibm-wsl-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-ibm-wsl-app.yaml
@@ -57,6 +57,7 @@ spec:
             junitreporter:
               reporter_name: "ibm-wsl-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
+              instance_id: "{{ .Values.instance.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"
               gitops_version: "{{ .Values.source.revision }}"

--- a/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-app.yaml
@@ -115,6 +115,7 @@ spec:
             junitreporter:
               reporter_name: "ibm-mas-suite-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
+              instance_id: "{{ .Values.instance.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"
               gitops_version: "{{ .Values.source.revision }}"

--- a/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-configs-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-configs-app.yaml
@@ -57,6 +57,7 @@ spec:
             junitreporter:
               reporter_name: "{{ $value.mas_config_chart }}-{{ $value.mas_config_scope }}-{{ $.Values.instance.id }}"
               cluster_id: "{{ $.Values.cluster.id }}"
+              instance_id: "{{ $.Values.instance.id }}"
               devops_mongo_uri: "{{ $.Values.devops.mongo_uri }}"
               devops_build_number: "{{ $.Values.devops.build_number }}"
               gitops_version: "{{ $.Values.source.revision }}"

--- a/root-applications/ibm-mas-instance-root/templates/200-ibm-mas-workspaces.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/200-ibm-mas-workspaces.yaml
@@ -48,6 +48,7 @@ spec:
             junitreporter:
               reporter_name: "ibm-mas-ws-{{ $.Values.instance.id }}-{{ $value.mas_workspace_id }}"
               cluster_id: "{{ $.Values.cluster.id }}"
+              instance_id: "{{ $.Values.instance.id }}"
               devops_mongo_uri: "{{ $.Values.devops.mongo_uri }}"
               devops_build_number: "{{ $.Values.devops.build_number }}"
               gitops_version: "{{ $.Values.source.revision }}"

--- a/root-applications/ibm-mas-instance-root/templates/500-ibm-mas-masapp-manage-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/500-ibm-mas-masapp-manage-install.yaml
@@ -63,6 +63,7 @@ spec:
             junitreporter:
               reporter_name: "app-install-manage-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
+              instance_id: "{{ .Values.instance.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"
               gitops_version: "{{ .Values.source.revision }}"

--- a/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
@@ -110,6 +110,7 @@ spec:
             junitreporter:
               reporter_name: "app-config-{{ $value.mas_app_id }}-{{ $.Values.instance.id }}"
               cluster_id: "{{ $.Values.cluster.id }}"
+              instance_id: "{{ $.Values.instance.id }}"
               devops_mongo_uri: "{{ $.Values.devops.mongo_uri }}"
               devops_build_number: "{{ $.Values.devops.build_number }}"
               gitops_version: "{{ $.Values.source.revision }}"

--- a/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-assist-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-assist-install.yaml
@@ -62,6 +62,7 @@ spec:
             junitreporter:
               reporter_name: "app-install-assist-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
+              instance_id: "{{ .Values.instance.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"
               gitops_version: "{{ .Values.source.revision }}"

--- a/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-facilities-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-facilities-install.yaml
@@ -62,6 +62,7 @@ spec:
             junitreporter:
               reporter_name: "app-install-facilities-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
+              instance_id: "{{ .Values.instance.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"
               gitops_version: "{{ .Values.source.revision }}"

--- a/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-iot-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-iot-install.yaml
@@ -63,6 +63,7 @@ spec:
             junitreporter:
               reporter_name: "app-install-iot-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
+              instance_id: "{{ .Values.instance.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"
               gitops_version: "{{ .Values.source.revision }}"

--- a/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-visualinspection-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-visualinspection-install.yaml
@@ -67,6 +67,7 @@ spec:
             junitreporter: 
               reporter_name: "app-install-mvi-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
+              instance_id: "{{ .Values.instance.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"
               gitops_version: "{{ .Values.source.revision }}"

--- a/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-health-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-health-install.yaml
@@ -63,6 +63,7 @@ spec:
             junitreporter:
               reporter_name: "app-install-health-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
+              instance_id: "{{ .Values.instance.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"
               gitops_version: "{{ .Values.source.revision }}"

--- a/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-monitor-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-monitor-install.yaml
@@ -63,6 +63,7 @@ spec:
             junitreporter:
               reporter_name: "app-install-monitor-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
+              instance_id: "{{ .Values.instance.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"
               gitops_version: "{{ .Values.source.revision }}"

--- a/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-optimizer-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-optimizer-install.yaml
@@ -63,6 +63,7 @@ spec:
             junitreporter:
               reporter_name: "app-install-optimizer-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
+              instance_id: "{{ .Values.instance.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"
               gitops_version: "{{ .Values.source.revision }}"

--- a/root-applications/ibm-mas-instance-root/templates/540-ibm-mas-masapp-predict-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/540-ibm-mas-masapp-predict-install.yaml
@@ -63,6 +63,7 @@ spec:
             junitreporter:
               reporter_name: "app-install-predict-{{ .Values.instance.id }}"
               cluster_id: "{{ .Values.cluster.id }}"
+              instance_id: "{{ .Values.instance.id }}"
               devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
               devops_build_number: "{{ .Values.devops.build_number }}"
               gitops_version: "{{ .Values.source.revision }}"

--- a/sub-charts/junitreporter/templates/00-presync-report-starter.yaml
+++ b/sub-charts/junitreporter/templates/00-presync-report-starter.yaml
@@ -136,8 +136,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+{{- if .Values.mas_instance_id }}
+            - name: DEVOPS_ENVIRONMENT
+              value: "{{ .Values.mas_instance_id }}"
+{{- else }}
             - name: DEVOPS_ENVIRONMENT
               value: "{{ .Values.cluster_id }}"
+{{- end }}
             - name: DEVOPS_SUITE_NAME
               value: "{{ .Values.reporter_name }}"
             - name: DEVOPS_BUILD_NUMBER

--- a/sub-charts/junitreporter/templates/00-presync-report-starter.yaml
+++ b/sub-charts/junitreporter/templates/00-presync-report-starter.yaml
@@ -136,9 +136,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-{{- if .Values.mas_instance_id }}
+{{- if .Values.instance_id }}
             - name: DEVOPS_ENVIRONMENT
-              value: "{{ .Values.mas_instance_id }}"
+              value: "{{ .Values.instance_id }}"
 {{- else }}
             - name: DEVOPS_ENVIRONMENT
               value: "{{ .Values.cluster_id }}"

--- a/sub-charts/junitreporter/templates/10-postsync-report-starter.yaml
+++ b/sub-charts/junitreporter/templates/10-postsync-report-starter.yaml
@@ -137,8 +137,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+{{- if .Values.mas_instance_id }}
+            - name: DEVOPS_ENVIRONMENT
+              value: "{{ .Values.mas_instance_id }}"
+{{- else }}
             - name: DEVOPS_ENVIRONMENT
               value: "{{ .Values.cluster_id }}"
+{{- end }}
             - name: DEVOPS_SUITE_NAME
               value: "{{ .Values.reporter_name }}"
             - name: DEVOPS_BUILD_NUMBER

--- a/sub-charts/junitreporter/templates/10-postsync-report-starter.yaml
+++ b/sub-charts/junitreporter/templates/10-postsync-report-starter.yaml
@@ -137,9 +137,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-{{- if .Values.mas_instance_id }}
+{{- if .Values.instance_id }}
             - name: DEVOPS_ENVIRONMENT
-              value: "{{ .Values.mas_instance_id }}"
+              value: "{{ .Values.instance_id }}"
 {{- else }}
             - name: DEVOPS_ENVIRONMENT
               value: "{{ .Values.cluster_id }}"


### PR DESCRIPTION
Set the instance_id in the junit reporter for gitops so that devops_environment to be based on the instanceid rather than the clusterid. This allows different mas instances to report test results on a per instance level basis rather than per cluster, as per cluster would mean the test results of instance A would wipe over the test results of instance B.

Tested in fvtsaas as we know have test results per instance:
![image- 2025-04-04 at 10 25 17@2x](https://github.com/user-attachments/assets/efc323fc-a4e6-401c-845e-c377ccd0cdcf)
![image- 2025-04-04 at 10 25 29@2x](https://github.com/user-attachments/assets/602bc81e-04d3-4a56-a788-4384fea8eac2)
