### PR TITLE
[minor] Patch labels to route always regardless of ingress label

### DIFF
--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -1,9 +1,3 @@
-# .Values.ingress is passed into the suite as a string (even though the original value is a boolean)
-# (see https://github.com/ibm-mas/gitops/blob/d46e6577fc2081e0a5624dddf575cead5310d794/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-app.yaml#L60)
-# This meant the check was passing even when ingress was false (.Values.ingress is considered true when it is the string "false")
-# Rather than change the suite app (and force it to resync in all existing envs), we'll instead fix the check here to look for either boolean true OR the string "true".
-{{- if (eq (toString .Values.ingress) "true") }}
-
 {{- /*
 Meaningful prefix for the job resource name. Must be under 52 chars in length to leave room for the 11 chars reserved for '-' and $_job_hash.
 */}}
@@ -232,6 +226,3 @@ spec:
       restartPolicy: Never
       serviceAccountName: "mas-route-sa"
   backoffLimit: 4
-
-{{- end }}
-

--- a/instance-applications/220-ibm-mas-workspace/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/220-ibm-mas-workspace/templates/05-postsync-add-label_Job.yaml
@@ -1,8 +1,3 @@
-# .Values.ingress is passed into the workspace as a string (even though the original value is a boolean)
-# (see https://github.com/ibm-mas/gitops/blob/d46e6577fc2081e0a5624dddf575cead5310d794/root-applications/ibm-mas-instance-root/templates/200-ibm-mas-workspaces.yaml#L44)
-# This meant the check was passing even when ingress was false (.Values.ingress is considered true when it is the string "false")
-# Rather than change the workspace app (and force it to resync in all existing envs), we'll instead fix the check here to look for either boolean true OR the string "true".
-{{- if (eq (toString .Values.ingress) "true") }}
 {{ $job_label :=  "mas-ws-route-patch" }}
 
 {{- /*
@@ -190,6 +185,3 @@ spec:
       restartPolicy: Never
       serviceAccountName: "mas-ws-route-sa"
   backoffLimit: 4
-
-{{- end }}
-

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
@@ -1,8 +1,3 @@
-# .Values.ingress is properly passed into the suite-app-config app as a boolean 
-# (see https://github.com/ibm-mas/gitops/blob/d46e6577fc2081e0a5624dddf575cead5310d794/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml#L67)
-# Nevertheless, for consistency with checks against .Values.ingress in other charts, we will also accept the string "true" here.
-{{- if (eq (toString .Values.ingress) "true") }}
-
 {{- /*
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
@@ -218,5 +213,3 @@ spec:
       restartPolicy: Never
       serviceAccountName: "mas-app-route-sa"
   backoffLimit: 4
-
-{{- end }}


### PR DESCRIPTION
This changes the add label job so that it always runs regardless of the ingress flag or not. This is being done so we can correctly label the routes even when we don't create the ingresscontroller directly via gitops. Even with these labels, the default ingresscontroller will still pick these up if there is no other ingresscontroller installed.

Tested with ingress set to false and the jobs still execute/exist:

![image- 2025-07-08 at 13 29 11@2x](https://github.com/user-attachments/assets/4a9b3ff7-dcda-479f-8385-a70c9ee6b26a)
