### PR TITLE
[patch] fix automated initial user creation when Manage is not installed

### DIFF
--- a/instance-applications/600-ibm-post-sync-jobs/templates/001-ibm-create-initial-users.yaml
+++ b/instance-applications/600-ibm-post-sync-jobs/templates/001-ibm-create-initial-users.yaml
@@ -53,8 +53,7 @@ $_job_cleanup_group can usually just be based on $_job_name_prefix. There are so
 where multiple Jobs are created in our templates using a Helm loop. In those cases, additional descriminators
 must be added to $_job_cleanup_group.
 
-By convention, we sha1sum this value to guarantee we never exceed the 63 char limit regardless of which discriminatorstest python-devops bui
-are required here.
+By convention, we sha1sum this value to guarantee we never exceed the 63 char limit regardless of which discriminators are required here.
 
 */}}
 {{- $_job_cleanup_group := cat $_job_name_prefix | sha1sum }}
@@ -184,6 +183,12 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 
 
+{{- /*
+mas-devops-create-initial-users-for-saas script run by the Job requires access to the xxx-internal-manage-tls
+secret in the manage namespace so it can create an API Key for the MAXADMIN user
+Since these roles must be created in the manage namespace, we only attempt to create them if Manage is actually installed.
+*/}}
+{{- if .Values.manage_is_installed }}
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -224,7 +229,7 @@ roleRef:
   kind: Role
   name: {{ $role_manage_name }}
   apiGroup: rbac.authorization.k8s.io
-
+{{- end }}
 
 ---
 apiVersion: batch/v1

--- a/root-applications/ibm-mas-instance-root/templates/600-ibm-post-sync-jobs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/600-ibm-post-sync-jobs.yaml
@@ -59,11 +59,7 @@ spec:
             {{- end }}
 
             mas_is_active: {{ $mas_is_active }}
-
-
-            {{- if not (empty .Values.ibm_suite_app_manage_install) }}
-            manage_is_installed: true
-            {{- endif }}
+            manage_is_installed: {{ not (empty .Values.ibm_suite_app_manage_install) }}
 
             {{- if .Values.custom_labels }}
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}

--- a/root-applications/ibm-mas-instance-root/templates/600-ibm-post-sync-jobs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/600-ibm-post-sync-jobs.yaml
@@ -60,6 +60,11 @@ spec:
 
             mas_is_active: {{ $mas_is_active }}
 
+
+            {{- if not (empty .Values.ibm_suite_app_manage_install) }}
+            manage_is_installed: true
+            {{- endif }}
+
             {{- if .Values.custom_labels }}
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}


### PR DESCRIPTION
# Description

