### PR TITLE
[patch] use digests to reference cli image

### DIFF
--- a/build/bin/set-cli-image-digest.sh
+++ b/build/bin/set-cli-image-digest.sh
@@ -4,15 +4,15 @@
 
 function print_help() {
   cat << EOM
-Usage: set-cli-image-tag.sh [OPTION]
-Replace value of the \$_cli_image_tag constant with a given tag for all .yaml and .yml files in a given directory (and its sub-directories).
+Usage: set-cli-image-digest.sh [OPTION]
+Replace value of the \$_cli_image_digest constant with a given hash for all .yaml and .yml files in a given directory (and its sub-directories).
 
     -d, --root-dir   Directory to (recursively) search for .yml and .yaml files
-    -t, --tag        The new value for \$_cli_image_tag
+    -g, --digest     The new value for \$_cli_image_digest
     -h, --help       Print this help message and exit
 
 Example:
-    set-cli-image-tag.sh --root-dir /home/tom/workspace/gitops --tag 13.2.1
+    set-cli-image-digest.sh --root-dir /home/tom/workspace/gitops --digest 'sha256:53c53e53f5e7615fe219375d2600ba4601477bec392eebf5580ac0d518fe065c'
 EOM
 }
 
@@ -26,8 +26,8 @@ do
         ROOT_DIR=$1
         shift
         ;;
-        -t|--tag)
-        TAG=$1
+        -g|--digest)
+        DIGEST=$1
         shift
         ;;
         -h|--help)
@@ -43,7 +43,7 @@ do
 done
 
 : ${ROOT_DIR?"Need to set -d|--root-dir) argument"}
-: ${TAG?"Need to set -t|--tag argument"}
+: ${DIGEST?"Need to set -g|--digest argument"}
 
 scanned_count=0
 updated_count=0
@@ -51,9 +51,9 @@ for file in $(find ${ROOT_DIR} -type f \( -name "*.yaml" -o -name "*.yml" \)); d
     (( scanned_count++ ))
     before_cksum=$(cksum "$file")
     if [[ "$OSTYPE" == "darwin"* ]]; then
-        sed -Ei '' 's/(\{\{-?[[:space:]]*\$_cli_image_tag[[:space:]]*:=[[:space:]]*")([^"]*)("[[:space:]]*\}\})/\1'${TAG}'\3/g' ${file}
+        sed -Ei '' 's/(\{\{-?[[:space:]]*\$_cli_image_digest[[:space:]]*:=[[:space:]]*")([^"]*)("[[:space:]]*\}\})/\1'${DIGEST}'\3/g' ${file}
     else
-        sed -Ei 's/(\{\{-?[[:space:]]*\$_cli_image_tag[[:space:]]*:=[[:space:]]*")([^"]*)("[[:space:]]*\}\})/\1'${TAG}'\3/g' ${file}
+        sed -Ei 's/(\{\{-?[[:space:]]*\$_cli_image_digest[[:space:]]*:=[[:space:]]*")([^"]*)("[[:space:]]*\}\})/\1'${DIGEST}'\3/g' ${file}
     fi
     after_cksum=$(cksum "$file")
     if [[ "$before_cksum" != "$after_cksum" ]]; then

--- a/cluster-applications/000-job-cleaner/templates/04-jobcleaner_CronJob.yaml
+++ b/cluster-applications/000-job-cleaner/templates/04-jobcleaner_CronJob.yaml
@@ -1,7 +1,7 @@
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 
 {{- $ns := "job-cleaner" }}
@@ -90,7 +90,7 @@ spec:
         spec:
           containers:
             - name: "mas-saas-job-cleaner"
-              image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+              image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh

--- a/cluster-applications/010-redhat-cert-manager/templates/04-postsync-update-sm_Job.yaml
+++ b/cluster-applications/010-redhat-cert-manager/templates/04-postsync-update-sm_Job.yaml
@@ -14,10 +14,10 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 {{- $_job_name_prefix := "postsync-rhcm-update-sm-job" }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
@@ -37,11 +37,11 @@ Included in $_job_hash (see below).
 {{- $_job_version := "v3" }}
 
 {{- /*
-10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_tag
+10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_digest
 This is to ensure ArgoCD will create a new job resource intead of attempting (and failing) to update an
 immutable field of any existing Job resource.
 */}}
-{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_tag $_job_version | adler32sum }}
+{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_digest $_job_version | adler32sum }}
 
 {{- $_job_name := join "-" (list $_job_name_prefix $_job_hash )}}
 
@@ -178,7 +178,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: Always
           resources:
             limits:

