### PR TITLE
[patch] Fix bug with ReplicaDB post hadr setup job

### DIFF
--- a/instance-applications/120-ibm-db2u-database/templates/07-postsync-setup-db2_Job.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/07-postsync-setup-db2_Job.yaml
@@ -26,7 +26,7 @@ Increment this value whenever you make a change to an immutable field of the Job
 E.g. passing in a new environment variable.
 Included in $_job_hash (see below).
 */}}
-{{- $_job_version := "v9" }}
+{{- $_job_version := "v10" }}
 
 {{- /*
 10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_tag
@@ -700,7 +700,7 @@ spec:
                 [ \$rc -ne 0 ] && exit \$rc
 
                 echo "backupdb.sh: db2set comms manager"
-                db2set DB2COMM=SSL
+                db2set DB2COMM=TCPIP,SSL
                 rc=\$?
                 [ \$rc -ne 0 ] && exit \$rc
 

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -351,7 +351,7 @@ spec:
                 if [[ $is_backup_copied == 'true' ]]; then
                   echo "Earlier copied backup is available in standby. Validating the backup file"
                   rc=0
-                  bkp_validation=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2ckbkp -h /tmp/${backup_filename}; exit 1;" db2inst1`
+                  bkp_validation=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2ckbkp -h /tmp/${backup_filename}; echo 'ERROR';" db2inst1`
                   echo $bkp_validation
                   if [[ $bkp_validation == *"ERROR"* ]]; then
                     echo "The earlier copied backup is not a valid image."

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -317,17 +317,29 @@ spec:
               PRIMARY_ROLE=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 get db cfg for BLUDB | grep role | cut -d'=' -f2 | tr -d ' '" db2inst1`
               STANDBY_ROLE=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2 get db cfg for BLUDB | grep role | cut -d'=' -f2 | tr -d ' '" db2inst1`
 
+              is_backup_file_available='false'
               if [[ ! ($PRIMARY_ROLE == 'PRIMARY' && $STANDBY_ROLE == 'STANDBY') ]]; then
-                echo ""
-                echo "Taking backup on ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0"
-                echo "--------------------------------------------------------------------------------"
-                oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "mkdir -p /mnt/backup/standby; db2 backup db ${DB2_DBNAME} on all dbpartitionnums online to /mnt/backup/standby | tee /mnt/backup/standby/dbbackup.log" db2inst1 || exit $?
-                echo ""
-                timestamp=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "cat /mnt/backup/standby/dbbackup.log | grep 'timestamp' | rev | cut -d ' ' -f1 | rev" db2inst1`
-                echo "Timestamp of backup is ${timestamp}"
+                echo "Checking if a backup already exists on ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0"
+                is_backup_log_available=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "if [ -f /mnt/backup/standby/dbbackup.log ]; then echo 'true'; else echo 'false'; fi"`
+                if [[ $is_backup_log_available == 'true' ]]; then
+                  backup_filename=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "ls /mnt/backup/standby | grep ${timestamp}" db2inst1`
+                  timestamp=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "cat /mnt/backup/standby/dbbackup.log | grep 'timestamp' | rev | cut -d ' ' -f1 | rev" db2inst1`
+                  echo "Timestamp of backup is ${timestamp}"
+                  is_backup_file_available=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "if [ -f $backup_filename ]; then echo 'true'; else echo 'false'; fi"`
+                fi
 
-                backup_filename=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "ls /mnt/backup/standby | grep ${timestamp}" db2inst1`
-                echo "Backup filename is ${backup_filename}"
+                if [[ $is_backup_file_available == 'false' ]]; then
+                  echo ""
+                  echo "Taking backup on ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0"
+                  echo "--------------------------------------------------------------------------------"
+                  oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "mkdir -p /mnt/backup/standby; db2 backup db ${DB2_DBNAME} on all dbpartitionnums online to /mnt/backup/standby | tee /mnt/backup/standby/dbbackup.log" db2inst1 || exit $?
+                  echo ""
+                  timestamp=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "cat /mnt/backup/standby/dbbackup.log | grep 'timestamp' | rev | cut -d ' ' -f1 | rev" db2inst1`
+                  echo "Timestamp of backup is ${timestamp}"
+
+                  backup_filename=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "ls /mnt/backup/standby | grep ${timestamp}" db2inst1`
+                  echo "Backup filename is ${backup_filename}"
+                fi
 
                 echo ""
                 echo "Copying backup /mnt/backup/standby/${backup_filename} from ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 to ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0 "

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -349,10 +349,12 @@ spec:
 
                 echo "Checking if backup file was copied already to standby c-${DB2_INSTANCE_NAME}-db2u-0"
                 is_backup_copied=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "if [ -f /tmp/${backup_filename} ]; then echo 'true' else echo 'false'; fi"`
+                echo $is_backup_copied
                 if [[ $is_backup_copied == 'true' ]]; then
                   echo "Validating the copied backup image"
                   rc=0
-                  oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2ckbkp -H /tmp/${backup_filename}" db2inst1 || rc=$?
+                  oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2ckbkp -H /tmp/${backup_filename}; exit 1;" db2inst1 || rc=$?
+                  echo $rc
                 fi
                 if [[ $rc != 0 || $is_backup_copied == 'false' ]]; then
                   echo ""

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -351,8 +351,10 @@ spec:
                 is_backup_copied=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "if [ -f /tmp/${backup_filename} ]; then echo 'true' else echo 'false'; fi"`
                 if [[ $is_backup_copied == 'true' ]]; then
                   echo "Validating the copied backup image"
-                  oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2ckbkp -H /tmp/${backup_filename}" db2inst1 || exit $?
-                else
+                  rc=0
+                  oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2ckbkp -H /tmp/${backup_filename}" db2inst1 || rc=$?
+                fi
+                if [[ $rc != 0 || $is_backup_copied == 'false' ]]; then
                   echo ""
                   echo "Copying backup /mnt/backup/standby/${backup_filename} from ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 to ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0 "
                   oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "cp /mnt/backup/standby/${backup_filename} /tmp; chmod 777 /tmp/${backup_filename}" db2inst1 || exit $?

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -328,7 +328,7 @@ spec:
                   backup_filename=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "ls /mnt/backup/standby | grep ${timestamp}" db2inst1`
                   echo "backup_filename - $backup_filename"
                   if [[ ${timestamp:0:8} == `date +%Y%m%d` ]]; then
-                    is_backup_file_available=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "if [ -f $backup_filename ]; then echo 'true'; else echo 'false'; fi"`
+                    is_backup_file_available=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "if [ -f /mnt/backup/standby/$backup_filename ]; then echo 'true'; else echo 'false'; fi"`
                     echo "is_backup_file_available - $is_backup_file_available"
                   fi
                 fi

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -324,8 +324,9 @@ spec:
                 if [[ $is_backup_log_available == 'true' ]]; then
                   backup_filename=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "ls /mnt/backup/standby | grep ${timestamp}" db2inst1`
                   timestamp=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "cat /mnt/backup/standby/dbbackup.log | grep 'timestamp' | rev | cut -d ' ' -f1 | rev" db2inst1`
-                  echo "Timestamp of backup is ${timestamp}"
-                  is_backup_file_available=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "if [ -f $backup_filename ]; then echo 'true'; else echo 'false'; fi"`
+                  if [[ ${timestamp:0:8} == `date +%Y%m%d` ]]; then
+                    is_backup_file_available=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "if [ -f $backup_filename ]; then echo 'true'; else echo 'false'; fi"`
+                  fi
                 fi
 
                 if [[ $is_backup_file_available == 'false' ]]; then

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -351,7 +351,7 @@ spec:
                 if [[ $is_backup_copied == 'true' ]]; then
                   echo "Earlier copied backup is available in standby. Validating the backup file"
                   rc=0
-                  bkp_validation=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2ckbkp -h /tmp/${backup_filename}; echo 'ERROR';" db2inst1`
+                  bkp_validation=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2ckbkp -h /tmp/${backup_filename};" db2inst1`
                   echo $bkp_validation
                   if [[ $bkp_validation == *"ERROR"* ]]; then
                     echo "The earlier copied backup is not a valid image."

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -347,11 +347,18 @@ spec:
                   echo "Backup filename is ${backup_filename}"
                 fi
 
-                echo ""
-                echo "Copying backup /mnt/backup/standby/${backup_filename} from ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 to ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0 "
-                oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "cp /mnt/backup/standby/${backup_filename} /tmp; chmod 777 /tmp/${backup_filename}" db2inst1 || exit $?
-                oc cp ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0:/tmp/${backup_filename} /tmp/${backup_filename}
-                oc cp /tmp/${backup_filename} ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/tmp/${backup_filename}
+                echo "Checking if backup file was copied already to standby c-${DB2_INSTANCE_NAME}-db2u-0"
+                is_backup_copied=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "if [ -f /tmp/${backup_filename} ]; then echo 'true' else echo 'false'; fi"`
+                if [[ $is_backup_copied == 'true' ]]; then
+                  echo "Validating the copied backup image"
+                  oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2ckbkp -H /tmp/${backup_filename}" db2inst1 || exit $?
+                else
+                  echo ""
+                  echo "Copying backup /mnt/backup/standby/${backup_filename} from ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 to ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0 "
+                  oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "cp /mnt/backup/standby/${backup_filename} /tmp; chmod 777 /tmp/${backup_filename}" db2inst1 || exit $?
+                  oc cp ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0:/tmp/${backup_filename} /tmp/${backup_filename}
+                  oc cp /tmp/${backup_filename} ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0:/tmp/${backup_filename}
+                fi
 
                 echo ""
                 echo "Copying keystore from primary to standby"

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -353,7 +353,8 @@ spec:
                   rc=0
                   bkp_validation=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2ckbkp -h /tmp/${backup_filename}; exit 1;" db2inst1`
                   echo $bkp_validation
-                  if [[ echo $bkp_validation | grep 'ERROR' ]]; then
+                  if [[ $bkp_validation == *"ERROR"* ]]; then
+                    echo "The earlier copied backup is not a valid image."
                     rc=1
                   fi
                   echo $rc

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -348,7 +348,7 @@ spec:
                 fi
 
                 echo "Checking if backup file was copied already to standby c-${DB2_INSTANCE_NAME}-db2u-0"
-                is_backup_copied=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "if [ -f /tmp/${backup_filename} ]; then echo 'true' else echo 'false'; fi"`
+                is_backup_copied=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "if [ -f /tmp/${backup_filename} ]; then echo 'true'; else echo 'false'; fi"`
                 echo $is_backup_copied
                 if [[ $is_backup_copied == 'true' ]]; then
                   echo "Validating the copied backup image"

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -4,7 +4,7 @@
 {{- /*
 Meaningful prefix for the job resource name. Must be under 52 chars in length to leave room for the 11 chars reserved for '-' and $_job_hash.
 */}}
