### PR TITLE
[patch] Update the name of the mvi test records

### DIFF
--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-sanity.yaml
@@ -11,7 +11,7 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 {{ $sa_name          :=  "postsync-sanity-mvi-sa" }}
 {{ $rb_name          :=  "postsync-sanity-mvi-rb" }}
 {{ $tests_cm_name    :=  "postsync-sanity-tests-mvi-cm" }}
-{{ $record_cm_name   :=  "postsync-sanity-tests-mvi-record-cm" }}
+{{ $record_cm_name   :=  "postsync-sanity-tests-visualinspection-record-cm" }}
 {{ $job_name         :=  "postsync-sanity-mvi-job" }}
 
 

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-verify.yaml
@@ -15,7 +15,7 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 {{ $rb_name          :=  "postsync-verify-mvi-rb" }}
 {{ $crb_name         :=  "postsync-verify-mvi-crb" }}
 {{ $tests_cm_name    :=  "postsync-verify-tests-mvi-cm" }}
-{{ $record_cm_name   :=  "postsync-verify-tests-mvi-record-cm" }}
+{{ $record_cm_name   :=  "postsync-verify-tests-visualinspection-record-cm" }}
 {{ $job_name         :=  "postsync-verify-mvi-job" }}
 
 


### PR DESCRIPTION
The test records should contain the applicationid rather than a shorten version of it so that the FVT test can see it.

See https://jsw.ibm.com/browse/MASMVI-2285