--- a/cluster-applications/020-ibm-dro/templates/08-postsync-update-sm_Job.yaml
+++ b/cluster-applications/020-ibm-dro/templates/08-postsync-update-sm_Job.yaml
@@ -6,10 +6,10 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 {{- $_job_name_prefix := "postsync-ibm-dro-update-sm-job" }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
@@ -29,11 +29,11 @@ Included in $_job_hash (see below).
 {{- $_job_version := "v3" }}
 
 {{- /*
-10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_tag
+10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_digest
 This is to ensure ArgoCD will create a new job resource intead of attempting (and failing) to update an
 immutable field of any existing Job resource.
 */}}
-{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_tag $_job_version | adler32sum }}
+{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_digest $_job_version | adler32sum }}
 
 {{- $_job_name := join "-" (list $_job_name_prefix $_job_hash )}}
 
@@ -160,7 +160,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/cluster-applications/021-ibm-dro-cleanup/templates/postdelete-MarketplaceConfigs.yaml
+++ b/cluster-applications/021-ibm-dro-cleanup/templates/postdelete-MarketplaceConfigs.yaml
@@ -1,8 +1,8 @@
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 
 {{ $job_name := "postdelete-delete-marketplaceconfigs-job" }}
@@ -38,7 +38,7 @@ spec:
         - name: run
           # TODO: use a dedicated image with a smaller footprint for this sort of thing?
           # Just using cli for now since it has all the deps we need to talk with AWS SM
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/cluster-applications/041-cis-compliance-cleanup/templates/postdelete-ProfileBundles.yaml
+++ b/cluster-applications/041-cis-compliance-cleanup/templates/postdelete-ProfileBundles.yaml
@@ -1,8 +1,8 @@
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{ $job_name := "postdelete-delete-profilebundles-job" }}
 
@@ -41,7 +41,7 @@ spec:
         - name: run
           # TODO: use a dedicated image with a smaller footprint for this sort of thing?
           # Just using cli for now since it has all the deps we need to talk with AWS SM
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/cluster-applications/055-instana-agent-operator/templates/08-CronJob.yaml
+++ b/cluster-applications/055-instana-agent-operator/templates/08-CronJob.yaml
@@ -1,8 +1,8 @@
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 
 ---
@@ -49,7 +49,7 @@ spec:
           # Additionally, it writes the DB2 certificate to a persistent volume.
           initContainers:
             - name: update-agent-cr
-              image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+              image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
               imagePullPolicy: IfNotPresent              
               volumeMounts:
                 - name: instana-db2-jks

--- a/cluster-applications/060-custom-sa/templates/04-postsync-update-sm_Job.yaml
+++ b/cluster-applications/060-custom-sa/templates/04-postsync-update-sm_Job.yaml
@@ -6,10 +6,10 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 {{- $_job_name_prefix := "postsync-custom-sa-update-sm-job" }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
@@ -29,11 +29,11 @@ Included in $_job_hash (see below).
 {{- $_job_version := "v1" }}
 
 {{- /*
-10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_tag
+10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_digest
 This is to ensure ArgoCD will create a new job resource intead of attempting (and failing) to update an
 immutable field of any existing Job resource.
 */}}
-{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_tag $_job_version | adler32sum }}
+{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_digest $_job_version | adler32sum }}
 
 {{- $_job_name := join "-" (list $_job_name_prefix $_job_hash )}}
 
@@ -82,7 +82,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/cluster-applications/200-cluster-promotion/templates/02-cluster-verify_Job.yaml
+++ b/cluster-applications/200-cluster-promotion/templates/02-cluster-verify_Job.yaml
@@ -4,10 +4,10 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 {{- $_job_name_prefix := "cluster-verify" }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
@@ -27,11 +27,11 @@ Included in $_job_hash (see below).
 {{- $_job_version := "v3" }}
 
 {{- /*
-10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_tag
+10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_digest
 This is to ensure ArgoCD will create a new job resource intead of attempting (and failing) to update an
 immutable field of any existing Job resource.
 */}}
-{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_tag $_job_version | adler32sum }}
+{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_digest $_job_version | adler32sum }}
 
 {{- $_job_name := join "-" (list $_job_name_prefix $_job_hash )}}
 
@@ -113,7 +113,7 @@ spec:
     spec:
       containers:
         - name: cluster-verify
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           env:
             - name: ACCOUNT_ID

--- a/cluster-applications/200-cluster-promotion/templates/03-cluster-promoter_Job.yaml
+++ b/cluster-applications/200-cluster-promotion/templates/03-cluster-promoter_Job.yaml
@@ -4,10 +4,10 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 {{- $_job_name_prefix := "cluster-promoter" }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
@@ -27,11 +27,11 @@ Included in $_job_hash (see below).
 {{- $_job_version := "v2" }}
 
 {{- /*
-10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_tag
+10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_digest
 This is to ensure ArgoCD will create a new job resource intead of attempting (and failing) to update an
 immutable field of any existing Job resource.
 */}}
-{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_tag $_job_version | adler32sum }}
+{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_digest $_job_version | adler32sum }}
 
 {{- $_job_name := join "-" (list $_job_name_prefix $_job_hash )}}
 
