### PR TITLE
[minor] Allow suite_dns job to create edge certs per function

### DIFF
--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
@@ -82,8 +82,8 @@ spec:
     spec:
       containers:
         - name: suite-dns-role-run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
-          imagePullPolicy: IfNotPresent
+          image: quay.io/ibmmas/cli:13.25.0-pre.ajw-mascore6943
+          imagePullPolicy: Always
 
           env:
             - name: ACCOUNT_ID

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
@@ -135,6 +135,8 @@ spec:
               value: "{{ .Values.delete_wildcards }}"
             - name: OVERRIDE_EDGE_CERTS
               value: "{{ .Values.override_edge_certs }}"
+            - name: CIS_ENTRIES_TO_ADD
+              value: "{{ .Values.cis_entries_to_add }}"
 
             - name: SM_AWS_REGION
               value: "{{ .Values.sm_aws_region }}"
@@ -191,6 +193,7 @@ spec:
               echo "update DNS entries Flag ............. ${COLOR_MAGENTA}${UPDATE_DNS_ENTRIES}"
               echo "DELETE_WILDCARDS Flag ............... ${COLOR_MAGENTA}${DELETE_WILDCARDS}"
               echo "OVERRIDE_EDGE_CERTS Flag ............ ${COLOR_MAGENTA}${OVERRIDE_EDGE_CERTS}"
+              echo "CIS_ENTRIES_TO_ADD  ................. ${COLOR_MAGENTA}${CIS_ENTRIES_TO_ADD}"
 
               echo "OCP_INGRESS  ........................ ${COLOR_MAGENTA}${OCP_INGRESS}"
               echo "SM_AWS_REGION ....................... ${COLOR_MAGENTA}${SM_AWS_REGION}"
@@ -207,9 +210,6 @@ spec:
               else
                 export MAS_MANUAL_CERT_MGMT=False
               fi
-
-
-              export SAAS_MODE=True
 
               # Ref - https://github.com/ibm-mas/ansible-devops/blob/master/ibm/mas_devops/roles/suite_dns/README.md
               export ROLE_NAME=suite_dns

--- a/root-applications/ibm-mas-instance-root/templates/010-ibm-sync-jobs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/010-ibm-sync-jobs.yaml
@@ -74,6 +74,39 @@ spec:
             cis_proxy: "{{ .Values.ibm_mas_suite.cis_proxy }}"
             cis_service_name: "{{ .Values.ibm_mas_suite.cis_service_name }}"
 
+            {{- $health := .Values.ibm_suite_app_health_install -}}
+            {{- $iot := .Values.ibm_suite_app_iot_install -}}
+            {{- $core := .Values.ibm_mas_suite -}}
+            {{- $manage := .Values.ibm_suite_app_manage_install -}}
+            {{- $monitor := .Values.ibm_suite_app_monitor_install -}}
+            {{- $predict := .Values.ibm_suite_app_predict_install -}}
+            {{- $visualinspection := .Values.ibm_suite_app_visualinspection_install -}}
+            {{- $optimizer := .Values.ibm_suite_app_optimizer_install -}}
+            {{- $facilities := .Values.ibm_suite_app_facilities_install -}}
+
+            {{- $health_str := printf "%s" (default "" $health) -}}
+            {{- $iot_str := printf "%s" (default "" $iot) -}}
+            {{- $core_str := printf "%s" (default "" $core) -}}
+            {{- $manage_str := printf "%s" (default "" $manage) -}}
+            {{- $monitor_str := printf "%s" (default "" $monitor) -}}
+            {{- $predict_str := printf "%s" (default "" $predict) -}}
+            {{- $visualinspection_str := printf "%s" (default "" $visualinspection) -}}
+            {{- $optimizer_str := printf "%s" (default "" $optimizer) -}}
+            {{- $facilities_str := printf "%s" (default "" $facilities) -}}
+
+            {{- $health_comma_separated := printf "%s" (if (gt (len $health_str) 0) "health") -}}
+            {{- $iot_comma_separated := printf "%s" (if (gt (len $iot_str) 0) "iot") -}}
+            {{- $core_comma_separated := printf "%s" (if (gt (len $core_str) 0) "core") -}}
+            {{- $manage_comma_separated := printf "%s" (if (gt (len $manage_str) 0) "manage") -}}
+            {{- $reportdb_comma_separated := printf "%s" (if (gt (len $manage_str) 0) "reportdb") -}}
+            {{- $monitor_comma_separated := printf "%s" (if (gt (len $monitor_str) 0) "monitor") -}}
+            {{- $predict_comma_separated := printf "%s" (if (gt (len $predict_str) 0) "predict") -}}
+            {{- $visualinspection_comma_separated := printf "%s" (if (gt (len $visualinspection_str) 0) "visualinspection") -}}
+            {{- $optimizer_comma_separated := printf "%s" (if (gt (len $optimizer_str) 0) "optimizer") -}}
+            {{- $facilities_comma_separated := printf "%s" (if (gt (len $facilities_str) 0) "facilities") -}}
+            
+            {{- $list := list $health_comma_separated $iot_comma_separated $core_comma_separated $manage_comma_separated $reportdb_comma_separated $monitor_comma_separated $predict_comma_separated $visualinspection_comma_separated $optimizer_comma_separated $facilities_comma_separated -}}
+            cis_entries_to_add: {{ printf "%s" (join "," $list) }}
 
             {{- if .Values.override_dns_cis_flags_to_false }}
             update_dns_entries: "false"

