### PR TITLE
[patch] add optimizerworkspaces resource to rbac

### DIFF
--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
@@ -84,6 +84,7 @@ rules:
       - visualinspectionappworkspaces
       - workspaces
       - facilitiesworkspaces
+      - optimizerworkspaces
   - verbs:
       - get
       - list


### PR DESCRIPTION
mas-app-route-sa is not able to list optimizerworkspaces
updated RBAC to allow service account to list and get optimizerworkspaces resource.

Error:
Wait for App workspaces to be ready and add label type=external to routes
Wait for App Workspaces to be ready
Error from server (Forbidden): optimizerworkspaces.apps.mas.ibm.com is forbidden: User "system:serviceaccount:mas-vta-test-optimizer:mas-app-route-sa" cannot list resource "optimizerworkspaces" in API group "apps.mas.ibm.com" in the namespace "mas-vta-test-optimizer"


