### PR TITLE
[patch] Add smtpcfg certs to gitops

### DIFF
--- a/instance-applications/130-ibm-mas-smtp-config/templates/02-ibm-mas_SmtpCfg.yaml
+++ b/instance-applications/130-ibm-mas-smtp-config/templates/02-ibm-mas_SmtpCfg.yaml
@@ -15,6 +15,9 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   displayName: "{{ .Values.suite_smtp_display_name }}"
+  # certificates:
+  #   alias: #A human-readable alias for the certificate. Must be unique wrt the other aliases in this request.
+  #   crt: #A SINGLE PEM-formatted certificate.
 {{- if not (empty .Values.mas_smtpcfg_pod_templates) }}
   podTemplates:
 {{ .Values.mas_smtpcfg_pod_templates | toYaml | indent 4 }}
@@ -33,4 +36,14 @@ spec:
 {{- if .Values.suite_smtp_disabled_templates }}
     disabledTemplates:
       {{ .Values.suite_smtp_disabled_templates | toYaml | nindent 6 }}
+{{- end }}
+{{ -if not (empty .Values.smtp_config_ca_certificate) }}
+  certificates:
+    - alias: smtpca
+{{ .Values.smtp_config_ca_certificate | toYaml | indent 6 }}
+# list of certificate according to CR definition. So we should accept list of certificates
+#     certificates:
+# {{  .Values.smtp_config_certificates | toYaml | indent 4 }}
+#     - alias: smptpca
+# {{ .Values.smtp_config_certificate | toYaml | indent 6 }}
 {{- end }}

--- a/instance-applications/130-ibm-mas-smtp-config/templates/02-ibm-mas_SmtpCfg.yaml
+++ b/instance-applications/130-ibm-mas-smtp-config/templates/02-ibm-mas_SmtpCfg.yaml
@@ -37,7 +37,7 @@ spec:
     disabledTemplates:
       {{ .Values.suite_smtp_disabled_templates | toYaml | nindent 6 }}
 {{- end }}
-{{ -if not (empty .Values.smtp_config_ca_certificate) }}
+{{- if not (empty .Values.smtp_config_ca_certificate) }}
   certificates:
     - alias: smtpca
 {{ .Values.smtp_config_ca_certificate | toYaml | indent 6 }}

--- a/instance-applications/130-ibm-mas-smtp-config/templates/02-ibm-mas_SmtpCfg.yaml
+++ b/instance-applications/130-ibm-mas-smtp-config/templates/02-ibm-mas_SmtpCfg.yaml
@@ -15,9 +15,6 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   displayName: "{{ .Values.suite_smtp_display_name }}"
-  # certificates:
-  #   alias: #A human-readable alias for the certificate. Must be unique wrt the other aliases in this request.
-  #   crt: #A SINGLE PEM-formatted certificate.
 {{- if not (empty .Values.mas_smtpcfg_pod_templates) }}
   podTemplates:
 {{ .Values.mas_smtpcfg_pod_templates | toYaml | indent 4 }}
@@ -41,9 +38,4 @@ spec:
   certificates:
     - alias: smtpca
 {{ .Values.smtp_config_ca_certificate | toYaml | indent 6 }}
-# list of certificate according to CR definition. So we should accept list of certificates
-#     certificates:
-# {{  .Values.smtp_config_certificates | toYaml | indent 4 }}
-#     - alias: smptpca
-# {{ .Values.smtp_config_certificate | toYaml | indent 6 }}
 {{- end }}


### PR DESCRIPTION
Issue: [MASCORE-6185](https://jsw.ibm.com/browse/MASCORE-6185)
## Description
Provision to support for optional CA certificate for smtpcfg CR

## Testing
Tested in noble4
<img width="673" alt="Screenshot 2025-05-22 at 1 31 22 PM" src="https://github.com/user-attachments/assets/a7e37cf7-1f03-4a20-8109-8d50299cc353" />
