### PR TITLE
[patch] Cleanup ingress variable

### DIFF
--- a/cluster-applications/000-job-cleaner/templates/04-jobcleaner_CronJob.yaml
+++ b/cluster-applications/000-job-cleaner/templates/04-jobcleaner_CronJob.yaml
@@ -1,7 +1,7 @@
 {{- /*
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 
 {{- $ns := "job-cleaner" }}

--- a/cluster-applications/010-redhat-cert-manager/templates/04-postsync-update-sm_Job.yaml
+++ b/cluster-applications/010-redhat-cert-manager/templates/04-postsync-update-sm_Job.yaml
@@ -17,7 +17,7 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.

--- a/cluster-applications/020-ibm-dro/templates/08-postsync-update-sm_Job.yaml
+++ b/cluster-applications/020-ibm-dro/templates/08-postsync-update-sm_Job.yaml
@@ -9,7 +9,7 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.

--- a/cluster-applications/021-ibm-dro-cleanup/templates/postdelete-MarketplaceConfigs.yaml
+++ b/cluster-applications/021-ibm-dro-cleanup/templates/postdelete-MarketplaceConfigs.yaml
@@ -2,7 +2,7 @@
 {{- /*
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 
 {{ $job_name := "postdelete-delete-marketplaceconfigs-job" }}

--- a/cluster-applications/041-cis-compliance-cleanup/templates/postdelete-ProfileBundles.yaml
+++ b/cluster-applications/041-cis-compliance-cleanup/templates/postdelete-ProfileBundles.yaml
@@ -2,7 +2,7 @@
 {{- /*
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{ $job_name := "postdelete-delete-profilebundles-job" }}
 

--- a/cluster-applications/055-instana-agent-operator/templates/08-CronJob.yaml
+++ b/cluster-applications/055-instana-agent-operator/templates/08-CronJob.yaml
@@ -2,7 +2,7 @@
 {{- /*
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 
 ---

--- a/cluster-applications/060-custom-sa/templates/04-postsync-update-sm_Job.yaml
+++ b/cluster-applications/060-custom-sa/templates/04-postsync-update-sm_Job.yaml
@@ -9,7 +9,7 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.

--- a/cluster-applications/200-cluster-promotion/templates/02-cluster-verify_Job.yaml
+++ b/cluster-applications/200-cluster-promotion/templates/02-cluster-verify_Job.yaml
@@ -7,7 +7,7 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.

--- a/cluster-applications/200-cluster-promotion/templates/03-cluster-promoter_Job.yaml
+++ b/cluster-applications/200-cluster-promotion/templates/03-cluster-promoter_Job.yaml
@@ -7,7 +7,7 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.

--- a/instance-applications/010-ibm-sync-jobs/templates/00-aws-docdb-add-user_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/00-aws-docdb-add-user_Job.yaml
@@ -9,7 +9,7 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
@@ -10,7 +10,7 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_digest := "sha256:834dffd4da534c01daea4e0a6d9db7d00a9ad9b18b054cc034985fcaceedeacd" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
@@ -9,7 +9,7 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_digest := "sha256:834dffd4da534c01daea4e0a6d9db7d00a9ad9b18b054cc034985fcaceedeacd" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.

--- a/instance-applications/010-ibm-sync-jobs/templates/PostDelete-aws-docdb-remove-user_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/PostDelete-aws-docdb-remove-user_Job.yaml
@@ -5,7 +5,7 @@
 {{- /*
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 
 # Deletes user "masinst_${MAS_INSTANCE_ID}" from docdb an deletes the acc/cluster/instance/mongo#password secret from AWS SM

--- a/instance-applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
+++ b/instance-applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
@@ -9,7 +9,7 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.

--- a/instance-applications/101-ibm-sync-jobs-cp4d/templates/00-ibm-cp4d-presync.yaml
+++ b/instance-applications/101-ibm-sync-jobs-cp4d/templates/00-ibm-cp4d-presync.yaml
@@ -9,7 +9,7 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.

--- a/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_prereqs_ops.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_prereqs_ops.yaml
@@ -7,7 +7,7 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.

--- a/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_upg_cleanup.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_upg_cleanup.yaml
@@ -7,7 +7,7 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.

--- a/instance-applications/110-ibm-cp4d/templates/03-ibm-cp4d-mcs_patch_sa.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/03-ibm-cp4d-mcs_patch_sa.yaml
@@ -14,7 +14,7 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.

--- a/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_patch_zenservice.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_patch_zenservice.yaml
@@ -8,7 +8,7 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.

--- a/instance-applications/110-ibm-cp4d/templates/08-ibm-cp4d-post-verify.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/08-ibm-cp4d-post-verify.yaml
@@ -7,7 +7,7 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.

--- a/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
@@ -7,7 +7,7 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.

--- a/instance-applications/112-ibm-odh/templates/05-odh-operator-job.yaml
+++ b/instance-applications/112-ibm-odh/templates/05-odh-operator-job.yaml
@@ -4,7 +4,7 @@
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_digest := "sha256:934706a7173d45ea53c3d191afa6d75b4e41d25422e6a3685f1c57d1ddf49a00" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.

--- a/instance-applications/112-ibm-odh/templates/11-odh.yaml
+++ b/instance-applications/112-ibm-odh/templates/11-odh.yaml
@@ -4,7 +4,7 @@
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_digest := "sha256:934706a7173d45ea53c3d191afa6d75b4e41d25422e6a3685f1c57d1ddf49a00" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.

--- a/instance-applications/120-ibm-db2u-database/templates/00-presync-await-crd_Job.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/00-presync-await-crd_Job.yaml
@@ -1,7 +1,7 @@
 {{- /*
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 ---
 # Service account that is authorized to read k8s secrets (needed by the job)

--- a/instance-applications/120-ibm-db2u-database/templates/04-db2u-Backup_Cron.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/04-db2u-Backup_Cron.yaml
@@ -3,7 +3,7 @@
 {{- /*
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 #apiVersion: batch/v1beta1
 kind: CronJob

--- a/instance-applications/120-ibm-db2u-database/templates/07-postsync-setup-db2_Job.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/07-postsync-setup-db2_Job.yaml
@@ -9,7 +9,7 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -450,6 +450,8 @@ spec:
                       echo "The latest backup ${timestamp} is not a full backup"
                       timestamp=''
                     fi
+                  else
+                    timestamp=''
                   fi
                 fi
 

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -450,9 +450,6 @@ spec:
                       echo "The latest backup ${timestamp} is not a full backup"
                       timestamp=''
                     fi
-                  else
-                    timestamp=''
-                  fi
                 fi
 
                 if [[ ${AUTO_BACKUP} == 'false' || -z ${timestamp} ]]; then

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -10,7 +10,7 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -450,6 +450,7 @@ spec:
                       echo "The latest backup ${timestamp} is not a full backup"
                       timestamp=''
                     fi
+                  fi
                 fi
 
                 if [[ ${AUTO_BACKUP} == 'false' || -z ${timestamp} ]]; then

--- a/instance-applications/120-ibm-dbs-rds-database/templates/01-dbs-rds-postsync-setup.yaml
+++ b/instance-applications/120-ibm-dbs-rds-database/templates/01-dbs-rds-postsync-setup.yaml
@@ -7,7 +7,7 @@
   Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
   Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{- /*
   A dict of values that influence the behaviour of the job in some way.

--- a/instance-applications/120-ibm-spark/templates/02-ibm-spark-control-plane.yaml
+++ b/instance-applications/120-ibm-spark/templates/02-ibm-spark-control-plane.yaml
@@ -7,7 +7,7 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.

--- a/instance-applications/120-ibm-spss/templates/02-ibm-spss-post-verify.yaml
+++ b/instance-applications/120-ibm-spss/templates/02-ibm-spss-post-verify.yaml
@@ -7,7 +7,7 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.

--- a/instance-applications/120-ibm-wsl/templates/02-ibm-wsl-post-verify.yaml
+++ b/instance-applications/120-ibm-wsl/templates/02-ibm-wsl-post-verify.yaml
@@ -7,7 +7,7 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.

--- a/instance-applications/130-ibm-jdbc-config/templates/00-presync-create-db2-user_Job.yaml
+++ b/instance-applications/130-ibm-jdbc-config/templates/00-presync-create-db2-user_Job.yaml
@@ -3,7 +3,7 @@
 {{- /*
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{ $ns := printf "mas-%s-core" .Values.instance_id }}
 {{ $prefix := printf "pre-jdbc-usr-%s" .Values.mas_config_name }}

--- a/instance-applications/130-ibm-jdbc-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-jdbc-config/templates/postdelete-delete-cr.yaml
@@ -3,7 +3,7 @@
 {{- /*
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{ $cr_name := .Values.mas_config_name }}
 {{ $cr_kind := .Values.mas_config_kind }}

--- a/instance-applications/130-ibm-jdbc-config/templates/postdelete-delete-db2-user_Job.yaml
+++ b/instance-applications/130-ibm-jdbc-config/templates/postdelete-delete-db2-user_Job.yaml
@@ -3,7 +3,7 @@
 {{- /*
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{ $ns := printf "mas-%s-syncres" .Values.instance_id }}
 {{ $prefix := printf "post-jdbc-usr-%s" .Values.mas_config_name }}

--- a/instance-applications/130-ibm-kafka-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-kafka-config/templates/postdelete-delete-cr.yaml
@@ -18,7 +18,7 @@
 {{- /*
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 ---
 apiVersion: batch/v1

--- a/instance-applications/130-ibm-mas-bas-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-mas-bas-config/templates/postdelete-delete-cr.yaml
@@ -3,7 +3,7 @@
 {{- /*
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{ $cr_name := .Values.mas_config_name }}
 {{ $cr_kind := .Values.mas_config_kind }}

--- a/instance-applications/130-ibm-mas-idp-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-mas-idp-config/templates/postdelete-delete-cr.yaml
@@ -3,7 +3,7 @@
 {{- /*
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{ $cr_name := .Values.mas_config_name }}
 {{ $cr_kind := .Values.mas_config_kind }}

--- a/instance-applications/130-ibm-mas-mongo-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-mas-mongo-config/templates/postdelete-delete-cr.yaml
@@ -3,7 +3,7 @@
 {{- /*
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{ $cr_name := .Values.mas_config_name }}
 {{ $cr_kind := .Values.mas_config_kind }}

--- a/instance-applications/130-ibm-mas-sls-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-mas-sls-config/templates/postdelete-delete-cr.yaml
@@ -3,7 +3,7 @@
 {{- /*
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{ $cr_name := .Values.mas_config_name }}
 {{ $cr_kind := .Values.mas_config_kind }}

--- a/instance-applications/130-ibm-mas-smtp-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-mas-smtp-config/templates/postdelete-delete-cr.yaml
@@ -3,7 +3,7 @@
 {{- /*
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{ $cr_name := .Values.mas_config_name }}
 {{ $cr_kind := .Values.mas_config_kind }}

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -8,7 +8,7 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.

--- a/instance-applications/130-ibm-mas-suite/templates/06-postsync-configtool-oidc.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/06-postsync-configtool-oidc.yaml
@@ -10,7 +10,7 @@ Meaningful prefix for the job resource name. Must be under 52 chars in length to
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.

--- a/instance-applications/130-ibm-objectstorage-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-objectstorage-config/templates/postdelete-delete-cr.yaml
@@ -3,7 +3,7 @@
 {{- /*
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{ $cr_name := .Values.mas_config_name }}
 {{ $cr_kind := .Values.mas_config_kind }}

--- a/instance-applications/220-ibm-mas-workspace/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/220-ibm-mas-workspace/templates/05-postsync-add-label_Job.yaml
@@ -3,7 +3,7 @@
 {{- /*
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 ---
 # Permit outbound communication by the Job pods

--- a/instance-applications/500-540-ibm-mas-suite-app-install/templates/00-presync-add-mvi-scc_Job.yaml
+++ b/instance-applications/500-540-ibm-mas-suite-app-install/templates/00-presync-add-mvi-scc_Job.yaml
@@ -4,7 +4,7 @@
 {{- /*
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 
 {{ $ns := .Values.mas_app_namespace }}

--- a/instance-applications/500-540-ibm-mas-suite-app-install/templates/06-postsync-add-mvi-scc_Job.yaml
+++ b/instance-applications/500-540-ibm-mas-suite-app-install/templates/06-postsync-add-mvi-scc_Job.yaml
@@ -4,7 +4,7 @@
 {{- /*
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 
 {{ $ns := .Values.mas_app_namespace }}

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/02-ibm-manage-update_Job.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/02-ibm-manage-update_Job.yaml
@@ -5,7 +5,7 @@
 {{- /*
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{ $ns        :=  .Values.mas_app_namespace }}
 {{ $prefix := printf "%s-manage-update" .Values.mas_workspace_id}}

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
@@ -1,7 +1,7 @@
 {{- /*
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{ $ns        :=  .Values.mas_app_namespace }}
 {{ $job_label :=  "mas-app-route-patch" }}

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
@@ -84,6 +84,7 @@ rules:
       - visualinspectionappworkspaces
       - workspaces
       - facilitiesworkspaces
+      - optimizerworkspaces
   - verbs:
       - get
       - list

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-sanity.yaml
@@ -4,7 +4,7 @@
 {{- /*
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 # A sanity test is one that can be disruptive i.e. it can create new users, call authenticated apis, creates resources 
 # in the application. This type of test should only be run in a downstream environment such as a dev or staging env

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -3,7 +3,7 @@
 {{- /*
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 # A verify test is one that is non disruptive i.e. it won't create new users, i won't call authenticated apis, and it won't creates resources 
 # in the application. This type of test is run on every environment and allows a layer of verification of the app

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-maximoit-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-maximoit-sanity.yaml
@@ -5,7 +5,7 @@
 {{- /*
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 # A sanity test is one that can be disruptive i.e. it can create new users, call authenticated apis, creates resources 
 # in the application. This type of test should only be run in a downstream environment such as a dev or staging env

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-maximoit-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-maximoit-verify.yaml
@@ -4,7 +4,7 @@
 {{- /*
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 # A verify test is one that is non disruptive i.e. it won't create new users, i won't call authenticated apis, and it won't creates resources 
 # in the application. This type of test is run on every environment and allows a layer of verification of the app

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-sanity.yaml
@@ -3,7 +3,7 @@
 {{- /*
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{ $ns               :=  .Values.mas_app_namespace }}
 {{ $np_name          :=  "postsync-sanity-mvi-np" }}

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-verify.yaml
@@ -4,7 +4,7 @@
 {{- /*
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 
 {{ $ns               :=  .Values.mas_app_namespace }}

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/700-702-postsync-db2-manage.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/700-702-postsync-db2-manage.yaml
@@ -86,7 +86,7 @@ will take care of differentiating the jobs.
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 Included in $_job_hash (see below).
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.

--- a/instance-applications/600-ibm-post-sync-jobs/templates/001-ibm-create-initial-users.yaml
+++ b/instance-applications/600-ibm-post-sync-jobs/templates/001-ibm-create-initial-users.yaml
@@ -11,7 +11,7 @@ Use the build/bin/set-cli-image-tag.sh script to update this value across all ch
 Included in $_job_hash (see below).
 13.22.1-amd64 - includes mas-devops-create-initial-users script from https://github.com/ibm-mas/python-devops/pull/66
 */}}
