### PR TITLE
[patch] change default nvidia driver for gitops

### DIFF
--- a/cluster-applications/051-nvidia-gpu-operator/values.yaml
+++ b/cluster-applications/051-nvidia-gpu-operator/values.yaml
@@ -1,5 +1,5 @@
 ---
 gpu_namespace: "nvidia-gpu-operator"
 gpu_channel: "v24.3"
-gpu_driver_version: 550.90.07
+gpu_driver_version: 575.57.08
 gpu_driver_repository_path: "nvcr.io/nvidia"


### PR DESCRIPTION
This change is to update nvidia versionndue to below error:
![image](https://github.com/user-attachments/assets/10e42024-0842-4ece-b90b-353430f7878f)
Bug: https://jsw.ibm.com/browse/MASCORE-7846