@@ -80,7 +80,7 @@ spec:
     spec:
       containers:
         - name: cluster-promoter
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           env:
             - name: ACCOUNT_ID

--- a/instance-applications/010-ibm-sync-jobs/templates/00-aws-docdb-add-user_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/00-aws-docdb-add-user_Job.yaml
@@ -6,10 +6,10 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 {{- $_job_name_prefix := "aws-docdb-add-user" }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
@@ -29,11 +29,11 @@ Included in $_job_hash (see below).
 {{- $_job_version := "v3" }}
 
 {{- /*
-10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_tag
+10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_digest
 This is to ensure ArgoCD will create a new job resource intead of attempting (and failing) to update an
 immutable field of any existing Job resource.
 */}}
-{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_tag $_job_version | adler32sum }}
+{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_digest $_job_version | adler32sum }}
 
 {{- $_job_name := join "-" (list $_job_name_prefix $_job_hash )}}
 
@@ -89,7 +89,7 @@ spec:
     spec:
       containers:
         - name: aws-docdb-process-user
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           env:
 

--- a/instance-applications/010-ibm-sync-jobs/templates/00-ibm-cp4d-presync.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/00-ibm-cp4d-presync.yaml
@@ -6,10 +6,10 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 {{- $_job_name_prefix := "presync-cpd-olm-job" }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
@@ -29,11 +29,11 @@ Included in $_job_hash (see below).
 {{- $_job_version := "v3" }}
 
 {{- /*
-10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_tag
+10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_digest
 This is to ensure ArgoCD will create a new job resource intead of attempting (and failing) to update an
 immutable field of any existing Job resource.
 */}}
-{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_tag $_job_version | adler32sum }}
+{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_digest $_job_version | adler32sum }}
 
 {{- $_job_name := join "-" (list $_job_name_prefix $_job_hash )}}
 
@@ -143,7 +143,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
@@ -7,10 +7,10 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 {{- $_job_name_prefix := "ibm-suite-certs" }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
@@ -30,11 +30,11 @@ Included in $_job_hash (see below).
 {{- $_job_version := "v2" }}
 
 {{- /*
-10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_tag
+10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_digest
 This is to ensure ArgoCD will create a new job resource intead of attempting (and failing) to update an
 immutable field of any existing Job resource.
 */}}
-{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_tag $_job_version | adler32sum }}
+{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_digest $_job_version | adler32sum }}
 
 {{- $_job_name := join "-" (list $_job_name_prefix $_job_hash )}}
 
@@ -82,7 +82,7 @@ spec:
     spec:
       containers:
         - name: suite-certs-role-run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
 
           env:

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
@@ -6,10 +6,10 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 {{- $_job_name_prefix := "ibm-suite-dns" }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
@@ -29,11 +29,11 @@ Included in $_job_hash (see below).
 {{- $_job_version := "v3" }}
 
 {{- /*
-10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_tag
+10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_digest
 This is to ensure ArgoCD will create a new job resource intead of attempting (and failing) to update an
 immutable field of any existing Job resource.
 */}}
-{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_tag $_job_version | adler32sum }}
+{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_digest $_job_version | adler32sum }}
 
 {{- $_job_name := join "-" (list $_job_name_prefix $_job_hash )}}
 
@@ -82,7 +82,7 @@ spec:
     spec:
       containers:
         - name: suite-dns-role-run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
 
           env:

--- a/instance-applications/010-ibm-sync-jobs/templates/PostDelete-aws-docdb-remove-user_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/PostDelete-aws-docdb-remove-user_Job.yaml
@@ -3,9 +3,9 @@
 
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 
 # Deletes user "masinst_${MAS_INSTANCE_ID}" from docdb an deletes the acc/cluster/instance/mongo#password secret from AWS SM
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
         - name: aws-docdb-process-user
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           env:
 

--- a/instance-applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
+++ b/instance-applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
@@ -6,10 +6,10 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 {{- $_job_name_prefix := "postsync-ibm-sls-update-sm-job" }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
@@ -29,11 +29,11 @@ Included in $_job_hash (see below).
 {{- $_job_version := "v3" }}
 
 {{- /*
-10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_tag
+10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_digest
 This is to ensure ArgoCD will create a new job resource intead of attempting (and failing) to update an
 immutable field of any existing Job resource.
 */}}
-{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_tag $_job_version | adler32sum }}
+{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_digest $_job_version | adler32sum }}
 
 {{- $_job_name := join "-" (list $_job_name_prefix $_job_hash )}}
 
