### PR TITLE
[minor] Add connectivity tests from existing Manage to AI service using the unauthenticated ping API 

### DIFF
--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-sanity.yaml
@@ -350,7 +350,7 @@ data:
       except KeyError as e:
         pass
 
-      # Read the key field for RSA PRIVATE KEY from the Manage Route. 
+      # Read the caCertificate field from the Manage Route. 
       # This may include CA certificates that we need in order to trust the certificates presented by the external Manage endpoint.
       try:
         manage_route_caCertificate = manage_route['spec']['tls']['caCertificate']
@@ -378,7 +378,7 @@ data:
           chain_file.write(manage_route_certificate.encode())
         
         if manage_route_caCertificate:
-          chain_file.write(manage_route_caCertificate.encode())
+          chain_file.write(manage_route_certificate.encode())
 
         if manage_route_destinationCACertificate:
           chain_file.write(manage_route_destinationCACertificate.encode())

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-sanity.yaml
@@ -350,7 +350,7 @@ data:
       except KeyError as e:
         pass
 
-      # Read the caCertificate field from the Manage Route. 
+      # Read the key field for RSA PRIVATE KEY from the Manage Route. 
       # This may include CA certificates that we need in order to trust the certificates presented by the external Manage endpoint.
       try:
         manage_route_caCertificate = manage_route['spec']['tls']['caCertificate']
@@ -378,7 +378,7 @@ data:
           chain_file.write(manage_route_certificate.encode())
         
         if manage_route_caCertificate:
-          chain_file.write(manage_route_certificate.encode())
+          chain_file.write(manage_route_caCertificate.encode())
 
         if manage_route_destinationCACertificate:
           chain_file.write(manage_route_destinationCACertificate.encode())

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -173,7 +173,7 @@ data:
     manage_namespace = f"mas-{mas_instance_id}-manage"
     manage_route_name = f"{mas_instance_id}-manage-{mas_workspace_id}"
     MANAGE_URL = ""
-    MAX_RETRY = 30
+    MAX_RETRY = 4
 
     @pytest.fixture(scope="session")
     def dyn_client():
@@ -361,10 +361,10 @@ data:
             try:
                 resp = make_request(manage_host_ca_filepath)
                 resp_json = resp.json()
-                if resp.status_code == 200 and resp_json['aiservicehealth'] == False or resp_json['aiserviceapikey'] == False:              
+                if resp.status_code == 200 and (resp_json['aiservicehealth'] == False or resp_json['aiserviceapikey'] == False):
                   attempts += 1
                   print(f"attempts : {attempts}")
-                  time.sleep(180)
+                  time.sleep(5)
                   print(resp)
                 elif resp.status_code == 200:
                   return resp

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -171,6 +171,7 @@ data:
     aibroker_api_key = os.getenv("AIBROKERAPIKEY")
     manage_namespace = f"mas-{mas_instance_id}-manage"
     manage_route_name = f"{mas_instance_id}-manage-{mas_workspace_id}"
+    MANAGE_URL = ""
 
     @pytest.fixture(scope="session")
     def dyn_client():
@@ -325,17 +326,14 @@ data:
         MANAGE_URL = f'https://{manage_service}.mas-{mas_instance_id}-manage.svc.cluster.local'
 
       try:
-        resp = requests.get(
-          f"{MANAGE_URL}/maximo/api/pingaiservice",
-          headers={
-          "Content-Type": "application/json"
-          },
-          verify=manage_host_ca_filepath
-        )
-        resp.raise_for_status()  # Raise an error for bad responses
-      except requests.exceptions.RequestException as e:
-          print("Error during requests to Maximo Ping AI service:", e)
-          assert False, "Error calling  GET /maximo/api/pingaiservice. Error details: {e}"
+        print(f"assertion")
+        logger.info("assertion:")
+        data = request_with_retry(manage_host_ca_filepath)
+      except RuntimeError as err:
+        print(err)
+        assert False, "Error calling  GET /maximo/api/pingaiservice. Error details: {err}"
+
+      print(f"Response Data: {data}" )
 
       resp_json = resp.json()
       logger.info("ping to ai service ::")
@@ -352,6 +350,43 @@ data:
         assert resp_json['aiserviceapikey'] == True, f"Expected healthy field from GET /maximo/api/pingaiservice to be true, but was {resp_json['aiserviceapikey']}. Body: {resp_json}"
       except KeyError as e:
         assert False, f"Expected aiserviceapikey key not found in response from GET /maximo/api/pingaiservice. Body: {resp_json}"
+
+    def request_with_retry(manage_host_ca_filepath):
+        attempts = 1
+        print(f"Requests with retry")
+        logger.info("Requests with retry:")
+        while attempts < MAX_RETRY:
+            try:
+                resp = make_request(manage_host_ca_filepath)
+                resp_json = resp.json()
+                if resp.status_code == 200 and resp_json['aiservicehealth'] == False or resp_json['aiserviceapikey'] == False:              
+                  attempts += 1
+                  print(f"attempts : {attempts}")
+                  time.sleep(180)
+                  print(resp)
+                elif resp.status_code == 200:
+                  return resp
+            except requests.exceptions.RequestException as e:
+                print("Error during requests to Maximo Ping AI service:", e)
+        return resp    
+
+    def make_request(manage_host_ca_filepath):
+      # Replace 'get' with whichever method you're using, and the URL with the actual API URL
+      print(f"actual request")
+      logger.info("actual request:")
+      r = requests.get(
+          f"{MANAGE_URL}/maximo/api/pingaiservice",
+          headers={
+          "Content-Type": "application/json"
+          },
+          verify=manage_host_ca_filepath
+      )
+      r.raise_for_status()
+      # If r.status_code is not 200, treat it as an error.
+      logger.info("ping to ai service ::")
+      logger.info(r.text)
+      return r
+
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -262,7 +262,7 @@ data:
           chain_file.write(manage_route_certificate.encode())
         
         if manage_route_caCertificate:
