### PR TITLE
[patch] Fix Manage verify test for Manage Foundation

### DIFF
--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -212,8 +212,11 @@ data:
     def test_bundle_sizes(mange_workspace_cr):
       spec_serverbundles = mange_workspace_cr['spec']['settings']['deployment']['serverBundles']
       status_serverbundles = mange_workspace_cr['status']['settings']['deployment']['serverBundles']
-      if spec_serverbundles is not None:
-        assert status_serverbundles == spec_serverbundles, f"Expected serverbundles set in the spec: {spec_serverbundles} to be equal to the languages in the status: {status_serverbundles}"
+      spec_serverbundles_updated = $(echo spec_serverbundles | yq '.serverBundles |= del(.[] | select(.bundleType == "foundation"))')
+      status_serverbundles_updated =  $(echo status_serverbundles | yq '.serverBundles |= del(.[] | select(.bundleType == "foundation"))')
+
+      if spec_serverbundles_updated is not None:
+        assert status_serverbundles_updated == spec_serverbundles_updated, f"Expected serverbundles set in the spec: {spec_serverbundles_updated} to be equal to the serverbundles in the status: {status_serverbundles_updated}"
 
 ---
 kind: ConfigMap

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -212,11 +212,11 @@ data:
     def test_bundle_sizes(mange_workspace_cr):
       spec_serverbundles = mange_workspace_cr['spec']['settings']['deployment']['serverBundles']
       status_serverbundles = mange_workspace_cr['status']['settings']['deployment']['serverBundles']
-      spec_serverbundles_updated = $(echo spec_serverbundles | yq '.serverBundles |= del(.[] | select(.bundleType == "foundation"))')
-      status_serverbundles_updated =  $(echo status_serverbundles | yq '.serverBundles |= del(.[] | select(.bundleType == "foundation"))')
+      spec_serverbundles = [item for item in spec_serverbundlesif item['bundleType'] != 'foundation']
+      status_serverbundles = [item for item in status_serverbundles if item['bundleType'] != 'foundation']
 
-      if spec_serverbundles_updated is not None:
-        assert status_serverbundles_updated == spec_serverbundles_updated, f"Expected serverbundles set in the spec: {spec_serverbundles_updated} to be equal to the serverbundles in the status: {status_serverbundles_updated}"
+      if status_serverbundles is not None:
+        assert spec_serverbundles == status_serverbundles, f"Expected serverbundles set in the spec: {spec_serverbundles} to be equal to the serverbundles in the status: {status_serverbundles}"
 
 ---
 kind: ConfigMap

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -212,7 +212,7 @@ data:
     def test_bundle_sizes(mange_workspace_cr):
       spec_serverbundles = mange_workspace_cr['spec']['settings']['deployment']['serverBundles']
       status_serverbundles = mange_workspace_cr['status']['settings']['deployment']['serverBundles']
-      spec_serverbundles = [item for item in spec_serverbundlesif item['bundleType'] != 'foundation']
+      spec_serverbundles = [item for item in spec_serverbundles if item['bundleType'] != 'foundation']
       status_serverbundles = [item for item in status_serverbundles if item['bundleType'] != 'foundation']
 
       if status_serverbundles is not None:


### PR DESCRIPTION
The Manage Foundation bundle is a new bundle that is deployed in all situations even if it is not set on the bundle CR spec. This means the test as it is fails as the spec doesn't match the status. This change is to drop the foundation bundle part and just check the other bundles. 

Tested in fvtsaas

Part of https://jsw.ibm.com/browse/MASCORE-5864