@@ -191,7 +191,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_prereqs_ops.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_prereqs_ops.yaml
@@ -4,10 +4,10 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 {{- $_job_name_prefix := "patch-common-service-job" }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
@@ -27,11 +27,11 @@ Included in $_job_hash (see below).
 {{- $_job_version := "v2" }}
 
 {{- /*
-10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_tag
+10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_digest
 This is to ensure ArgoCD will create a new job resource intead of attempting (and failing) to update an
 immutable field of any existing Job resource.
 */}}
-{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_tag $_job_version | adler32sum }}
+{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_digest $_job_version | adler32sum }}
 
 {{- $_job_name := join "-" (list $_job_name_prefix $_job_hash )}}
 
@@ -146,7 +146,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_upg_cleanup.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_upg_cleanup.yaml
@@ -4,10 +4,10 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 {{- $_job_name_prefix := "cpd-upg-cleanup" }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
@@ -27,11 +27,11 @@ Included in $_job_hash (see below).
 {{- $_job_version := "v2" }}
 
 {{- /*
-10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_tag
+10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_digest
 This is to ensure ArgoCD will create a new job resource intead of attempting (and failing) to update an
 immutable field of any existing Job resource.
 */}}
-{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_tag $_job_version | adler32sum }}
+{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_digest $_job_version | adler32sum }}
 
 {{- $_job_name := join "-" (list $_job_name_prefix $_job_hash )}}
 
@@ -84,7 +84,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/110-ibm-cp4d/templates/03-ibm-cp4d-mcs_patch_sa.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/03-ibm-cp4d-mcs_patch_sa.yaml
@@ -11,10 +11,10 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 {{- $_job_name_prefix := "cpd-mcs-sa-patch-job" }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
@@ -34,11 +34,11 @@ Included in $_job_hash (see below).
 {{- $_job_version := "v2" }}
 
 {{- /*
-10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_tag
+10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_digest
 This is to ensure ArgoCD will create a new job resource intead of attempting (and failing) to update an
 immutable field of any existing Job resource.
 */}}
-{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_tag $_job_version | adler32sum }}
+{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_digest $_job_version | adler32sum }}
 
 {{- $_job_name := join "-" (list $_job_name_prefix $_job_hash )}}
 
@@ -85,7 +85,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_patch_zenservice.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_patch_zenservice.yaml
@@ -5,10 +5,10 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 {{- $_job_name_prefix := "cpd-patch-zenservices" }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
@@ -28,11 +28,11 @@ Included in $_job_hash (see below).
 {{- $_job_version := "v5" }}
 
 {{- /*
-10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_tag
+10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_digest
 This is to ensure ArgoCD will create a new job resource intead of attempting (and failing) to update an
 immutable field of any existing Job resource.
 */}}
-{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_tag $_job_version | adler32sum }}
+{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_digest $_job_version | adler32sum }}
 
 {{- $_job_name := join "-" (list $_job_name_prefix $_job_hash )}}
 
@@ -80,7 +80,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/110-ibm-cp4d/templates/08-ibm-cp4d-post-verify.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/08-ibm-cp4d-post-verify.yaml
@@ -4,10 +4,10 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 {{- $_job_name_prefix := "cpd-post-verify-job" }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
@@ -27,11 +27,11 @@ Included in $_job_hash (see below).
 {{- $_job_version := "v2" }}
 
 {{- /*
-10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_tag
+10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_digest
 This is to ensure ArgoCD will create a new job resource intead of attempting (and failing) to update an
 immutable field of any existing Job resource.
 */}}
-{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_tag $_job_version | adler32sum }}
+{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_digest $_job_version | adler32sum }}
 
 {{- $_job_name := join "-" (list $_job_name_prefix $_job_hash )}}
 
@@ -78,7 +78,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
@@ -4,10 +4,10 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 {{- $_job_name_prefix := "cpd-base-sa-patch-job" }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
@@ -27,11 +27,11 @@ Included in $_job_hash (see below).
 {{- $_job_version := "v2" }}
 
 {{- /*
-10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_tag
+10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_digest
 This is to ensure ArgoCD will create a new job resource intead of attempting (and failing) to update an
 immutable field of any existing Job resource.
 */}}
-{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_tag $_job_version | adler32sum }}
+{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_digest $_job_version | adler32sum }}
 
 {{- $_job_name := join "-" (list $_job_name_prefix $_job_hash )}}
 
@@ -79,7 +79,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/120-ibm-db2u-database/templates/00-presync-await-crd_Job.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/00-presync-await-crd_Job.yaml
@@ -1,7 +1,7 @@
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 ---
 # Service account that is authorized to read k8s secrets (needed by the job)
