### PR TITLE
[minor] re-add crowdstrike deploy back to mas deploy

### DIFF
--- a/cluster-applications/053-falcon-operator/Chart.yaml
+++ b/cluster-applications/053-falcon-operator/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: falcon-operator
+description: CrowdStrike Falcon Operator
+type: application
+version: 1.0.0
+
+dependencies:
+- name: junitreporter
+  version: 1.0.0
+  repository: "file://../../sub-charts/junitreporter/"
+  condition: junitreporter.devops_mongo_uri != ""

--- a/cluster-applications/053-falcon-operator/README.md
+++ b/cluster-applications/053-falcon-operator/README.md
@@ -1,0 +1,3 @@
+CrowdStrike Falcon Operator
+===============================================================================
+Installs the CrowdStrike Falcon Operator for node monitoring. See https://github.com/CrowdStrike/falcon-operator

--- a/cluster-applications/053-falcon-operator/templates/01-OperatorGroup.yaml
+++ b/cluster-applications/053-falcon-operator/templates/01-OperatorGroup.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: falcon-operator
+  namespace: falcon-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "053"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}

--- a/cluster-applications/053-falcon-operator/templates/02-Subscription.yaml
+++ b/cluster-applications/053-falcon-operator/templates/02-Subscription.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: falcon-operator
+  namespace: falcon-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "053"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+spec:
+  channel: "{{ .Values.falcon_operator_channel }}"
+  installPlanApproval: {{ .Values.falcon_operator_install_plan | default "Automatic" | quote }}
+  name: falcon-operator
+  source: certified-operators
+  sourceNamespace: openshift-marketplace

--- a/cluster-applications/053-falcon-operator/templates/03-FalconNodeSensor.yaml
+++ b/cluster-applications/053-falcon-operator/templates/03-FalconNodeSensor.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: falcon.crowdstrike.com/v1alpha1
+kind: FalconNodeSensor
+metadata:
+  name: falcon-node-sensor
+  namespace: falcon-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "054"
+    argocd.argoproj.io/sync-options: "SkipDryRunOnMissingResource=true,Validate=false"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+spec:
+  falcon_api:
+    client_id: "{{ .Values.falcon_operator_client_id }}"
+    client_secret: "{{ .Values.falcon_operator_client_secret }}"
+    cloud_region: "{{ .Values.falcon_operator_cloud_region }}"
+{{- if .Values.falcon_operator_node_sensor }}
+{{ .Values.falcon_operator_node_sensor | toYaml | indent 2 }}
+{{- end }}

--- a/cluster-applications/053-falcon-operator/values.yaml
+++ b/cluster-applications/053-falcon-operator/values.yaml
@@ -1,0 +1,10 @@
+---
+falcon_operator_channel: certified-1.0
+falcon_operator_cloud_region: autodiscover
+falcon_operator_client_id: xxx
+falcon_operator_client_secret: xxx
+falcon_operator_node_sensor:
+  node:
+    terminationGracePeriod: 30
+  falcon:
+    trace: err

--- a/root-applications/ibm-mas-account-root/templates/000-cluster-appset.yaml
+++ b/root-applications/ibm-mas-account-root/templates/000-cluster-appset.yaml
@@ -86,6 +86,11 @@ spec:
               repoURL: "{{ .Values.generator.repo_url }}"
               revision: "{{ .Values.generator.revision }}"
               files:
+              - path: "{{ .Values.account.id }}/*/falcon-operator.yaml"              
+          - git:
+              repoURL: "{{ .Values.generator.repo_url }}"
+              revision: "{{ .Values.generator.revision }}"
+              files:
               - path: "{{ .Values.account.id }}/*/cluster-logging-operator.yaml"
           - git:
               repoURL: "{{ .Values.generator.repo_url }}"