-          chain_file.write(manage_route_certificate.encode())
+          chain_file.write(manage_route_caCertificate.encode())
 
         if manage_route_destinationCACertificate:
           chain_file.write(manage_route_destinationCACertificate.encode())

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -320,7 +320,7 @@ data:
 
       try:
         resp = requests.get(
-          f"https://{manage_host}/maximo/api/pingaiservice",
+          f"https://{manage_host}/maximo/api/ping",
           headers={
           "Content-Type": "application/json"
           },

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -264,18 +264,18 @@ data:
         
         if manage_route_certificate:
           chain_file.write(manage_route_certificate.encode())
-          print("manage_route_certificate")
-          print(manage_route_certificate.encode())
+          # print("manage_route_certificate")
+          # print(manage_route_certificate.encode())
         
         if manage_route_caCertificate:
           chain_file.write(manage_route_caCertificate.encode())
-          print("manage_route_caCertificate")
-          print(manage_route_caCertificate.encode())
+          # print("manage_route_caCertificate")
+          # print(manage_route_caCertificate.encode())
 
         if manage_route_destinationCACertificate:
           chain_file.write(manage_route_destinationCACertificate.encode())
-          print("manage_route_destinationCACertificate")
-          print(manage_route_destinationCACertificate.encode())
+          # print("manage_route_destinationCACertificate")
+          # print(manage_route_destinationCACertificate.encode())
 
         chain_file.write(default_ca_content)
         chain_file.flush()
@@ -312,9 +312,9 @@ data:
     def test_get_manage_ai_service_ping(manage_host,manage_host_ca_filepath):
         # if isVersionApplicable==False:
         #    pytest.skip("Skipping because version is below 9.1")
-      with open(manage_host_ca_filepath, 'r') as file:
-        content = file.read()
-      print(f"Contents of '{manage_host_ca_filepath}': {content}")
+      # with open(manage_host_ca_filepath, 'r') as file:
+      #   content = file.read()
+      # print(f"Contents of '{manage_host_ca_filepath}': {content}")
 
       if aibroker_api_key == False:
         pytest.skip("AI Broker API key not found.")

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -173,7 +173,7 @@ data:
     manage_namespace = f"mas-{mas_instance_id}-manage"
     manage_route_name = f"{mas_instance_id}-manage-{mas_workspace_id}"
     MANAGE_URL = ""
-    MAX_RETRY = 4
+    MAX_RETRY = 20
 
     @pytest.fixture(scope="session")
     def dyn_client():
@@ -368,7 +368,7 @@ data:
                     if not resp_json.get('aiservicehealth') or not resp_json.get('aiserviceapikey'):
                         attempts += 1
                         logger.warning("Unhealthy service or missing API key. Retrying... (Attempt %d)", attempts)
-                        time.sleep(5)
+                        time.sleep(180)
                     else:
                         return resp
                 else:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -325,11 +325,11 @@ data:
 
       try:
         resp = requests.get(
-          f"https://{manage_host}/maximo/api/pingaiservice",
+          f"https://{manage_host}/maximo/api/ping",
           headers={
           "Content-Type": "application/json"
           },
-          verify=False
+          verify=manage_host_ca_filepath
         )
         resp.raise_for_status()  # Raise an error for bad responses
       except requests.exceptions.RequestException as e:
@@ -341,16 +341,18 @@ data:
       logger.info(resp.text)
 
       assert resp.status_code == 200, f"Expected status 200 from GET /maximo/api/pingaiservice, but got {resp.status_code}. Body: {resp_json}."
+      assert "hasfoundation" in resp.text
+      assert "manageorhealth" in resp.text
 
-      try:
-        assert resp_json['aiservicehealth'] == True, f"Expected healthy field from GET /maximo/api/pingaiservice to be true, but was {resp_json['aiservicehealth']}. Body: {resp_json}"
-      except KeyError as e:
-        assert False, f"Expected aiservicehealth key not found in response from GET /maximo/api/pingaiservice. Body: {resp_json}"
+#      try:
+#        assert resp_json['aiservicehealth'] == True, f"Expected healthy field from GET /maximo/api/pingaiservice to be true, but was {resp_json['aiservicehealth']}. Body: {resp_json}"
+#      except KeyError as e:
+#        assert False, f"Expected aiservicehealth key not found in response from GET /maximo/api/pingaiservice. Body: {resp_json}"
 
-      try:
-        assert resp_json['aiserviceapikey'] == True, f"Expected healthy field from GET /maximo/api/pingaiservice to be true, but was {resp_json['aiserviceapikey']}. Body: {resp_json}"
-      except KeyError as e:
-        assert False, f"Expected aiserviceapikey key not found in response from GET /maximo/api/pingaiservice. Body: {resp_json}"
+#      try:
+#        assert resp_json['aiserviceapikey'] == True, f"Expected healthy field from GET /maximo/api/pingaiservice to be true, but was {resp_json['aiserviceapikey']}. Body: {resp_json}"
+#      except KeyError as e:
+#        assert False, f"Expected aiserviceapikey key not found in response from GET /maximo/api/pingaiservice. Body: {resp_json}"
 
 ---
 kind: ConfigMap

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -156,7 +156,9 @@ data:
     import requests
     import certifi
     import tempfile
-    
+    import logging
+
+    logger = logging.getLogger()
     mas_instance_id = os.getenv("MAS_INSTANCE_ID")
     if mas_instance_id is None:
       raise Exception(f"Required MAS_INSTANCE_ID environment variable is not set")
@@ -302,9 +304,12 @@ data:
       if status_serverbundles is not None:
         assert spec_serverbundles == status_serverbundles, f"Expected serverbundles set in the spec: {spec_serverbundles} to be equal to the serverbundles in the status: {status_serverbundles}"
 
-    def test_get_manage_ai_service_ping(manage_host):
+    def test_get_manage_ai_service_ping(manage_host,manage_host_ca_filepath):
         # if isVersionApplicable==False:
         #    pytest.skip("Skipping because version is below 9.1")
+
+      logger.info("Host CA Filepath:")
+      logger.info(manage_host_ca_filepath)
 
       if aibroker_api_key == False:
         pytest.skip("AI Broker API key not found.")

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -220,7 +220,7 @@ data:
     @pytest.fixture(scope="session")
     def manage_host(manage_route):
       try:
-        yield manage_route[spec][host]
+        yield manage_route['spec']['host']
       except KeyError as e:
         assert False, f"Unable to determine manage host; spec.host key not present in {manage_route_name}/{manage_namespace}: {manage_route}. Error details: {e}"
 
@@ -307,12 +307,13 @@ data:
       if aibroker_api_key == False:
         pytest.skip("AI Broker API key not found.")
 
-      if manage_host:
-          MANAGE_URL = f'https://{mas_instance_id}-{mas_workspace_id}.mas-{mas_instance_id}-manage.svc'
+      #if manage_host:
+      #    MANAGE_URL = f'https://{mas_instance_id}-{mas_workspace_id}.mas-{mas_instance_id}-manage.svc'
+      #  f"{MANAGE_URL}/maximo/api/pingaiservice",
 
       try:
         resp = requests.get(
-          f"{MANAGE_URL}/maximo/api/pingaiservice",
+          f"https://{manage_host}/maximo/api/pingaiservice",
           headers={
           "Content-Type": "application/json"
           },

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -264,15 +264,20 @@ data:
         
         if manage_route_certificate:
           chain_file.write(manage_route_certificate.encode())
+          print("manage_route_certificate")
+          print(manage_route_certificate.encode())
         
         if manage_route_caCertificate:
           chain_file.write(manage_route_caCertificate.encode())
+          print("manage_route_caCertificate")
+          print(manage_route_caCertificate.encode())
 
         if manage_route_destinationCACertificate:
           chain_file.write(manage_route_destinationCACertificate.encode())
+          print("manage_route_destinationCACertificate")
+          print(manage_route_destinationCACertificate.encode())
 
         chain_file.write(default_ca_content)
-        print(chain_file)
         chain_file.flush()
         chain_file.close()
 

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -306,7 +306,7 @@ data:
         assert mange_workspace_cr['status']['components'][component[0]]["enabled"], f"Expected component {component} to be enabled in status"
 
     def test_bundle_sizes(mange_workspace_cr):
-      spec_serverbundles = mange_workspace_cr['spec']['settings']['deployment']['serverBundles']
+      spec_serverbundles = mange_workspace_cr['spec']['settings']['deployment'][' ']
       status_serverbundles = mange_workspace_cr['status']['settings']['deployment']['serverBundles']
       spec_serverbundles = [item for item in spec_serverbundles if item['bundleType'] != 'foundation']
       status_serverbundles = [item for item in status_serverbundles if item['bundleType'] != 'foundation']
@@ -315,12 +315,6 @@ data:
         assert spec_serverbundles == status_serverbundles, f"Expected serverbundles set in the spec: {spec_serverbundles} to be equal to the serverbundles in the status: {status_serverbundles}"
 
     def test_get_manage_ai_service_ping(manage_service,manage_host_ca_filepath):
-        # if isVersionApplicable==False:
-        #    pytest.skip("Skipping because version is below 9.1")
-      # with open(manage_host_ca_filepath, 'r') as file:
-      #   content = file.read()
-      # print(f"Contents of '{manage_host_ca_filepath}': {content}")
-      # f"https://testmanage-masdev-ui.mas-testmanage-manage.svc.cluster.local/maximo/api/pingaiservice",
 
       if aibroker_api_key == False:
         pytest.skip("AI Broker API key not found.")

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -319,12 +319,13 @@ data:
         pytest.skip("AI Broker API key not found.")
 
       #if manage_host:
-      #    MANAGE_URL = f'https://{mas_instance_id}-{mas_workspace_id}.mas-{mas_instance_id}-manage.svc'
+        # MANAGE_URL = f'https://{mas_instance_id}-{mas_workspace_id}.mas-{mas_instance_id}-manage.svc'
       #  f"{MANAGE_URL}/maximo/api/pingaiservice",
 
       try:
         resp = requests.get(
-          f"https://{manage_host}/maximo/api/pingaiservice",
+          # f"https://{manage_host}/maximo/api/pingaiservice",
+          f"https://testmanage-masdev-ui.mas-testmanage-manage.svc.cluster.local/maximo/api/pingaiservice",
           headers={
           "Content-Type": "application/json"
           },

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -324,7 +324,7 @@ data:
           headers={
           "Content-Type": "application/json"
           },
-          verify=false
+          verify=False
         )
         resp.raise_for_status()  # Raise an error for bad responses
       except requests.exceptions.RequestException as e:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -147,7 +147,8 @@ data:
     from openshift.dynamic import DynamicClient
     import pytest
     import os
-
+    import requests
+    
     mas_instance_id = os.getenv("MAS_INSTANCE_ID")
     if mas_instance_id is None:
       raise Exception(f"Required MAS_INSTANCE_ID environment variable is not set")
@@ -157,7 +158,9 @@ data:
     if mas_workspace_id is None:
       raise Exception(f"Required MAS_WORKSPACE_ID environment variable is not set")
 
+    aibroker_api_key = os.getenv("AIBROKERAPIKEY")
     manage_namespace = f"mas-{mas_instance_id}-manage"
+    manage_route_name = f"{mas_instance_id}-manage-{mas_workspace_id}"
 
     @pytest.fixture(scope="session")
     def dyn_client():
@@ -200,6 +203,74 @@ data:
     def mange_app_cr(v1_manageapp):
       yield v1_manageapp.get(namespace=manage_namespace, label_selector=f"mas.ibm.com/instanceId={mas_instance_id}").items[0]
 
+    @pytest.fixture(scope="session")
+    def v1_routes(dyn_client):
+        yield dyn_client.resources.get(api_version='route.openshift.io/v1', kind='Route')
+
+    @pytest.fixture(scope="session")
+    def manage_route(v1_routes):
+        yield v1_routes.get(name=manage_route_name, namespace=manageNamespace)
+
+    @pytest.fixture(scope="session")
+    def manage_host(manage_route)
+      try:
+        yield manage_route[spec][host]
+      except KeyError as e;
+        assert False, f"Unable to determine manage host; spec.host key not present in {manage_route_name}/{manageNamespace}: {manage_route}. Error details: {e}"
+
+    @pytest.fixture(scope="session")
+    def manage_host_ca_filepath(manage_route):
+
+      # Read the certificate field from the Manage Route. 
+      # This may include CA certificates that we need in order to trust the certificates presented by the external Manage endpoint.
+      try:
+        manage_route_certificate = manage_route['spec']['tls']['certificate']
+      except KeyError as e:
+        pass
+
+      # Read the caCertificate field from the Manage Route. 
+      # This may include CA certificates that we need in order to trust the certificates presented by the external Manage endpoint.
+      try:
+        manage_route_caCertificate = manage_route['spec']['tls']['caCertificate']
+      except KeyError as e:
+        pass
+
+      # Read the destinationCACertificate field from the Manage Route. 
+      # This may include CA certificates that we need in order to trust the certificates presented by the internal Manage services.
+      try:
+        manage_route_destinationCACertificate = manage_route['spec']['tls']['destinationCACertificate']
+      except KeyError as e:
+        pass
+
+      # Load default CA bundle. This will include certs for well-known CAs. This ensures that we will
+      # trust the certificates presented by the external Manage endpoints when MAS is configured to use
+      # an external frontend like CIS.
+      with open(certifi.where(), 'rb') as default_ca:
+        default_ca_content = default_ca.read()
+
+      # Combine all of the above into a single .pem file that we can use when issuing HTTP requests
+      chain_file = tempfile.NamedTemporaryFile(delete=False)
+      try:
+        
+        if manage_route_certificate:
+          chain_file.write(manage_route_certificate.encode())
+        
+        if manage_route_caCertificate:
+          chain_file.write(manage_route_certificate.encode())
+
+        if manage_route_destinationCACertificate:
+          chain_file.write(manage_route_destinationCACertificate.encode())
+
+        chain_file.write(default_ca_content)
+
+        chain_file.flush()
+        chain_file.close()
+
+        yield chain_file.name
+
+      finally:
+        os.remove(chain_file.name)
+
     def test_expected_reconciled_version(mange_workspace_reconciled_version, manage_version):
       assert manage_version == mange_workspace_reconciled_version, f"Expected ManageWorkspace Reconciled version: {mange_workspace_reconciled_version} to match Manage Operator version: {manage_version}"
 
@@ -222,6 +293,45 @@ data:
 
       if status_serverbundles is not None:
         assert spec_serverbundles == status_serverbundles, f"Expected serverbundles set in the spec: {spec_serverbundles} to be equal to the serverbundles in the status: {status_serverbundles}"
+
+    def test_get_manage_ai_service_ping(manage_host):
+        # if isVersionApplicable==False:
+        #    pytest.skip("Skipping because version is below 9.1")
+
+      if aibroker_api_key == False:
+        pytest.skip("AI Broker API key not found.")
+
+      if manage_host:
+          MANAGE_URL = f'https://{mas_instance_id}-{mas_workspace_id}.mas-{mas_instance_id}-manage.svc'
+
+      try:
+        resp = requests.get(
+          f"{MANAGE_URL}/maximo/api/pingaiservice",
+          headers={
+          "Content-Type": "application/json"
+          },
+          verify=manage_host_ca_filepath
+        )
+        resp.raise_for_status()  # Raise an error for bad responses
+      except requests.exceptions.RequestException as e:
+          print("Error during requests to Maximo Ping AI service:", e)
+          assert False, "Error calling  GET /maximo/api/pingaiservice. Error details: {e}"
+
+      resp_json = resp.json()
+      logger.info("ping to ai service ::")
+      logger.info(response.text)
+
+      assert resp.status_code == 200, f"Expected status 200 from GET /maximo/api/pingaiservice, but got {resp.status_code}. Body: {resp_json}."
+
+      try:
+        assert resp_json['aiservicehealth'] == True, f"Expected healthy field from GET /maximo/api/pingaiservice to be true, but was {resp_json['aiservicehealth']}. Body: {resp_json}"
+      except KeyError as e:
+        assert False, f"Expected aiservicehealth key not found in response from GET /maximo/api/pingaiservice. Body: {resp_json}"
+
+      try:
+        assert resp_json['aiserviceapikey'] == True, f"Expected healthy field from GET /maximo/api/pingaiservice to be true, but was {resp_json['aiserviceapikey']}. Body: {resp_json}"
+      except KeyError as e:
+        assert False, f"Expected aiserviceapikey key not found in response from GET /maximo/api/pingaiservice. Body: {resp_json}"
 
 ---
 kind: ConfigMap
@@ -287,6 +397,10 @@ spec:
               value: "{{ .Values.mas_workspace_id }}"
             - name: TEST_RECORD_CM
               value: "{{ $record_cm_name }}"
+{{- if and (hasKey .Values "global_secrets") (hasKey .Values.global_secrets "MXE_INT_AIBROKERAPIKEY") }}
+            - name: AIBROKERAPIKEY
+              value: "True"
+{{- end }}
           volumeMounts:
             - name: tests
               mountPath: /tmp/tests

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -157,6 +157,7 @@ data:
     import certifi
     import tempfile
     import logging
+    import time
 
     logger = logging.getLogger()
     mas_instance_id = os.getenv("MAS_INSTANCE_ID")
@@ -350,7 +351,7 @@ data:
         assert resp_json['aiserviceapikey'] == True, f"Expected healthy field from GET /maximo/api/pingaiservice to be true, but was {resp_json['aiserviceapikey']}. Body: {resp_json}"
       except KeyError as e:
         assert False, f"Expected aiserviceapikey key not found in response from GET /maximo/api/pingaiservice. Body: {resp_json}"
-
+      time.sleep(50000)
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -390,7 +390,7 @@ data:
         response = requests.get(
             f"{manage_url}/maximo/api/pingaiservice",
             headers={"Content-Type": "application/json"},
-            verify=manage_host_ca_filepath
+            verify=manage_host_ca_filepate
         )
         response.raise_for_status()
         return response

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -390,7 +390,7 @@ data:
         response = requests.get(
             f"{manage_url}/maximo/api/pingaiservice",
             headers={"Content-Type": "application/json"},
-            verify=manage_host_ca_filepate
+            verify=manage_host_ca_filepath
         )
         response.raise_for_status()
         return response

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -319,15 +319,13 @@ data:
 
       # if manage_host:
       MANAGE_URL = f'https://{mas_instance_id}-{mas_workspace_id}.mas-{mas_instance_id}-manage.svc'
-      #  f"{MANAGE_URL}/maximo/api/pingaiservice",
       try:
         resp = requests.get(
-          # f"https://{manage_host}/maximo/api/pingaiservice",
-          f"http://testmanage-masdev-ui.mas-testmanage-manage.svc.cluster.local:9080/maximo/api/pingaiservice",
+          f"https://testmanage-masdev-ui.mas-testmanage-manage.svc.cluster.local/maximo/api/pingaiservice",
           headers={
           "Content-Type": "application/json"
-          }
-          # verify=manage_host_ca_filepath
+          },
+          verify=manage_host_ca_filepath
         )
         resp.raise_for_status()  # Raise an error for bad responses
       except requests.exceptions.RequestException as e:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -235,7 +235,7 @@ data:
       # This may include CA certificates that we need in order to trust the certificates presented by the external Manage endpoint.
       try:
         manage_route_certificate = manage_route['spec']['tls']['certificate']
-        print(f"Contents of 'manage_route_certificate': {manage_route_certificate}")
+        # print(f"Contents of 'manage_route_certificate': {manage_route_certificate}")
       except KeyError as e:
         pass
 
@@ -243,7 +243,7 @@ data:
       # This may include CA certificates that we need in order to trust the certificates presented by the external Manage endpoint.
       try:
         manage_route_caCertificate = manage_route['spec']['tls']['key']
-        print(f"Contents of 'manage_route_caCertificate': {manage_route_caCertificate}")
+        # print(f"Contents of 'manage_route_caCertificate': {manage_route_caCertificate}")
       except KeyError as e:
         pass
 
@@ -251,7 +251,7 @@ data:
       # This may include CA certificates that we need in order to trust the certificates presented by the internal Manage services.
       try:
         manage_route_destinationCACertificate = manage_route['spec']['tls']['destinationCACertificate']
-        print(f"Contents of 'manage_route_destinationCACertificate': {manage_route_destinationCACertificate}")
+        # print(f"Contents of 'manage_route_destinationCACertificate': {manage_route_destinationCACertificate}")
       except KeyError as e:
         pass
 
@@ -328,7 +328,7 @@ data:
           "Content-Type": "application/json"
           },
           # verify=False