@@ -85,7 +85,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/120-ibm-db2u-database/templates/04-db2u-Backup_Cron.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/04-db2u-Backup_Cron.yaml
@@ -1,9 +1,9 @@
 {{- if and .Values.db2_backup_bucket_name (not (contains "sdb" .Values.db2_instance_name)) }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 #apiVersion: batch/v1beta1
 kind: CronJob
@@ -27,7 +27,7 @@ spec:
         spec:
           containers:
             - name: "db2-backup-job-v1-{{ .Values.db2_instance_name }}"
-              image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+              image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
               command:
                 - oc
                 - rsh

--- a/instance-applications/120-ibm-db2u-database/templates/07-postsync-setup-db2_Job.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/07-postsync-setup-db2_Job.yaml
@@ -6,10 +6,10 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 {{- $_job_name_prefix := "postsync-setup-db2" }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
@@ -29,11 +29,11 @@ Included in $_job_hash (see below).
 {{- $_job_version := "v10" }}
 
 {{- /*
-10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_tag
+10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_digest
 This is to ensure ArgoCD will create a new job resource intead of attempting (and failing) to update an
 immutable field of any existing Job resource.
 */}}
-{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_tag $_job_version | adler32sum }}
+{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_digest $_job_version | adler32sum }}
 
 {{- $_job_name := join "-" (list $_job_name_prefix $_job_hash )}}
 
@@ -186,7 +186,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -7,10 +7,10 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 {{- $_job_name_prefix := "postsync-setup-hadr" }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
@@ -30,11 +30,11 @@ Included in $_job_hash (see below).
 {{- $_job_version := "v4" }}
 
 {{- /*
-10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_tag
+10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_digest
 This is to ensure ArgoCD will create a new job resource intead of attempting (and failing) to update an
 immutable field of any existing Job resource.
 */}}
-{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_tag $_job_version | adler32sum }}
+{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_digest $_job_version | adler32sum }}
 
 {{- $_job_name := join "-" (list $_job_name_prefix $_job_hash )}}
 
@@ -161,7 +161,7 @@ spec:
       serviceAccountName: "postsync-hadr-sa-{{ .Values.db2_instance_name }}"
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/120-ibm-spark/templates/02-ibm-spark-control-plane.yaml
+++ b/instance-applications/120-ibm-spark/templates/02-ibm-spark-control-plane.yaml
@@ -4,10 +4,10 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 {{- $_job_name_prefix := "spark-control-plane-patch" }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
@@ -27,11 +27,11 @@ Included in $_job_hash (see below).
 {{- $_job_version := "v2" }}
 
 {{- /*
-10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_tag
+10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_digest
 This is to ensure ArgoCD will create a new job resource intead of attempting (and failing) to update an
 immutable field of any existing Job resource.
 */}}
-{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_tag $_job_version | adler32sum }}
+{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_digest $_job_version | adler32sum }}
 
 {{- $_job_name := join "-" (list $_job_name_prefix $_job_hash )}}
 
@@ -131,7 +131,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/120-ibm-spss/templates/02-ibm-spss-post-verify.yaml
+++ b/instance-applications/120-ibm-spss/templates/02-ibm-spss-post-verify.yaml
@@ -4,10 +4,10 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 {{- $_job_name_prefix := "cpd-spss-post-verify-job" }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
@@ -27,11 +27,11 @@ Included in $_job_hash (see below).
 {{- $_job_version := "v2" }}
 
 {{- /*
-10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_tag
+10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_digest
 This is to ensure ArgoCD will create a new job resource intead of attempting (and failing) to update an
 immutable field of any existing Job resource.
 */}}
-{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_tag $_job_version | adler32sum }}
+{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_digest $_job_version | adler32sum }}
 
 {{- $_job_name := join "-" (list $_job_name_prefix $_job_hash )}}
 
@@ -167,7 +167,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/120-ibm-wsl/templates/02-ibm-wsl-post-verify.yaml
+++ b/instance-applications/120-ibm-wsl/templates/02-ibm-wsl-post-verify.yaml
@@ -4,10 +4,10 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 {{- $_job_name_prefix := "cpd-wsl-post-verify" }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
@@ -27,11 +27,11 @@ Included in $_job_hash (see below).
 {{- $_job_version := "v3" }}
 
 {{- /*
-10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_tag
+10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_digest
 This is to ensure ArgoCD will create a new job resource intead of attempting (and failing) to update an
 immutable field of any existing Job resource.
 */}}
-{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_tag $_job_version | adler32sum }}
+{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_digest $_job_version | adler32sum }}
 
 {{- $_job_name := join "-" (list $_job_name_prefix $_job_hash )}}
 
@@ -151,7 +151,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/130-ibm-jdbc-config/templates/00-presync-create-db2-user_Job.yaml
+++ b/instance-applications/130-ibm-jdbc-config/templates/00-presync-create-db2-user_Job.yaml
@@ -1,9 +1,9 @@
 {{- if eq .Values.jdbc_type "incluster-db2" }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{ $ns := printf "mas-%s-core" .Values.instance_id }}
 {{ $prefix := printf "pre-jdbc-usr-%s" .Values.mas_config_name }}