-{{- $_job_name_prefix := "postsync-setup-hadr" }}
+{{- $_job_name_prefix := "postsync-setup-hadr-v1" }}
 
 {{- /*
 Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
@@ -321,14 +321,19 @@ spec:
               if [[ ! ($PRIMARY_ROLE == 'PRIMARY' && $STANDBY_ROLE == 'STANDBY') ]]; then
                 echo "Checking if a backup already exists on ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0"
                 is_backup_log_available=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "if [ -f /mnt/backup/standby/dbbackup.log ]; then echo 'true'; else echo 'false'; fi"`
+                echo "is_backup_log_available - $is_backup_log_available"
                 if [[ $is_backup_log_available == 'true' ]]; then
                   timestamp=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "cat /mnt/backup/standby/dbbackup.log | grep 'timestamp' | rev | cut -d ' ' -f1 | rev" db2inst1`
+                  echo "timestamp - $timestamp"
                   backup_filename=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "ls /mnt/backup/standby | grep ${timestamp}" db2inst1`
+                  echo "backup_filename - $backup_filename"
                   if [[ ${timestamp:0:8} == `date +%Y%m%d` ]]; then
                     is_backup_file_available=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "if [ -f $backup_filename ]; then echo 'true'; else echo 'false'; fi"`
+                    echo "is_backup_file_available - $is_backup_file_available"
                   fi
                 fi
 
+                echo "is_backup_file_available - $is_backup_file_available"
                 if [[ $is_backup_file_available == 'false' ]]; then
                   echo ""
                   echo "Taking backup on ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0"

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -321,7 +321,6 @@ spec:
               if [[ ! ($PRIMARY_ROLE == 'PRIMARY' && $STANDBY_ROLE == 'STANDBY') ]]; then
                 echo "Checking if a backup already exists on ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0"
                 is_backup_log_available=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "if [ -f /mnt/backup/standby/dbbackup.log ]; then echo 'true'; else echo 'false'; fi"`
-                echo "is_backup_log_available - $is_backup_log_available"
                 if [[ $is_backup_log_available == 'true' ]]; then
                   timestamp=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "cat /mnt/backup/standby/dbbackup.log | grep 'timestamp' | rev | cut -d ' ' -f1 | rev" db2inst1`
                   echo "timestamp - $timestamp"
@@ -329,11 +328,9 @@ spec:
                   echo "backup_filename - $backup_filename"
                   if [[ ${timestamp:0:8} == `date +%Y%m%d` ]]; then
                     is_backup_file_available=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "if [ -f /mnt/backup/standby/$backup_filename ]; then echo 'true'; else echo 'false'; fi"`
-                    echo "is_backup_file_available - $is_backup_file_available"
                   fi
                 fi
 
-                echo "is_backup_file_available - $is_backup_file_available"
                 if [[ $is_backup_file_available == 'false' ]]; then
                   echo ""
                   echo "Taking backup on ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0"
@@ -345,17 +342,23 @@ spec:
 
                   backup_filename=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "ls /mnt/backup/standby | grep ${timestamp}" db2inst1`
                   echo "Backup filename is ${backup_filename}"
+                else
+                  echo "Backup is already available in primary. Hence skipping"
                 fi
 
                 echo "Checking if backup file was copied already to standby c-${DB2_INSTANCE_NAME}-db2u-0"
                 is_backup_copied=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "if [ -f /tmp/${backup_filename} ]; then echo 'true'; else echo 'false'; fi"`
-                echo $is_backup_copied
                 if [[ $is_backup_copied == 'true' ]]; then
-                  echo "Validating the copied backup image"
+                  echo "Earlier copied backup is available in standby. Validating the backup file"
                   rc=0
-                  oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2ckbkp -H /tmp/${backup_filename}; exit 1;" db2inst1 || rc=$?
+                  bkp_validation=`oc exec -n ${DB2_NAMESPACE} c-${DB2_INSTANCE_NAME}-db2u-0 -- su -lc "db2ckbkp -h /tmp/${backup_filename}; exit 1;" db2inst1`
+                  echo $bkp_validation
+                  if [[ echo $bkp_validation | grep 'ERROR' ]]; then
+                    rc=1
+                  fi
                   echo $rc
                 fi
+                echo $rc
                 if [[ $rc != 0 || $is_backup_copied == 'false' ]]; then
                   echo ""
                   echo "Copying backup /mnt/backup/standby/${backup_filename} from ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 to ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0 "

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -356,10 +356,10 @@ spec:
                   if [[ $bkp_validation == *"ERROR"* ]]; then
                     echo "The earlier copied backup is not a valid image."
                     rc=1
+                  else
+                    echo "The earlier copied backup is a valid image"
                   fi
-                  echo $rc
                 fi
-                echo $rc
                 if [[ $rc != 0 || $is_backup_copied == 'false' ]]; then
                   echo ""
                   echo "Copying backup /mnt/backup/standby/${backup_filename} from ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 to ${DB2_NAMESPACE}/c-${DB2_INSTANCE_NAME}-db2u-0 "

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -322,8 +322,8 @@ spec:
                 echo "Checking if a backup already exists on ${DB2_NAMESPACE}/c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0"
                 is_backup_log_available=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "if [ -f /mnt/backup/standby/dbbackup.log ]; then echo 'true'; else echo 'false'; fi"`
                 if [[ $is_backup_log_available == 'true' ]]; then
-                  backup_filename=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "ls /mnt/backup/standby | grep ${timestamp}" db2inst1`
                   timestamp=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "cat /mnt/backup/standby/dbbackup.log | grep 'timestamp' | rev | cut -d ' ' -f1 | rev" db2inst1`
+                  backup_filename=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "ls /mnt/backup/standby | grep ${timestamp}" db2inst1`
                   if [[ ${timestamp:0:8} == `date +%Y%m%d` ]]; then
                     is_backup_file_available=`oc exec -n ${DB2_NAMESPACE} c-${PRIMARY_DB2_INSTANCE_NAME}-db2u-0 -- su -lc "if [ -f $backup_filename ]; then echo 'true'; else echo 'false'; fi"`
                   fi

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -4,7 +4,7 @@
 {{- /*
 Meaningful prefix for the job resource name. Must be under 52 chars in length to leave room for the 11 chars reserved for '-' and $_job_hash.
 */}}
-{{- $_job_name_prefix := "postsync-setup-hadr-v1" }}
+{{- $_job_name_prefix := "postsync-setup-hadr" }}
 
 {{- /*
 Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
@@ -27,7 +27,7 @@ Increment this value whenever you make a change to an immutable field of the Job
 E.g. passing in a new environment variable.
 Included in $_job_hash (see below).
 */}}
-{{- $_job_version := "v3" }}
+{{- $_job_version := "v4" }}
 
 {{- /*
 10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_tag


### PR DESCRIPTION
Issue: [MASCORE-6469](https://jsw.ibm.com/browse/MASCORE-6469)

## Description
1. SREs reported that if there was some other issue and the HADR setup job exited before starting the primary and standby HADR services, the job was retrying to take backup again and again even though earlier backups were successful - Hence we are checking if backup file is available (taking the timestamp from the log) and validating it was taken today, then we skip backup process and re-use this existing one. If not, we take backup
2. Copying the backup from Primary to Standby - we are checking if backup file is already available in standby. If available, we are validating the backup image using db2ckbkp command. If no error, we skip the copy process. If not, we copy the backup from primary to standby
3. DB2COMM value to be set as TCPIP,SSL as requested by DBA