### PR TITLE
[patch] Add toleration to instana agent pod

### DIFF
--- a/cluster-applications/055-instana-agent-operator/templates/03-InstanaAgent.yaml
+++ b/cluster-applications/055-instana-agent-operator/templates/03-InstanaAgent.yaml
@@ -27,6 +27,10 @@ spec:
     env:
 {{ .Values.instana_agent_operator_env | toYaml | indent 6 }}
     pod:
+      tolerations:
+        - effect: NoSchedule
+          key: icp4data
+          operator: Exists
       volumeMounts:
         - name: tmp-volume
           mountPath: /tmp


### PR DESCRIPTION
This PR introduces a toleration on the Instana agent that will allow the agent to be deployed on nodes that have a taint with key icp4data frequently used within our saas environments for nodes with exclusively DB2 workload.

Resolves MASCORE-7792

Testing
--------
tainted node with icp4data = xxxxx with NoSchedule.  Then deployed instana and validated that the instana agent was deployed on the node. 
<img width="1122" alt="image" src="https://github.com/user-attachments/assets/38c34069-ad98-4c1f-9c64-96c69b6d88f3" />

Then ensured with the taint that applied to the node that the agent was still deployed.
<img width="653" alt="image" src="https://github.com/user-attachments/assets/63e6c1dd-a6b9-4259-8d87-0ce267c1a5b6" />