@@ -170,7 +170,7 @@ spec:
         - name: run
           # TODO: use a dedicated image with a smaller footprint for this sort of thing?
           # Just using cli for now since it has all the deps we need to talk with AWS SM
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/130-ibm-jdbc-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-jdbc-config/templates/postdelete-delete-cr.yaml
@@ -1,9 +1,9 @@
 {{- if .Values.use_postdelete_hooks }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{ $cr_name := .Values.mas_config_name }}
 {{ $cr_kind := .Values.mas_config_kind }}
@@ -45,7 +45,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/130-ibm-jdbc-config/templates/postdelete-delete-db2-user_Job.yaml
+++ b/instance-applications/130-ibm-jdbc-config/templates/postdelete-delete-db2-user_Job.yaml
@@ -1,9 +1,9 @@
 {{- if and ( eq .Values.jdbc_type "incluster-db2" ) ( .Values.use_postdelete_hooks ) }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{ $ns := printf "mas-%s-syncres" .Values.instance_id }}
 {{ $prefix := printf "post-jdbc-usr-%s" .Values.mas_config_name }}
@@ -35,7 +35,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/130-ibm-kafka-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-kafka-config/templates/postdelete-delete-cr.yaml
@@ -16,9 +16,9 @@
 {{ $ns := printf "mas-%s-core" .Values.instance_id }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 ---
 apiVersion: batch/v1
@@ -46,7 +46,7 @@ spec:
         - name: run
           # TODO: use a dedicated image with a smaller footprint for this sort of thing?
           # Just using cli for now since it has all the deps we need to talk with AWS SM
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/130-ibm-mas-bas-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-mas-bas-config/templates/postdelete-delete-cr.yaml
@@ -1,9 +1,9 @@
 {{- if .Values.use_postdelete_hooks }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{ $cr_name := .Values.mas_config_name }}
 {{ $cr_kind := .Values.mas_config_kind }}
@@ -47,7 +47,7 @@ spec:
         - name: run
           # TODO: use a dedicated image with a smaller footprint for this sort of thing?
           # Just using cli for now since it has all the deps we need to talk with AWS SM
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/130-ibm-mas-idp-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-mas-idp-config/templates/postdelete-delete-cr.yaml
@@ -1,9 +1,9 @@
 {{- if .Values.use_postdelete_hooks }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{ $cr_name := .Values.mas_config_name }}
 {{ $cr_kind := .Values.mas_config_kind }}
@@ -47,7 +47,7 @@ spec:
         - name: run
           # TODO: use a dedicated image with a smaller footprint for this sort of thing?
           # Just using cli for now since it has all the deps we need to talk with AWS SM
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/130-ibm-mas-mongo-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-mas-mongo-config/templates/postdelete-delete-cr.yaml
@@ -1,9 +1,9 @@
 {{- if .Values.use_postdelete_hooks }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{ $cr_name := .Values.mas_config_name }}
 {{ $cr_kind := .Values.mas_config_kind }}
@@ -47,7 +47,7 @@ spec:
         - name: run
           # TODO: use a dedicated image with a smaller footprint for this sort of thing?
           # Just using cli for now since it has all the deps we need to talk with AWS SM
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/130-ibm-mas-sls-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-mas-sls-config/templates/postdelete-delete-cr.yaml
@@ -1,9 +1,9 @@
 {{- if .Values.use_postdelete_hooks }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{ $cr_name := .Values.mas_config_name }}
 {{ $cr_kind := .Values.mas_config_kind }}
@@ -47,7 +47,7 @@ spec:
         - name: run
           # TODO: use a dedicated image with a smaller footprint for this sort of thing?
           # Just using cli for now since it has all the deps we need to talk with AWS SM
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/130-ibm-mas-smtp-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-mas-smtp-config/templates/postdelete-delete-cr.yaml
@@ -1,9 +1,9 @@
 {{- if .Values.use_postdelete_hooks }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{ $cr_name := .Values.mas_config_name }}
 {{ $cr_kind := .Values.mas_config_kind }}
@@ -47,7 +47,7 @@ spec:
         - name: run
           # TODO: use a dedicated image with a smaller footprint for this sort of thing?
           # Just using cli for now since it has all the deps we need to talk with AWS SM
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -11,10 +11,10 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
@@ -34,11 +34,11 @@ Included in $_job_hash (see below).
 {{- $_job_version := "v3" }}
 
 {{- /*
-10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_tag
+10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_digest
 This is to ensure ArgoCD will create a new job resource intead of attempting (and failing) to update an
 immutable field of any existing Job resource.
 */}}
-{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_tag $_job_version | adler32sum }}
+{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_digest $_job_version | adler32sum }}
 
 {{- $_job_name := join "-" (list $_job_name_prefix $_job_hash )}}
 