-          # verify=manage_host_ca_filepath
+          verify=manage_host_ca_filepath
         )
         resp.raise_for_status()  # Raise an error for bad responses
       except requests.exceptions.RequestException as e:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -325,7 +325,7 @@ data:
 
       try:
         resp = requests.get(
-          f"https://{manage_host}/maximo/api/ping",
+          f"https://{manage_host}/maximo/api/pingaiservice",
           headers={
           "Content-Type": "application/json"
           },
@@ -341,18 +341,16 @@ data:
       logger.info(resp.text)
 
       assert resp.status_code == 200, f"Expected status 200 from GET /maximo/api/pingaiservice, but got {resp.status_code}. Body: {resp_json}."
-      assert "hasfoundation" in resp.text
-      assert "manageorhealth" in resp.text
 
-#      try:
-#        assert resp_json['aiservicehealth'] == True, f"Expected healthy field from GET /maximo/api/pingaiservice to be true, but was {resp_json['aiservicehealth']}. Body: {resp_json}"
-#      except KeyError as e:
-#        assert False, f"Expected aiservicehealth key not found in response from GET /maximo/api/pingaiservice. Body: {resp_json}"
+     try:
+       assert resp_json['aiservicehealth'] == True, f"Expected healthy field from GET /maximo/api/pingaiservice to be true, but was {resp_json['aiservicehealth']}. Body: {resp_json}"
+     except KeyError as e:
+       assert False, f"Expected aiservicehealth key not found in response from GET /maximo/api/pingaiservice. Body: {resp_json}"
 
-#      try:
-#        assert resp_json['aiserviceapikey'] == True, f"Expected healthy field from GET /maximo/api/pingaiservice to be true, but was {resp_json['aiserviceapikey']}. Body: {resp_json}"
-#      except KeyError as e:
-#        assert False, f"Expected aiserviceapikey key not found in response from GET /maximo/api/pingaiservice. Body: {resp_json}"
+     try:
+       assert resp_json['aiserviceapikey'] == True, f"Expected healthy field from GET /maximo/api/pingaiservice to be true, but was {resp_json['aiserviceapikey']}. Body: {resp_json}"
+     except KeyError as e:
+       assert False, f"Expected aiserviceapikey key not found in response from GET /maximo/api/pingaiservice. Body: {resp_json}"
 
 ---
 kind: ConfigMap

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -157,6 +157,7 @@ data:
     import certifi
     import tempfile
     import logging
+    import time
 
     logger = logging.getLogger()
     mas_instance_id = os.getenv("MAS_INSTANCE_ID")
@@ -172,6 +173,7 @@ data:
     manage_namespace = f"mas-{mas_instance_id}-manage"
     manage_route_name = f"{mas_instance_id}-manage-{mas_workspace_id}"
     MANAGE_URL = ""
+    MAX_RETRY = 30
 
     @pytest.fixture(scope="session")
     def dyn_client():

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -314,7 +314,9 @@ data:
         #    pytest.skip("Skipping because version is below 9.1")
 
       logger.info("Host CA Filepath:")
-      logger.info(manage_host_ca_filepath)
+      contents = os.listdir(manage_host_ca_filepath)
+      print(f"Contents of '{manage_host_ca_filepath}': {contents}")
+      #logger.info(manage_host_ca_filepath)
 
       if aibroker_api_key == False:
         pytest.skip("AI Broker API key not found.")

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -330,12 +330,12 @@ data:
       try:
         print(f"assertion")
         logger.info("assertion:")
-        data = request_with_retry(manage_host_ca_filepath)
+        resp = request_with_retry(manage_host_ca_filepath)
       except RuntimeError as err:
         print(err)
         assert False, "Error calling  GET /maximo/api/pingaiservice. Error details: {err}"
 
-      print(f"Response Data: {data}" )
+      print(f"Response Data: {resp}" )
 
       resp_json = resp.json()
       logger.info("ping to ai service ::")

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -317,89 +317,83 @@ data:
       if status_serverbundles is not None:
         assert spec_serverbundles == status_serverbundles, f"Expected serverbundles set in the spec: {spec_serverbundles} to be equal to the serverbundles in the status: {status_serverbundles}"
 
-    def test_get_manage_ai_service_ping(manage_service,manage_host_ca_filepath):
+    def test_get_manage_ai_service_ping(manage_service, manage_host_ca_filepath):
+        if not aibroker_api_key:
+            pytest.skip("AI Broker API key not found.")
 
-      if aibroker_api_key == False:
-        pytest.skip("AI Broker API key not found.")
+        if manage_service:
+            logger.info("Using manage service: %s", manage_service)
+            manage_url = f'https://{manage_service}.mas-{mas_instance_id}-manage.svc.cluster.local'
 
-      if manage_service:
-        print("service")
-        print(manage_service)
-        MANAGE_URL = f'https://{manage_service}.mas-{mas_instance_id}-manage.svc.cluster.local'
+        try:
+            logger.info("Sending request to ping AI service")
+            resp = request_with_retry(manage_url, manage_host_ca_filepath)
+        except RuntimeError as err:
+            logger.error("Error during request: %s", err)
+            assert False, f"Error calling GET /maximo/api/pingaiservice. Error details: {err}"
 
-      try:
-        print(f"assertion")
-        logger.info("assertion:")
-        resp = request_with_retry(manage_host_ca_filepath)
-      except RuntimeError as err:
-        print(err)
-        assert False, "Error calling  GET /maximo/api/pingaiservice. Error details: {err}"
+        logger.info("Response Data: %s", resp.text)
 
-      print(f"Response Data: {resp}" )
+        resp_json = resp.json()
 
-      resp_json = resp.json()
-      logger.info("ping to ai service ::")
-      logger.info(resp.text)
+        assert resp.status_code == 200, (
+            f"Expected status 200 from GET /maximo/api/pingaiservice, but got {resp.status_code}. Body: {resp_json}"
+        )
 
-      assert resp.status_code == 200, f"Expected status 200 from GET /maximo/api/pingaiservice, but got {resp.status_code}. Body: {resp_json}."
+        try:
+            assert resp_json['aiservicehealth'] is True, (
+                f"Expected 'aiservicehealth' to be true, but was {resp_json.get('aiservicehealth')}. Body: {resp_json}"
+            )
+        except KeyError:
+            assert False, f"'aiservicehealth' key not found in response. Body: {resp_json}"
 
-      try:
-        assert resp_json['aiservicehealth'] == True, f"Expected healthy field from GET /maximo/api/pingaiservice to be true, but was {resp_json['aiservicehealth']}. Body: {resp_json}"
-      except KeyError as e:
-        assert False, f"Expected aiservicehealth key not found in response from GET /maximo/api/pingaiservice. Body: {resp_json}"
+        try:
+            assert resp_json['aiserviceapikey'] is True, (
+                f"Expected 'aiserviceapikey' to be true, but was {resp_json.get('aiserviceapikey')}. Body: {resp_json}"
+            )
+        except KeyError:
+            assert False, f"'aiserviceapikey' key not found in response. Body: {resp_json}"
 
-      try:
-        assert resp_json['aiserviceapikey'] == True, f"Expected healthy field from GET /maximo/api/pingaiservice to be true, but was {resp_json['aiserviceapikey']}. Body: {resp_json}"
-      except KeyError as e:
-        assert False, f"Expected aiserviceapikey key not found in response from GET /maximo/api/pingaiservice. Body: {resp_json}"
-
-    def request_with_retry(manage_host_ca_filepath):
+    def request_with_retry(manage_url, manage_host_ca_filepath):
         attempts = 0
-        resp = None
-        logger.info("Requests with retry")
+        logger.info("Sending requests with retry")
 
         while attempts < MAX_RETRY:
             try:
-                resp = make_request(manage_host_ca_filepath)
+                resp = make_request(manage_url, manage_host_ca_filepath)
                 resp_json = resp.json()
                 logger.info(f"Attempt {attempts + 1}: Status Code {resp.status_code}")
 
                 if resp.status_code == 200:
-                    if resp_json.get('aiservicehealth') is False or resp_json.get('aiserviceapikey') is False:
+                    if not resp_json.get('aiservicehealth') or not resp_json.get('aiserviceapikey'):
                         attempts += 1
-                        logger.warning(f"Unhealthy service or missing API key. Retrying... (Attempt {attempts})")
+                        logger.warning("Unhealthy service or missing API key. Retrying... (Attempt %d)", attempts)
                         time.sleep(5)
                     else:
                         return resp
                 else:
                     attempts += 1
-                    logger.warning(f"Unexpected status {resp.status_code}. Retrying... (Attempt {attempts})")
+                    logger.warning("Unexpected status %d. Retrying... (Attempt %d)", resp.status_code, attempts)
                     time.sleep(5)
 
             except requests.exceptions.RequestException as e:
-                logger.error("Error during request to Maximo Ping AI service:", exc_info=e)
+                logger.error("Error during request to Maximo Ping AI service: %s", e)
                 attempts += 1
                 time.sleep(5)
 
         logger.error("All retry attempts failed.")
-        return resp   
+        raise RuntimeError("Failed to get a valid response after retries.")
 
-    def make_request(manage_host_ca_filepath):
-      # Replace 'get' with whichever method you're using, and the URL with the actual API URL
-      print(f"actual request")
-      logger.info("actual request:")
-      r = requests.get(
-          f"{MANAGE_URL}/maximo/api/pingaiservice",
-          headers={
-          "Content-Type": "application/json"
-          },
-          verify=manage_host_ca_filepath
-      )
-      r.raise_for_status()
-      # If r.status_code is not 200, treat it as an error.
-      logger.info("ping to ai service ::")
-      logger.info(r.text)
-      return r
+    def make_request(manage_url, manage_host_ca_filepath):
+        logger.info("Making actual request to AI service")
+
+        response = requests.get(
+            f"{manage_url}/maximo/api/pingaiservice",
+            headers={"Content-Type": "application/json"},
+            verify=manage_host_ca_filepath
+        )
+        response.raise_for_status()
+        return response
 
 ---
 kind: ConfigMap

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -212,7 +212,7 @@ data:
         yield v1_routes.get(name=manage_route_name, namespace=manageNamespace)
 
     @pytest.fixture(scope="session")
-    def manage_host(manage_route)
+    def manage_host(manage_route):
       try:
         yield manage_route[spec][host]
       except KeyError as e;
@@ -397,7 +397,7 @@ spec:
               value: "{{ .Values.mas_workspace_id }}"
             - name: TEST_RECORD_CM
               value: "{{ $record_cm_name }}"
-{{- if and (hasKey .Values "global_secrets") (hasKey .Values.global_secrets "MXE_INT_AIBROKERAPIKEY") }}
+{{- if and (hasKey .Values "global_secrets") (hasKey .Values.global_secrets "mxe.int.aibrokerapikey") }}
             - name: AIBROKERAPIKEY
               value: "True"
 {{- end }}

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -325,7 +325,7 @@ data:
           headers={
           "Content-Type": "application/json"
           },
-          verify=manage_host_ca_filepath
+          verify=False
         )
         resp.raise_for_status()  # Raise an error for bad responses
       except requests.exceptions.RequestException as e:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -231,19 +231,19 @@ data:
     @pytest.fixture(scope="session")
     def manage_host_ca_filepath(manage_route):
 