-{{- $_cli_image_digest := "sha256:3735885b3b9d46fcf6408c008768cc04faf2e28c1fa5f6da7c5f969931e2d3cd" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{- /*
 A dict of values that influence the behaviour of the job in some way.

--- a/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-app.yaml
@@ -57,7 +57,6 @@ spec:
             dns_provider: "{{ .Values.ibm_mas_suite.dns_provider }}"
             icr_cp: "{{ .Values.ibm_mas_suite.icr_cp }}"
             icr_cp_open: "{{ .Values.ibm_mas_suite.icr_cp_open }}"
-            ingress: "{{ .Values.ibm_mas_suite.ingress }}"
 
             {{- if .Values.ibm_mas_suite.mas_annotations }}
             mas_annotations: {{ .Values.ibm_mas_suite.mas_annotations | toYaml | nindent 14 }}

--- a/root-applications/ibm-mas-instance-root/templates/200-ibm-mas-workspaces.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/200-ibm-mas-workspaces.yaml
@@ -41,7 +41,6 @@ spec:
             instance_id: "{{ $.Values.instance.id }}"
             mas_workspace_id: "{{ $value.mas_workspace_id }}"
             mas_workspace_name: "{{ $value.mas_workspace_name }}"
-            ingress: "{{ $.Values.ibm_mas_suite.ingress }}"
             {{- if $.Values.custom_labels }}
             custom_labels: {{ $.Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}

--- a/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
@@ -66,7 +66,6 @@ spec:
 
             mas_manual_cert_mgmt: {{ $value.mas_manual_cert_mgmt }}
             run_sanity_test: {{ $value.run_sanity_test }}
-            ingress: {{ $value.ingress }}
             {{- if $value.mas_manual_cert_mgmt  }}
             public_tls_secret_name: "{{ $value.public_tls_secret_name }}"
             ca_cert: |

--- a/sub-charts/junitreporter/templates/00-presync-report-starter.yaml
+++ b/sub-charts/junitreporter/templates/00-presync-report-starter.yaml
@@ -3,7 +3,7 @@
 {{- /*
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 
 {{ $prefix := printf "pre-jreporter-%s" .Values.reporter_name }}

--- a/sub-charts/junitreporter/templates/10-postsync-report-starter.yaml
+++ b/sub-charts/junitreporter/templates/10-postsync-report-starter.yaml
@@ -3,7 +3,7 @@
 {{- /*
 Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
 */}}
-{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+{{- $_cli_image_digest := "sha256:aa3972d1777c01a86ab21a47854f1f5fbffc09452adfb0c734e245b3d46e6ffb" }}
 
 {{ $preprefix := printf "pre-jreporter-%s" .Values.reporter_name }}
 {{ $time_cm := printf "%s-synctime" $preprefix }}


### PR DESCRIPTION
Issue: [MASCORE-8170](https://jsw.ibm.com/browse/MASCORE-8170)

## Description
Ingress value is not used as the check is removed as part of https://github.com/ibm-mas/gitops/pull/327.
Hence cleaning up the ingress variable from argo apps