### PR TITLE
[patch] fix ws_runtime version in olm for cp4d instance

### DIFF
--- a/instance-applications/110-ibm-cp4d/templates/00-ibm-cp4d-olm-513.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/00-ibm-cp4d-olm-513.yaml
@@ -152,10 +152,10 @@ data:
       cr_version: 10.2.0
 
     ws_runtimes:
-      case_version: 10.2.0
-      sub_channel: "v10.2"
-      csv_version: 10.2.0
-      cr_version: 10.2.0
+      case_version: 10.3.0
+      sub_channel: "v10.3"
+      csv_version: 10.3.0
+      cr_version: 10.3.0
 
     db2aaservice:
       case_version: 5.1.2


### PR DESCRIPTION
Change version in olm in cp4d instance from 10.2 to 10.3