-      # Read the certificate field from the Manage Route. 
-      # This may include CA certificates that we need in order to trust the certificates presented by the external Manage endpoint.
-      try:
-        manage_route_certificate = manage_route['spec']['tls']['certificate']
-      except KeyError as e:
-        pass
+      # # Read the certificate field from the Manage Route. 
+      # # This may include CA certificates that we need in order to trust the certificates presented by the external Manage endpoint.
+      # try:
+      #   manage_route_certificate = manage_route['spec']['tls']['certificate']
+      # except KeyError as e:
+      #   pass
 
-      # Read the caCertificate field from the Manage Route. 
-      # This may include CA certificates that we need in order to trust the certificates presented by the external Manage endpoint.
-      try:
-        manage_route_caCertificate = manage_route['spec']['tls']['key']
-      except KeyError as e:
-        pass
+      # # Read the caCertificate field from the Manage Route. 
+      # # This may include CA certificates that we need in order to trust the certificates presented by the external Manage endpoint.
+      # try:
+      #   manage_route_caCertificate = manage_route['spec']['tls']['key']
+      # except KeyError as e:
+      #   pass
 
       # Read the destinationCACertificate field from the Manage Route. 
       # This may include CA certificates that we need in order to trust the certificates presented by the internal Manage services.
@@ -262,11 +262,11 @@ data:
       chain_file = tempfile.NamedTemporaryFile(delete=False)
       try:
         