--- a/root-applications/ibm-mas-instance-root/templates/010-ibm-sync-jobs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/010-ibm-sync-jobs.yaml
@@ -88,6 +88,7 @@ spec:
             {{- $iot_str := ternary "" "iot" (empty $iot) -}}
             {{- $core_str := ternary "" "core" (empty $core) -}}
             {{- $manage_str := ternary "" "manage" (empty $manage) -}}
+            {{- $reportdb_str := ternary "" "reportdb" (empty $manage) -}}
             {{- $monitor_str := ternary "" "monitor" (empty $monitor) -}}
             {{- $predict_str := ternary "" "predict" (empty $predict) -}}
             {{- $visualinspection_str := ternary "" "visualinspection" (empty $visualinspection) -}}

--- a/root-applications/ibm-mas-instance-root/templates/010-ibm-sync-jobs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/010-ibm-sync-jobs.yaml
@@ -95,8 +95,7 @@ spec:
             {{- $optimizer_str := ternary "" "optimizer" (empty $optimizer) -}}
             {{- $facilities_str := ternary "" "facilities" (empty $facilities) -}}
 
-            
-            {{- $list := list $health_str $iot_str $core_str $manage_str $reportdb_str $monitor_str $predict_str $visualinspection_str $optimizer_str $facilities_str -}}
+            {{- $list := list $health_str $iot_str $core_str $manage_str $reportdb_str $monitor_str $predict_str $visualinspection_str $optimizer_str $facilities_str | compact }}
             cis_entries_to_add: {{ printf "%s" (join "," $list) }}
 
             {{- if .Values.override_dns_cis_flags_to_false }}

--- a/root-applications/ibm-mas-instance-root/templates/010-ibm-sync-jobs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/010-ibm-sync-jobs.yaml
@@ -84,28 +84,18 @@ spec:
             {{- $optimizer := .Values.ibm_suite_app_optimizer_install -}}
             {{- $facilities := .Values.ibm_suite_app_facilities_install -}}
 
-            {{- $health_str := printf "%s" (default "" $health) -}}
-            {{- $iot_str := printf "%s" (default "" $iot) -}}
-            {{- $core_str := printf "%s" (default "" $core) -}}
-            {{- $manage_str := printf "%s" (default "" $manage) -}}
-            {{- $monitor_str := printf "%s" (default "" $monitor) -}}
-            {{- $predict_str := printf "%s" (default "" $predict) -}}
-            {{- $visualinspection_str := printf "%s" (default "" $visualinspection) -}}
-            {{- $optimizer_str := printf "%s" (default "" $optimizer) -}}
-            {{- $facilities_str := printf "%s" (default "" $facilities) -}}
+            {{- $health_str := ternary "" "health" (empty $health) -}}
+            {{- $iot_str := ternary "" "iot" (empty $iot) -}}
+            {{- $core_str := ternary "" "core" (empty $core) -}}
+            {{- $manage_str := ternary "" "manage" (empty $manage) -}}
+            {{- $monitor_str := ternary "" "monitor" (empty $monitor) -}}
+            {{- $predict_str := ternary "" "predict" (empty $predict) -}}
+            {{- $visualinspection_str := ternary "" "visualinspection" (empty $visualinspection) -}}
+            {{- $optimizer_str := ternary "" "optimizer" (empty $optimizer) -}}
+            {{- $facilities_str := ternary "" "facilities" (empty $facilities) -}}
 
-            {{- $health_comma_separated := printf "%s" (if (gt (len $health_str) 0) "health") -}}
-            {{- $iot_comma_separated := printf "%s" (if (gt (len $iot_str) 0) "iot") -}}
-            {{- $core_comma_separated := printf "%s" (if (gt (len $core_str) 0) "core") -}}
-            {{- $manage_comma_separated := printf "%s" (if (gt (len $manage_str) 0) "manage") -}}
-            {{- $reportdb_comma_separated := printf "%s" (if (gt (len $manage_str) 0) "reportdb") -}}
-            {{- $monitor_comma_separated := printf "%s" (if (gt (len $monitor_str) 0) "monitor") -}}
-            {{- $predict_comma_separated := printf "%s" (if (gt (len $predict_str) 0) "predict") -}}
-            {{- $visualinspection_comma_separated := printf "%s" (if (gt (len $visualinspection_str) 0) "visualinspection") -}}
-            {{- $optimizer_comma_separated := printf "%s" (if (gt (len $optimizer_str) 0) "optimizer") -}}
-            {{- $facilities_comma_separated := printf "%s" (if (gt (len $facilities_str) 0) "facilities") -}}
             
-            {{- $list := list $health_comma_separated $iot_comma_separated $core_comma_separated $manage_comma_separated $reportdb_comma_separated $monitor_comma_separated $predict_comma_separated $visualinspection_comma_separated $optimizer_comma_separated $facilities_comma_separated -}}
+            {{- $list := list $health_str $iot_str $core_str $manage_str $reportdb_str $monitor_str $predict_str $visualinspection_str $optimizer_str $facilities_str -}}
             cis_entries_to_add: {{ printf "%s" (join "," $list) }}
 
             {{- if .Values.override_dns_cis_flags_to_false }}


### PR DESCRIPTION
Takes the changes in https://github.com/ibm-mas/ansible-devops/pull/1785 and uses it in gitops. This will automatically set the `cis_entries_to_add` based on the values entries for each app. The testing shown in https://github.com/ibm-mas/ansible-devops/pull/1785 used these changes here.