--- a/root-applications/ibm-mas-cluster-root/templates/053-falcon-operator-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/053-falcon-operator-app.yaml
@@ -1,0 +1,69 @@
+{{- if not (empty .Values.falcon_operator) }}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: falcon-operator.{{ .Values.cluster.id }}
+  namespace: {{ .Values.argo.namespace }}
+  labels:
+    environment: '{{ .Values.account.id }}'
+    region: '{{ .Values.region.id }}'
+    cluster: '{{ .Values.cluster.id }}'
+  annotations:
+    argocd.argoproj.io/sync-wave: "053"
+    healthCheckTimeout: "1800"
+    {{- if and .Values.notifications .Values.notifications.slack_channel_id }}
+    notifications.argoproj.io/subscribe.on-sync-failed.workspace1: {{ .Values.notifications.slack_channel_id }}
+    notifications.argoproj.io/subscribe.on-sync-succeeded.workspace1: {{ .Values.notifications.slack_channel_id }}
+    {{- end }}
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: "{{ .Values.argo.projects.apps }}"
+  destination:
+    server: {{ .Values.cluster.url }}
+    namespace: falcon-operator
+  source:
+    repoURL: "{{ .Values.source.repo_url }}"
+    path: cluster-applications/053-falcon-operator
+    targetRevision: "{{ .Values.source.revision }}"
+    plugin:
+      name: {{ .Values.avp.name }} 
+      env:
+        - name: {{ .Values.avp.values_varname }}
+          value: |
+            falcon_operator_client_id: "{{ .Values.falcon_operator.client_id }}"
+            falcon_operator_client_secret: "{{ .Values.falcon_operator.client_secret }}"
+            falcon_operator_cloud_region: "{{ .Values.falcon_operator.cloud_region }}"
+            falcon_operator_node_sensor: {{ .Values.falcon_operator.node_sensor | toYaml | nindent 14 }}
+            junitreporter:
+              reporter_name: "falcon-operator"
+              cluster_id: "{{ .Values.cluster.id }}"
+              devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
+              devops_build_number: "{{ .Values.devops.build_number }}"
+              gitops_version: "{{ .Values.source.revision }}"
+            {{- if .Values.custom_labels }}
+            custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
+            {{- end }}
+        - name: ARGOCD_APP_NAME
+          value: falconoperatorapp
+        {{- if not (empty .Values.avp.secret) }}
+        - name: AVP_SECRET
+          value: {{ .Values.avp.secret }}
+        {{- end }}
+  syncPolicy:
+    automated:
+      {{- if .Values.auto_delete }}
+      prune: true
+      {{- end }}
+      selfHeal: true
+    retry:
+      limit: 20
+    syncOptions:
+      - CreateNamespace=true
+    managedNamespaceMetadata:
+      labels:
+{{- if .Values.custom_labels }}
+{{ .Values.custom_labels | toYaml | indent 8 }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
This is implementation for MASCORE-7805 - to add crowdstrike deployment back to the gitops pipelines. 

Testing
-------
**Validated the deployment of the CrowdStrike NodeSensor daemonset to the cluster, including nodes that are tainted.**
<img width="726" alt="image" src="https://github.com/user-attachments/assets/cb91a474-24c0-41cb-8b3e-fccbb49ecd8d" />
<img width="1097" alt="image" src="https://github.com/user-attachments/assets/64a37c0f-d586-4812-abeb-dee4936fdfa0" />
<img width="972" alt="image" src="https://github.com/user-attachments/assets/6871a5cb-cd49-44b4-8a9b-dfa3bdc2c69f" />

**Validated that all of the elements of the ArgoApp complete successfully**
<img width="1036" alt="image" src="https://github.com/user-attachments/assets/0aea0eee-e328-45e1-af3c-4394308245d9" />

**Validated the agent registered with IBM CS Portal**
<img width="1261" alt="image" src="https://github.com/user-attachments/assets/020b6209-adee-4934-943d-e2a201b5d7e2" />

**Validated that all containers started successfully **
<img width="990" alt="image" src="https://github.com/user-attachments/assets/fbc8230e-eecf-4d11-895e-2da58a447a4e" />

** Validated successful pipeline execution **
<img width="1287" alt="image" src="https://github.com/user-attachments/assets/9156b9a4-018f-4b5f-9f72-2249eb4e01b7" />
<img width="976" alt="image" src="https://github.com/user-attachments/assets/a4d1665a-be9a-4cf3-b803-05d5f7f3c477" />
<img width="1014" alt="image" src="https://github.com/user-attachments/assets/f25edb04-936b-4a8f-903a-6b8191bd8460" />