-        if manage_route_certificate:
-          chain_file.write(manage_route_certificate.encode())
+        # if manage_route_certificate:
+        #   chain_file.write(manage_route_certificate.encode())
         
-        if manage_route_caCertificate:
-          chain_file.write(manage_route_caCertificate.encode())
+        # if manage_route_caCertificate:
+        #   chain_file.write(manage_route_caCertificate.encode())
 
         if manage_route_destinationCACertificate:
           chain_file.write(manage_route_destinationCACertificate.encode())
@@ -308,9 +308,9 @@ data:
     def test_get_manage_ai_service_ping(manage_host,manage_host_ca_filepath):
         # if isVersionApplicable==False:
         #    pytest.skip("Skipping because version is below 9.1")
-      with open(manage_host_ca_filepath, 'r') as file:
-        content = file.read()
-      print(f"Contents of '{manage_host_ca_filepath}': {content}")
+      # with open(manage_host_ca_filepath, 'r') as file:
+      #   content = file.read()
+      # print(f"Contents of '{manage_host_ca_filepath}': {content}")
 
       if aibroker_api_key == False:
         pytest.skip("AI Broker API key not found.")

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -324,7 +324,7 @@ data:
           headers={
           "Content-Type": "application/json"
           },
-          verify=manage_host_ca_filepath
+          verify=false
         )
         resp.raise_for_status()  # Raise an error for bad responses
       except requests.exceptions.RequestException as e:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -90,6 +90,12 @@ rules:
       - manageapps
   - verbs:
       - get
+    apiGroups:
+      - "route.openshift.io"
+    resources:
+      - routes
+  - verbs:
+      - get
       - list
       - patch
     apiGroups:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -209,14 +209,14 @@ data:
 
     @pytest.fixture(scope="session")
     def manage_route(v1_routes):
-        yield v1_routes.get(name=manage_route_name, namespace=manageNamespace)
+        yield v1_routes.get(name=manage_route_name, namespace=manage_namespace)
 
     @pytest.fixture(scope="session")
     def manage_host(manage_route):
       try:
         yield manage_route[spec][host]
       except KeyError as e:
-        assert False, f"Unable to determine manage host; spec.host key not present in {manage_route_name}/{manageNamespace}: {manage_route}. Error details: {e}"
+        assert False, f"Unable to determine manage host; spec.host key not present in {manage_route_name}/{manage_namespace}: {manage_route}. Error details: {e}"
 
     @pytest.fixture(scope="session")
     def manage_host_ca_filepath(manage_route):

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -325,7 +325,8 @@ data:
           headers={
           "Content-Type": "application/json"
           },
-          verify=manage_host_ca_filepath
+          # verify=manage_host_ca_filepath
+          verify=false
         )
         resp.raise_for_status()  # Raise an error for bad responses
       except requests.exceptions.RequestException as e:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -266,7 +266,7 @@ data:
           chain_file.write(manage_route_certificate.encode())
         
         if manage_route_caCertificate:
-          chain_file.write(manage_route_certificate.encode())
+          chain_file.write(manage_route_caCertificate.encode())
 
         # if manage_route_destinationCACertificate:
         #   chain_file.write(manage_route_destinationCACertificate.encode())

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -312,7 +312,9 @@ data:
     def test_get_manage_ai_service_ping(manage_host,manage_host_ca_filepath):
         # if isVersionApplicable==False:
         #    pytest.skip("Skipping because version is below 9.1")
-      print(f"Contents of '{manage_host_ca_filepath}': {manage_host_ca_filepath}")
+      
+      named_content = manage_host_ca_filepath.read()
+      print(f"Contents of '{manage_host_ca_filepath}': {named_content}")
 
       if aibroker_api_key == False:
         pytest.skip("AI Broker API key not found.")

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -354,23 +354,35 @@ data:
         assert False, f"Expected aiserviceapikey key not found in response from GET /maximo/api/pingaiservice. Body: {resp_json}"
 
     def request_with_retry(manage_host_ca_filepath):
-        attempts = 1
-        print(f"Requests with retry")
-        logger.info("Requests with retry:")
+        attempts = 0
+        resp = None
+        logger.info("Requests with retry")
+
         while attempts < MAX_RETRY:
             try:
                 resp = make_request(manage_host_ca_filepath)
                 resp_json = resp.json()
-                if resp.status_code == 200 and (resp_json['aiservicehealth'] == False or resp_json['aiserviceapikey'] == False):
-                  attempts += 1
-                  print(f"attempts : {attempts}")
-                  time.sleep(5)
-                  print(resp)
-                elif resp.status_code == 200:
-                  return resp
+                logger.info(f"Attempt {attempts + 1}: Status Code {resp.status_code}")
+
+                if resp.status_code == 200:
+                    if resp_json.get('aiservicehealth') is False or resp_json.get('aiserviceapikey') is False:
+                        attempts += 1
+                        logger.warning(f"Unhealthy service or missing API key. Retrying... (Attempt {attempts})")
+                        time.sleep(5)
+                    else:
+                        return resp
+                else:
+                    attempts += 1
+                    logger.warning(f"Unexpected status {resp.status_code}. Retrying... (Attempt {attempts})")
+                    time.sleep(5)
+
             except requests.exceptions.RequestException as e:
-                print("Error during requests to Maximo Ping AI service:", e)
-        return resp    
+                logger.error("Error during request to Maximo Ping AI service:", exc_info=e)
+                attempts += 1
+                time.sleep(5)
+
+        logger.error("All retry attempts failed.")
+        return resp   
 
     def make_request(manage_host_ca_filepath):
       # Replace 'get' with whichever method you're using, and the URL with the actual API URL

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -317,6 +317,7 @@ data:
       if status_serverbundles is not None:
         assert spec_serverbundles == status_serverbundles, f"Expected serverbundles set in the spec: {spec_serverbundles} to be equal to the serverbundles in the status: {status_serverbundles}"
 