After the automated initial user creation feature was merged to `gitops:main`  (https://github.com/ibm-mas/gitops/pull/278) an issue was discovered in fvtsaas where the new `postsyncjobs` ArgoCD application would fail to sync on MAS instances where Manage is not installed (which may be the case <9.1.x) due to the `mas-xxx-manage` namespace not being present.

![image](https://github.com/user-attachments/assets/3df15968-896a-4104-b999-6404e6340f60)

This PR fixes this issue by only creating the Manage-related RBAC resources when Manage is actually installed.


# Testing

## Verified that the `postsyncjobs` application now syncs successfully and functions as expected in a 9.0.x env without Manage

![image](https://github.com/user-attachments/assets/91cea612-750f-461c-ba24-02a963c41740)

![image](https://github.com/user-attachments/assets/fd0118a7-bc5e-4e3c-97ed-5583b18ea090)

![image](https://github.com/user-attachments/assets/897087ab-9455-4af9-98a1-161e65cd911e)


```
Logging into AWS SecretsManager ...
      Name                    Value             Type    Location
      ----                    -----             ----    --------
   profile                <not set>             None    None
access_key     **************** shared-credentials-file
secret_key     **************** shared-credentials-file
    region                us-east-2              env    ['AWS_REGION', 'AWS_DEFAULT_REGION']
2025-05-15 12:57:30,431   root                                               [MainThread] INFO     Configuration:
2025-05-15 12:57:30,431   root                                               [MainThread] INFO     --------------
2025-05-15 12:57:30,431   root                                               [MainThread] INFO     mas_instance_id:           tgk02
2025-05-15 12:57:30,431   root                                               [MainThread] INFO     mas_workspace_id:          masdev
2025-05-15 12:57:30,431   root                                               [MainThread] INFO     initial_users_yaml_file:   None
2025-05-15 12:57:30,431   root                                               [MainThread] INFO     initial_users_secret_name: fyre-dev/noble6/tgk02/initial_users
2025-05-15 12:57:30,431   root                                               [MainThread] INFO     log_level:                 20
2025-05-15 12:57:30,431   root                                               [MainThread] INFO     coreapi_port:              443
2025-05-15 12:57:30,431   root                                               [MainThread] INFO     admin_dashboard_port:      443
2025-05-15 12:57:30,431   root                                               [MainThread] INFO     manage_api_port:           443
2025-05-15 12:57:30,431   root                                               [MainThread] INFO
2025-05-15 12:57:30,650   root                                               [MainThread] INFO     Loading initial_users configuration from secret fyre-dev/noble6/tgk02/initial_users
2025-05-15 12:57:30,664   botocore.credentials                               [MainThread] INFO     Found credentials in shared credentials file: ~/.aws/credentials
2025-05-15 12:57:32,141   mas.devops.users.MASUserUtils                      [MainThread] INFO
2025-05-15 12:57:32,142   mas.devops.users.MASUserUtils                      [MainThread] INFO     Syncing primary user test1@example.com
2025-05-15 12:57:32,246   mas.devops.users.MASUserUtils                      [MainThread] INFO     Creating new user test1@example.com
2025-05-15 12:57:34,255   mas.devops.users.MASUserUtils                      [MainThread] INFO     Linking user test1@example.com to local IDP (email_password: True)
2025-05-15 12:57:35,542   mas.devops.users.MASUserUtils                      [MainThread] INFO     Adding user test1@example.com to masdev (is_workspace_admin: True)
2025-05-15 12:57:36,008   mas.devops.users.MASUserUtils                      [MainThread] INFO     Completed sync of primary user test1@example.com
2025-05-15 12:57:36,008   mas.devops.users.MASUserUtils                      [MainThread] INFO
2025-05-15 12:57:36,008   mas.devops.users.MASUserUtils                      [MainThread] INFO
2025-05-15 12:57:36,008   mas.devops.users.MASUserUtils                      [MainThread] INFO     Syncing secondary user test2@example.com
2025-05-15 12:57:36,867   mas.devops.users.MASUserUtils                      [MainThread] INFO     Creating new user test2@example.com
2025-05-15 12:57:39,011   mas.devops.users.MASUserUtils                      [MainThread] INFO     Linking user test2@example.com to local IDP (email_password: True)
2025-05-15 12:57:39,673   mas.devops.users.MASUserUtils                      [MainThread] INFO     Adding user test2@example.com to masdev (is_workspace_admin: False)
2025-05-15 12:57:40,092   mas.devops.users.MASUserUtils                      [MainThread] INFO     Completed sync of secondary user test2@example.com
2025-05-15 12:57:40,092   mas.devops.users.MASUserUtils                      [MainThread] INFO
2025-05-15 12:57:40,092   root                                               [MainThread] INFO     Removing synced user test1@example.com from fyre-dev/noble6/tgk02/initial_users secret
2025-05-15 12:57:40,092   root                                               [MainThread] INFO     Removing synced user test2@example.com from fyre-dev/noble6/tgk02/initial_users secret
2025-05-15 12:57:40,092   root                                               [MainThread] INFO     Updating secret fyre-dev/noble6/tgk02/initial_users
```



## Verified that the `postsyncjobs` application still functions as expected (Manage RBAC resources created) in envs that do have Manage:

![image](https://github.com/user-attachments/assets/029c8ac2-4773-4f92-bf26-9ac4ab0984de)

![image](https://github.com/user-attachments/assets/fb2d3847-0a83-45db-ae49-9268cf8b2632)