@@ -174,7 +174,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/130-ibm-mas-suite/templates/06-postsync-configtool-oidc.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/06-postsync-configtool-oidc.yaml
@@ -4,10 +4,10 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 {{- $_job_name_prefix := "postsync-configtool-oidc-job" }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
@@ -27,11 +27,11 @@ Included in $_job_hash (see below).
 {{- $_job_version := "v9" }}
 
 {{- /*
-10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_tag
+10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_digest
 This is to ensure ArgoCD will create a new job resource intead of attempting (and failing) to update an
 immutable field of any existing Job resource.
 */}}
-{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_tag $_job_version | adler32sum }}
+{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_digest $_job_version | adler32sum }}
 
 {{- $_job_name := join "-" (list $_job_name_prefix $_job_hash )}}
 
@@ -161,7 +161,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/130-ibm-objectstorage-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-objectstorage-config/templates/postdelete-delete-cr.yaml
@@ -1,9 +1,9 @@
 {{- if .Values.use_postdelete_hooks }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{ $cr_name := .Values.mas_config_name }}
 {{ $cr_kind := .Values.mas_config_kind }}
@@ -47,7 +47,7 @@ spec:
         - name: run
           # TODO: use a dedicated image with a smaller footprint for this sort of thing?
           # Just using cli for now since it has all the deps we need to talk with AWS SM
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/220-ibm-mas-workspace/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/220-ibm-mas-workspace/templates/05-postsync-add-label_Job.yaml
@@ -6,9 +6,9 @@
 {{ $job_label :=  "mas-ws-route-patch" }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 ---
 # Permit outbound communication by the Job pods
@@ -132,7 +132,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/500-540-ibm-mas-suite-app-install/templates/00-presync-add-mvi-scc_Job.yaml
+++ b/instance-applications/500-540-ibm-mas-suite-app-install/templates/00-presync-add-mvi-scc_Job.yaml
@@ -2,9 +2,9 @@
  {{- if eq .Values.mas_app_id "visualinspection" }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 
 {{ $ns := .Values.mas_app_namespace }}
@@ -105,7 +105,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/500-540-ibm-mas-suite-app-install/templates/06-postsync-add-mvi-scc_Job.yaml
+++ b/instance-applications/500-540-ibm-mas-suite-app-install/templates/06-postsync-add-mvi-scc_Job.yaml
@@ -2,9 +2,9 @@
 {{- if eq .Values.mas_app_id "visualinspection" }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 
 {{ $ns := .Values.mas_app_namespace }}
@@ -105,7 +105,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/02-ibm-manage-update_Job.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/02-ibm-manage-update_Job.yaml
@@ -3,9 +3,9 @@
 {{- if (eq .Values.mas_appws_spec.settings.db.upgrade.upgradeType "onlineUpgrade") }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{ $ns        :=  .Values.mas_app_namespace }}
 {{ $prefix := printf "%s-manage-update" .Values.mas_workspace_id}}
@@ -129,7 +129,7 @@ spec:
         spec:
           containers:
             - name: run
-              image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+              image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
               imagePullPolicy: IfNotPresent
               resources:
                 limits:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
@@ -4,9 +4,9 @@
 {{- if (eq (toString .Values.ingress) "true") }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{ $ns        :=  .Values.mas_app_namespace }}
 {{ $job_label :=  "mas-app-route-patch" }}
@@ -142,7 +142,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-sanity.yaml
@@ -2,9 +2,9 @@
 
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 # A sanity test is one that can be disruptive i.e. it can create new users, call authenticated apis, creates resources 
 # in the application. This type of test should only be run in a downstream environment such as a dev or staging env
@@ -1044,7 +1044,7 @@ spec:
       imagePullSecrets: []
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -1,9 +1,9 @@
 {{- if eq .Values.mas_app_id "manage" }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 # A verify test is one that is non disruptive i.e. it won't create new users, i won't call authenticated apis, and it won't creates resources 
 # in the application. This type of test is run on every environment and allows a layer of verification of the app
@@ -271,7 +271,7 @@ spec:
       imagePullSecrets: []
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-maximoit-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-maximoit-sanity.yaml
@@ -3,9 +3,9 @@
 
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 # A sanity test is one that can be disruptive i.e. it can create new users, call authenticated apis, creates resources 
 # in the application. This type of test should only be run in a downstream environment such as a dev or staging env
@@ -1845,7 +1845,7 @@ spec:
       imagePullSecrets: []
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-maximoit-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-maximoit-verify.yaml
@@ -2,9 +2,9 @@
 {{- if and (.Values.mas_appws_spec.components) (.Values.mas_appws_spec.components.icd) }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 # A verify test is one that is non disruptive i.e. it won't create new users, i won't call authenticated apis, and it won't creates resources 
 # in the application. This type of test is run on every environment and allows a layer of verification of the app
@@ -444,7 +444,7 @@ spec:
       imagePullSecrets: []
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-sanity.yaml
@@ -1,9 +1,9 @@
 {{- if and (eq .Values.mas_app_id "visualinspection") (.Values.run_sanity_test) }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{ $ns               :=  .Values.mas_app_namespace }}
 {{ $np_name          :=  "postsync-sanity-mvi-np" }}
@@ -531,7 +531,7 @@ spec:
       imagePullSecrets: []
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-verify.yaml
@@ -2,9 +2,9 @@
 
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 
 {{ $ns               :=  .Values.mas_app_namespace }}
@@ -485,7 +485,7 @@ spec:
       imagePullSecrets: []
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/700-702-postsync-db2-manage.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/700-702-postsync-db2-manage.yaml
@@ -83,10 +83,10 @@ will take care of differentiating the jobs.
 {{- $_job_name_prefix := "postsync-manage-db2-job" }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
@@ -106,11 +106,11 @@ Included in $_job_hash (see below).
 {{- $_job_version := "v3" }}
 
 {{- /*
-10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_tag
+10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_digest
 This is to ensure ArgoCD will create a new job resource intead of attempting (and failing) to update an
 immutable field of any existing Job resource.
 */}}
-{{- $_job_hash := print  ( $_job_config_values  |  toYaml ) $_cli_image_tag  $_job_version  |  adler32sum  }}
+{{- $_job_hash := print  ( $_job_config_values  |  toYaml ) $_cli_image_digest  $_job_version  |  adler32sum  }}
 
 {{- $_job_name := join "-" (list $_job_name_prefix $_job_hash) }}
 
@@ -226,7 +226,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/sub-charts/junitreporter/templates/00-presync-report-starter.yaml
+++ b/sub-charts/junitreporter/templates/00-presync-report-starter.yaml
@@ -1,9 +1,9 @@
 {{- if .Values.devops_mongo_uri }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 
 {{ $prefix := printf "pre-jreporter-%s" .Values.reporter_name }}
@@ -127,7 +127,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: Always
           resources:
             limits:

--- a/sub-charts/junitreporter/templates/10-postsync-report-starter.yaml
+++ b/sub-charts/junitreporter/templates/10-postsync-report-starter.yaml
@@ -1,9 +1,9 @@
 {{- if .Values.devops_mongo_uri }}
 
 {{- /*
-Use the build/bin/set-cli-image-tag.sh script to update this value across all charts.
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_tag := "13.17.0" }}
+{{- $_cli_image_digest := "sha256:e266f8f28150b9e77b98bcee144721176475806dddc1922d84ab47c1b013b826" }}
 
 {{ $preprefix := printf "pre-jreporter-%s" .Values.reporter_name }}
 {{ $time_cm := printf "%s-synctime" $preprefix }}
@@ -127,7 +127,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli:{{ $_cli_image_tag }}
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
           imagePullPolicy: Always
           resources:
             limits:


### PR DESCRIPTION
https://jsw.ibm.com/browse/MASCORE-6592

Also:
 -  updates supporting scripts (set-cli-image-digest.sh and verify-job-definitions.sh) accordingly
  - configured with digest for [13.17.0-amd64](https://github.com/ibm-mas/cli/actions/runs/14512447148/job/40714194561)


# Testing

## Script updates

### `set-cli-image-digests.sh` 
The script was used to apply all of the $_cli_image_digest values in this PR

### `validate-job-definitions.sh`

---------
Correctly picks up cases where:
-   `_cli_image_digest` constant is missing, or its value does not look like a digest (e.g. because a tag is used):
-  When digest is incorrectly referenced by the job template, e.g. (`:` instead of `@`)
- When `$_cli_image_digest` is not included correctly in the `$_job_hash`:


```
build/bin/verify-job-definitions.sh .
Checking all YAML files with quay.io/ibmmas/cli references under directory .
---------
./instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml:
    Missing {{- $_cli_image_digest := "..." }} or assigned value does not look like valid digest
    Invalid CLI image digest found: ":{{ $_cli_image_digest }}" (should be "@{{ $_cli_image_digest }}")
    Invalid $_job_hash value found: "print ($_job_config_values | toYaml) $_cli_image_tag $_job_version | adler32sum " (should be "print ($_job_config_values | toYaml) $_cli_image_digest $_job_version | adler32sum")


Complete
  54 file(s) scanned
     53 valid
     1 invalid
     0 skipped

Invalid files were found, please consult logs above for details
```


## Deployment in Fyre

New versions of all Jobs are created that use digest instead of tag:

![image](https://github.com/user-attachments/assets/6288c819-cefc-4c95-8155-aabeec87352a)

all Jobs reran sucessfully. Cluster and instance apps remain healthy:

![image](https://github.com/user-attachments/assets/8f5e67e2-1158-479f-a662-55b55e854d82)

![image](https://github.com/user-attachments/assets/4262a2a6-6623-4808-975f-590a5c0dfd94)