+    #This is actual Test case method to ping AI service from Manage with retryable attempts
     def test_get_manage_ai_service_ping(manage_service, manage_host_ca_filepath):
 
         # skip test if no api key found in environment
@@ -355,6 +356,7 @@ data:
         except KeyError:
             assert False, f"'aiserviceapikey' key not found in response. Body: {resp_json}"
 
+    # Retry method having retry strategy logic
     def request_with_retry(manage_url, manage_host_ca_filepath):
         attempts = 0
         logger.info("Sending requests with retry")
@@ -386,6 +388,7 @@ data:
         logger.error("All retry attempts failed.")
         raise RuntimeError("Failed to get a valid response after retries.")
 
+    # Method to call api using the requests library
     def make_request(manage_url, manage_host_ca_filepath):
 
         # Actual api call to AI ping service

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -312,7 +312,7 @@ data:
     def test_get_manage_ai_service_ping(manage_host,manage_host_ca_filepath):
         # if isVersionApplicable==False:
         #    pytest.skip("Skipping because version is below 9.1")
-      with open('manage_host_ca_filepath', 'r') as file:
+      with open(manage_host_ca_filepath, 'r') as file:
       content = file.read()
       print(f"Contents of '{manage_host_ca_filepath}': {content}")
 

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -312,9 +312,9 @@ data:
     def test_get_manage_ai_service_ping(manage_host,manage_host_ca_filepath):
         # if isVersionApplicable==False:
         #    pytest.skip("Skipping because version is below 9.1")
-      
-      named_content = manage_host_ca_filepath.read()
-      print(f"Contents of '{manage_host_ca_filepath}': {named_content}")
+      with open('manage_host_ca_filepath', 'r') as file:
+      content = file.read()
+      print(f"Contents of '{manage_host_ca_filepath}': {content}")
 
       if aibroker_api_key == False:
         pytest.skip("AI Broker API key not found.")

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -318,6 +318,8 @@ data:
         assert spec_serverbundles == status_serverbundles, f"Expected serverbundles set in the spec: {spec_serverbundles} to be equal to the serverbundles in the status: {status_serverbundles}"
 
     def test_get_manage_ai_service_ping(manage_service, manage_host_ca_filepath):
+
+        # skip test if no api key found in environment
         if not aibroker_api_key:
             pytest.skip("AI Broker API key not found.")
 
@@ -325,6 +327,7 @@ data:
             logger.info("Using manage service: %s", manage_service)
             manage_url = f'https://{manage_service}.mas-{mas_instance_id}-manage.svc.cluster.local'
 
+        # Call the api through retry method and assertion logic for all the scenarios
         try:
             logger.info("Sending request to ping AI service")
             resp = request_with_retry(manage_url, manage_host_ca_filepath)
@@ -333,9 +336,7 @@ data:
             assert False, f"Error calling GET /maximo/api/pingaiservice. Error details: {err}"
 
         logger.info("Response Data: %s", resp.text)
-
         resp_json = resp.json()
-
         assert resp.status_code == 200, (
             f"Expected status 200 from GET /maximo/api/pingaiservice, but got {resp.status_code}. Body: {resp_json}"
         )
@@ -358,6 +359,7 @@ data:
         attempts = 0
         logger.info("Sending requests with retry")
 
+        # Make attempts until max retry threshold of 20 calls is reached with a sleep interval of 3 minutes between retries
         while attempts < MAX_RETRY:
             try:
                 resp = make_request(manage_url, manage_host_ca_filepath)
@@ -374,19 +376,20 @@ data:
                 else:
                     attempts += 1
                     logger.warning("Unexpected status %d. Retrying... (Attempt %d)", resp.status_code, attempts)
-                    time.sleep(5)
+                    time.sleep(180)
 
             except requests.exceptions.RequestException as e:
                 logger.error("Error during request to Maximo Ping AI service: %s", e)
                 attempts += 1
-                time.sleep(5)
+                time.sleep(180)
 
         logger.error("All retry attempts failed.")
         raise RuntimeError("Failed to get a valid response after retries.")
 
     def make_request(manage_url, manage_host_ca_filepath):
-        logger.info("Making actual request to AI service")
 
+        # Actual api call to AI ping service
+        logger.info("Making actual request to AI service")
         response = requests.get(
             f"{manage_url}/maximo/api/pingaiservice",
             headers={"Content-Type": "application/json"},

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -272,7 +272,7 @@ data:
           chain_file.write(manage_route_destinationCACertificate.encode())
 
         chain_file.write(default_ca_content)
-
+        print(chain_file)
         chain_file.flush()
         chain_file.close()
 
@@ -313,7 +313,6 @@ data:
 
       if aibroker_api_key == False:
         pytest.skip("AI Broker API key not found.")
-        print( f"https://{manage_host}/maximo/api/ping")
 
       #if manage_host:
       #    MANAGE_URL = f'https://{mas_instance_id}-{mas_workspace_id}.mas-{mas_instance_id}-manage.svc'

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -268,8 +268,8 @@ data:
         if manage_route_caCertificate:
           chain_file.write(manage_route_certificate.encode())
 
-        if manage_route_destinationCACertificate:
-          chain_file.write(manage_route_destinationCACertificate.encode())
+        # if manage_route_destinationCACertificate:
+        #   chain_file.write(manage_route_destinationCACertificate.encode())
 
         chain_file.write(default_ca_content)
 
@@ -279,7 +279,8 @@ data:
         yield chain_file.name
 
       finally:
-        os.remove(chain_file.name)
+        # os.remove(chain_file.name)
+        print(f"check finally")
 
     def test_expected_reconciled_version(mange_workspace_reconciled_version, manage_version):
       assert manage_version == mange_workspace_reconciled_version, f"Expected ManageWorkspace Reconciled version: {mange_workspace_reconciled_version} to match Manage Operator version: {manage_version}"
@@ -307,9 +308,9 @@ data:
     def test_get_manage_ai_service_ping(manage_host,manage_host_ca_filepath):
         # if isVersionApplicable==False:
         #    pytest.skip("Skipping because version is below 9.1")
-      # with open(manage_host_ca_filepath, 'r') as file:
-      #   content = file.read()
-      # print(f"Contents of '{manage_host_ca_filepath}': {content}")
+      with open(manage_host_ca_filepath, 'r') as file:
+        content = file.read()
+      print(f"Contents of '{manage_host_ca_filepath}': {content}")
 
       if aibroker_api_key == False:
         pytest.skip("AI Broker API key not found.")

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -229,6 +229,13 @@ data:
         assert False, f"Unable to determine manage host; spec.host key not present in {manage_route_name}/{manage_namespace}: {manage_route}. Error details: {e}"
 
     @pytest.fixture(scope="session")
+    def manage_service(manage_route):
+      try:
+        yield manage_route['spec']['to']['name']
+      except KeyError as e:
+        assert False, f"Unable to determine manage host; spec.host key not present in {manage_route_name}/{manage_namespace}: {manage_route}. Error details: {e}"
+
+    @pytest.fixture(scope="session")
     def manage_host_ca_filepath(manage_route):
 
       # Read the certificate field from the Manage Route. 
@@ -307,21 +314,25 @@ data:
       if status_serverbundles is not None:
         assert spec_serverbundles == status_serverbundles, f"Expected serverbundles set in the spec: {spec_serverbundles} to be equal to the serverbundles in the status: {status_serverbundles}"
 
-    def test_get_manage_ai_service_ping(manage_host,manage_host_ca_filepath):
+    def test_get_manage_ai_service_ping(manage_service,manage_host_ca_filepath):
         # if isVersionApplicable==False:
         #    pytest.skip("Skipping because version is below 9.1")
       # with open(manage_host_ca_filepath, 'r') as file:
       #   content = file.read()
       # print(f"Contents of '{manage_host_ca_filepath}': {content}")
+      # f"https://testmanage-masdev-ui.mas-testmanage-manage.svc.cluster.local/maximo/api/pingaiservice",
 
       if aibroker_api_key == False:
         pytest.skip("AI Broker API key not found.")
 
-      # if manage_host:
-      MANAGE_URL = f'https://{mas_instance_id}-{mas_workspace_id}.mas-{mas_instance_id}-manage.svc'
+      if manage_service:
+        print("service")
+        print(manage_service)
+        MANAGE_URL = f'https://{manage_service}.mas-{mas_instance_id}-manage.svc.cluster.local'
+
       try:
         resp = requests.get(
-          f"https://testmanage-masdev-ui.mas-testmanage-manage.svc.cluster.local/maximo/api/pingaiservice",
+          f"{MANAGE_URL}/maximo/api/pingaiservice",
           headers={
           "Content-Type": "application/json"
           },

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -172,7 +172,6 @@ data:
     aibroker_api_key = os.getenv("AIBROKERAPIKEY")
     manage_namespace = f"mas-{mas_instance_id}-manage"
     manage_route_name = f"{mas_instance_id}-manage-{mas_workspace_id}"
-    MANAGE_URL = ""
     MAX_RETRY = 20
 
     @pytest.fixture(scope="session")
@@ -225,13 +224,6 @@ data:
         yield v1_routes.get(name=manage_route_name, namespace=manage_namespace)
 
     @pytest.fixture(scope="session")
-    def manage_host(manage_route):
-      try:
-        yield manage_route['spec']['host']
-      except KeyError as e:
-        assert False, f"Unable to determine manage host; spec.host key not present in {manage_route_name}/{manage_namespace}: {manage_route}. Error details: {e}"
-
-    @pytest.fixture(scope="session")
     def manage_service(manage_route):
       try:
         yield manage_route['spec']['to']['name']
@@ -245,7 +237,6 @@ data:
       # This may include CA certificates that we need in order to trust the certificates presented by the external Manage endpoint.
       try:
         manage_route_certificate = manage_route['spec']['tls']['certificate']
-        # print(f"Contents of 'manage_route_certificate': {manage_route_certificate}")
       except KeyError as e:
         pass
 
@@ -253,7 +244,6 @@ data:
       # This may include CA certificates that we need in order to trust the certificates presented by the external Manage endpoint.
       try:
         manage_route_caCertificate = manage_route['spec']['tls']['key']
-        # print(f"Contents of 'manage_route_caCertificate': {manage_route_caCertificate}")
       except KeyError as e:
         pass
 
@@ -261,7 +251,6 @@ data:
       # This may include CA certificates that we need in order to trust the certificates presented by the internal Manage services.
       try:
         manage_route_destinationCACertificate = manage_route['spec']['tls']['destinationCACertificate']
-        # print(f"Contents of 'manage_route_destinationCACertificate': {manage_route_destinationCACertificate}")
       except KeyError as e:
         pass
 

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -313,7 +313,7 @@ data:
         # if isVersionApplicable==False:
         #    pytest.skip("Skipping because version is below 9.1")
       with open(manage_host_ca_filepath, 'r') as file:
-      content = file.read()
+        content = file.read()
       print(f"Contents of '{manage_host_ca_filepath}': {content}")
 
       if aibroker_api_key == False:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -313,6 +313,7 @@ data:
 
       if aibroker_api_key == False:
         pytest.skip("AI Broker API key not found.")
+        print( f"https://{manage_host}/maximo/api/ping")
 
       #if manage_host:
       #    MANAGE_URL = f'https://{mas_instance_id}-{mas_workspace_id}.mas-{mas_instance_id}-manage.svc'
@@ -333,7 +334,7 @@ data:
 
       resp_json = resp.json()
       logger.info("ping to ai service ::")
-      logger.info(response.text)
+      logger.info(resp.text)
 
       assert resp.status_code == 200, f"Expected status 200 from GET /maximo/api/pingaiservice, but got {resp.status_code}. Body: {resp_json}."
 

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -231,24 +231,27 @@ data:
     @pytest.fixture(scope="session")
     def manage_host_ca_filepath(manage_route):
 
-      # # Read the certificate field from the Manage Route. 
-      # # This may include CA certificates that we need in order to trust the certificates presented by the external Manage endpoint.
-      # try:
-      #   manage_route_certificate = manage_route['spec']['tls']['certificate']
-      # except KeyError as e:
-      #   pass
+      # Read the certificate field from the Manage Route. 
+      # This may include CA certificates that we need in order to trust the certificates presented by the external Manage endpoint.
+      try:
+        manage_route_certificate = manage_route['spec']['tls']['certificate']
+        print(f"Contents of '{manage_route_certificate}': {manage_route_certificate}")
+      except KeyError as e:
+        pass
 
-      # # Read the caCertificate field from the Manage Route. 
-      # # This may include CA certificates that we need in order to trust the certificates presented by the external Manage endpoint.
-      # try:
-      #   manage_route_caCertificate = manage_route['spec']['tls']['key']
-      # except KeyError as e:
-      #   pass
+      # Read the caCertificate field from the Manage Route. 
+      # This may include CA certificates that we need in order to trust the certificates presented by the external Manage endpoint.
+      try:
+        manage_route_caCertificate = manage_route['spec']['tls']['key']
+        print(f"Contents of '{manage_route_caCertificate}': {manage_route_caCertificate}")
+      except KeyError as e:
+        pass
 
       # Read the destinationCACertificate field from the Manage Route. 
       # This may include CA certificates that we need in order to trust the certificates presented by the internal Manage services.
       try:
         manage_route_destinationCACertificate = manage_route['spec']['tls']['destinationCACertificate']
+        print(f"Contents of '{manage_route_destinationCACertificate}': {manage_route_destinationCACertificate}")
       except KeyError as e:
         pass
 
@@ -262,11 +265,11 @@ data:
       chain_file = tempfile.NamedTemporaryFile(delete=False)
       try:
         
-        # if manage_route_certificate:
-        #   chain_file.write(manage_route_certificate.encode())
+        if manage_route_certificate:
+          chain_file.write(manage_route_certificate.encode())
         
-        # if manage_route_caCertificate:
-        #   chain_file.write(manage_route_caCertificate.encode())
+        if manage_route_caCertificate:
+          chain_file.write(manage_route_caCertificate.encode())
 
         if manage_route_destinationCACertificate:
           chain_file.write(manage_route_destinationCACertificate.encode())
@@ -325,7 +328,8 @@ data:
           headers={
           "Content-Type": "application/json"
           },
-          verify=False
+          # verify=False
+          verify=manage_host_ca_filepath
         )
         resp.raise_for_status()  # Raise an error for bad responses
       except requests.exceptions.RequestException as e:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -317,8 +317,8 @@ data:
       if aibroker_api_key == False:
         pytest.skip("AI Broker API key not found.")
 
-      #if manage_host:
-        # MANAGE_URL = f'https://{mas_instance_id}-{mas_workspace_id}.mas-{mas_instance_id}-manage.svc'
+      # if manage_host:
+      MANAGE_URL = f'https://{mas_instance_id}-{mas_workspace_id}.mas-{mas_instance_id}-manage.svc'
       #  f"{MANAGE_URL}/maximo/api/pingaiservice",
 
       try:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -320,7 +320,6 @@ data:
       # if manage_host:
       MANAGE_URL = f'https://{mas_instance_id}-{mas_workspace_id}.mas-{mas_instance_id}-manage.svc'
       #  f"{MANAGE_URL}/maximo/api/pingaiservice",
-      http://testmanage-masdev-ui.mas-testmanage-manage.svc.cluster.local:9080
       try:
         resp = requests.get(
           # f"https://{manage_host}/maximo/api/pingaiservice",

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -282,8 +282,7 @@ data:
         yield chain_file.name
 
       finally:
-        # os.remove(chain_file.name)
-        print(f"check finally")
+        os.remove(chain_file.name)
 
     def test_expected_reconciled_version(mange_workspace_reconciled_version, manage_version):
       assert manage_version == mange_workspace_reconciled_version, f"Expected ManageWorkspace Reconciled version: {mange_workspace_reconciled_version} to match Manage Operator version: {manage_version}"
@@ -324,8 +323,7 @@ data:
 
       try:
         resp = requests.get(
-          # f"https://{manage_host}/maximo/api/pingaiservice",
-          f"https://testmanage-masdev-ui.mas-testmanage-manage.svc.cluster.local/maximo/api/pingaiservice",
+          f"https://{MANAGE_URL}/maximo/api/pingaiservice",
           headers={
           "Content-Type": "application/json"
           },

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -154,6 +154,8 @@ data:
     import pytest
     import os
     import requests
+    import certifi
+    import tempfile
     
     mas_instance_id = os.getenv("MAS_INSTANCE_ID")
     if mas_instance_id is None:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -342,15 +342,15 @@ data:
 
       assert resp.status_code == 200, f"Expected status 200 from GET /maximo/api/pingaiservice, but got {resp.status_code}. Body: {resp_json}."
 
-     try:
-       assert resp_json['aiservicehealth'] == True, f"Expected healthy field from GET /maximo/api/pingaiservice to be true, but was {resp_json['aiservicehealth']}. Body: {resp_json}"
-     except KeyError as e:
-       assert False, f"Expected aiservicehealth key not found in response from GET /maximo/api/pingaiservice. Body: {resp_json}"
+      try:
+        assert resp_json['aiservicehealth'] == True, f"Expected healthy field from GET /maximo/api/pingaiservice to be true, but was {resp_json['aiservicehealth']}. Body: {resp_json}"
+      except KeyError as e:
+        assert False, f"Expected aiservicehealth key not found in response from GET /maximo/api/pingaiservice. Body: {resp_json}"
 
-     try:
-       assert resp_json['aiserviceapikey'] == True, f"Expected healthy field from GET /maximo/api/pingaiservice to be true, but was {resp_json['aiserviceapikey']}. Body: {resp_json}"
-     except KeyError as e:
-       assert False, f"Expected aiserviceapikey key not found in response from GET /maximo/api/pingaiservice. Body: {resp_json}"
+      try:
+        assert resp_json['aiserviceapikey'] == True, f"Expected healthy field from GET /maximo/api/pingaiservice to be true, but was {resp_json['aiserviceapikey']}. Body: {resp_json}"
+      except KeyError as e:
+        assert False, f"Expected aiserviceapikey key not found in response from GET /maximo/api/pingaiservice. Body: {resp_json}"
 
 ---
 kind: ConfigMap

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -329,7 +329,7 @@ data:
           "Content-Type": "application/json"
           },
           # verify=False
-          verify=manage_host_ca_filepath
+          # verify=manage_host_ca_filepath
         )
         resp.raise_for_status()  # Raise an error for bad responses
       except requests.exceptions.RequestException as e:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -241,7 +241,7 @@ data:
       # Read the caCertificate field from the Manage Route. 
       # This may include CA certificates that we need in order to trust the certificates presented by the external Manage endpoint.
       try:
-        manage_route_caCertificate = manage_route['spec']['tls']['caCertificate']
+        manage_route_caCertificate = manage_route['spec']['tls']['key']
       except KeyError as e:
         pass
 
@@ -262,14 +262,14 @@ data:
       chain_file = tempfile.NamedTemporaryFile(delete=False)
       try:
         
-        # if manage_route_certificate:
-        #   chain_file.write(manage_route_certificate.encode())
+        if manage_route_certificate:
+          chain_file.write(manage_route_certificate.encode())
         
         if manage_route_caCertificate:
           chain_file.write(manage_route_caCertificate.encode())
 
-        # if manage_route_destinationCACertificate:
-        #   chain_file.write(manage_route_destinationCACertificate.encode())
+        if manage_route_destinationCACertificate:
+          chain_file.write(manage_route_destinationCACertificate.encode())
 
         chain_file.write(default_ca_content)
 

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -312,11 +312,7 @@ data:
     def test_get_manage_ai_service_ping(manage_host,manage_host_ca_filepath):
         # if isVersionApplicable==False:
         #    pytest.skip("Skipping because version is below 9.1")
-
-      logger.info("Host CA Filepath:")
-      contents = os.listdir(manage_host_ca_filepath)
-      print(f"Contents of '{manage_host_ca_filepath}': {contents}")
-      #logger.info(manage_host_ca_filepath)
+      print(f"Contents of '{manage_host_ca_filepath}': {manage_host_ca_filepath}")
 
       if aibroker_api_key == False:
         pytest.skip("AI Broker API key not found.")

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -215,7 +215,7 @@ data:
     def manage_host(manage_route):
       try:
         yield manage_route[spec][host]
-      except KeyError as e;
+      except KeyError as e:
         assert False, f"Unable to determine manage host; spec.host key not present in {manage_route_name}/{manageNamespace}: {manage_route}. Error details: {e}"
 
     @pytest.fixture(scope="session")

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -321,7 +321,7 @@ data:
 
       try:
         resp = requests.get(
-          f"https://{manage_host}/maximo/api/ping",
+          f"https://{manage_host}/maximo/api/pingaiservice",
           headers={
           "Content-Type": "application/json"
           },

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -157,7 +157,6 @@ data:
     import certifi
     import tempfile
     import logging
-    import time
 
     logger = logging.getLogger()
     mas_instance_id = os.getenv("MAS_INSTANCE_ID")
@@ -321,15 +320,15 @@ data:
       # if manage_host:
       MANAGE_URL = f'https://{mas_instance_id}-{mas_workspace_id}.mas-{mas_instance_id}-manage.svc'
       #  f"{MANAGE_URL}/maximo/api/pingaiservice",
-
+      http://testmanage-masdev-ui.mas-testmanage-manage.svc.cluster.local:9080
       try:
         resp = requests.get(
-          f"https://{MANAGE_URL}/maximo/api/pingaiservice",
+          # f"https://{manage_host}/maximo/api/pingaiservice",
+          f"http://testmanage-masdev-ui.mas-testmanage-manage.svc.cluster.local:9080/maximo/api/pingaiservice",
           headers={
           "Content-Type": "application/json"
-          },
-          # verify=False
-          verify=manage_host_ca_filepath
+          }
+          # verify=manage_host_ca_filepath
         )
         resp.raise_for_status()  # Raise an error for bad responses
       except requests.exceptions.RequestException as e:
@@ -351,7 +350,6 @@ data:
         assert resp_json['aiserviceapikey'] == True, f"Expected healthy field from GET /maximo/api/pingaiservice to be true, but was {resp_json['aiserviceapikey']}. Body: {resp_json}"
       except KeyError as e:
         assert False, f"Expected aiserviceapikey key not found in response from GET /maximo/api/pingaiservice. Body: {resp_json}"
-      time.sleep(50000)
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -235,7 +235,7 @@ data:
       # This may include CA certificates that we need in order to trust the certificates presented by the external Manage endpoint.
       try:
         manage_route_certificate = manage_route['spec']['tls']['certificate']
-        print(f"Contents of '{manage_route_certificate}': {manage_route_certificate}")
+        print(f"Contents of 'manage_route_certificate': {manage_route_certificate}")
       except KeyError as e:
         pass
 
@@ -243,7 +243,7 @@ data:
       # This may include CA certificates that we need in order to trust the certificates presented by the external Manage endpoint.
       try:
         manage_route_caCertificate = manage_route['spec']['tls']['key']
-        print(f"Contents of '{manage_route_caCertificate}': {manage_route_caCertificate}")
+        print(f"Contents of 'manage_route_caCertificate': {manage_route_caCertificate}")
       except KeyError as e:
         pass
 
@@ -251,7 +251,7 @@ data:
       # This may include CA certificates that we need in order to trust the certificates presented by the internal Manage services.
       try:
         manage_route_destinationCACertificate = manage_route['spec']['tls']['destinationCACertificate']
-        print(f"Contents of '{manage_route_destinationCACertificate}': {manage_route_destinationCACertificate}")
+        print(f"Contents of 'manage_route_destinationCACertificate': {manage_route_destinationCACertificate}")
       except KeyError as e:
         pass
 

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -264,20 +264,15 @@ data:
         
         if manage_route_certificate:
           chain_file.write(manage_route_certificate.encode())
-          # print("manage_route_certificate")
-          # print(manage_route_certificate.encode())
         
         if manage_route_caCertificate:
-          chain_file.write(manage_route_caCertificate.encode())
-          # print("manage_route_caCertificate")
-          # print(manage_route_caCertificate.encode())
+          chain_file.write(manage_route_certificate.encode())
 
         if manage_route_destinationCACertificate:
           chain_file.write(manage_route_destinationCACertificate.encode())
-          # print("manage_route_destinationCACertificate")
-          # print(manage_route_destinationCACertificate.encode())
 
         chain_file.write(default_ca_content)
+
         chain_file.flush()
         chain_file.close()
 

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -325,8 +325,7 @@ data:
           headers={
           "Content-Type": "application/json"
           },
-          # verify=manage_host_ca_filepath
-          verify=false
+          verify=manage_host_ca_filepath
         )
         resp.raise_for_status()  # Raise an error for bad responses
       except requests.exceptions.RequestException as e:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -262,8 +262,8 @@ data:
       chain_file = tempfile.NamedTemporaryFile(delete=False)
       try:
         
-        if manage_route_certificate:
-          chain_file.write(manage_route_certificate.encode())
+        # if manage_route_certificate:
+        #   chain_file.write(manage_route_certificate.encode())
         
         if manage_route_caCertificate:
           chain_file.write(manage_route_caCertificate.encode())


### PR DESCRIPTION
This PR contains logic for AI Service connectivity from Manage application to AI service using the unauthenticated ping API  provided by the Manage dev team.

Changes included:
Modified k8s authorization role for accessing Openshift routes
Modified helm template logic for checking aibroker api key in post sync verify job environment
Wrote AI service connectivity tests through Manage with retry strategy & methods for retry logic
Updated tests.py in:
instance-applications/510-550-ibm-mas-suite-app-config/templates/04-post-sync-manage-verify.yaml

Verified retry logic for all scenarios 
Verified Ping AI service API for connectivity

<img width="1619" height="1069" alt="Retry_false_apikey_only" src="https://github.com/user-attachments/assets/a299eafe-7980-4b67-802f-4174f51dd1c9" />
<img width="1415" height="826" alt="Screenshot 2025-08-13 at 12 35 40 PM" src="https://github.com/user-attachments/assets/4c313da4-41d8-4d3a-be1b-89b73b7141f1" />
<img width="1572" height="462" alt="image (5)" src="https://github.com/user-attachments/assets/5f252a90-2d2b-4273-809a-8dcfb78c6dd8" />
<img width="1564" height="494" alt="image (4)" src="https://github.com/user-attachments/assets/18eb6a64-34ae-4a81-a466-85592e0808ac" />
