### PR TITLE
[minor] Removed and update Kmodel Role

### DIFF
--- a/instance-applications/114-ibm-kmodels/templates/06-kmodel-watcher.yaml
+++ b/instance-applications/114-ibm-kmodels/templates/06-kmodel-watcher.yaml
@@ -51,12 +51,10 @@ metadata:
   labels:
     app: km-watcher
 data:
-  EXCLUDE_POD_NAMESPACES: "openshift-operators,openshift-pipelines"
-  WATCHER_SENDER_DELAY: "5"
-  EXCLUDE_JOB_NAMESPACES: "ibm-cpd"
-  CONTROLLER_URL: "https://km-controller:8443"
+  EXCLUDE_TENANTS: provision-tenant
   TENANTS_BUCKET: {{ .Values.mas_aibroker_storage_tenants_bucket }}
   PIPELINES: "{{ .Values.aibroker_namespace }}"
+
 ---
 apiVersion: v1
 kind: Service

--- a/instance-applications/114-ibm-kmodels/templates/07-kmodel-controller.yaml
+++ b/instance-applications/114-ibm-kmodels/templates/07-kmodel-controller.yaml
@@ -58,7 +58,6 @@ spec:
       storage: 1Gi
   storageClassName: "{{ .Values.primary_storage_class }}"
 
-
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -67,7 +66,6 @@ metadata:
   namespace: "{{ .Values.aibroker_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "181"
-
 
 ---
 apiVersion: apps/v1

--- a/instance-applications/114-ibm-kmodels/templates/07-kmodel-controller.yaml
+++ b/instance-applications/114-ibm-kmodels/templates/07-kmodel-controller.yaml
@@ -10,14 +10,12 @@ metadata:
     app: km-controller
 data:
   CONTAINER_REGISTRY: "{{ .Values.mas_icr_cp }}/aibroker"
-  #DOCKER_SERVER: "{{ .Values.mas_icr_cp }}/aibroker"
   PIPELINES_BUCKET: "{{ .Values.mas_aibroker_storage_pipelines_bucket }}"
   TENANTS_BUCKET: "{{ .Values.mas_aibroker_storage_tenants_bucket }}"
   DOCKER_SECRETS_NAME: "ibm-entitlement"
   CONNECTOR_IMAGE_PREFIX: ''
   PIPELINE_STEP_IMAGE_PREFIX: '' 
   PIPELINE_DEFAULT_STEP_TAG: "{{ .Values.mas_aibroker_pipeline_steps_tag }}"
-  CONNECTOR_DEFAULT_TAG: "{{ .Values.mas_aibroker_connector_tag }}"
   DEFAULT_TENANTS: "{{ .Values.mas_aibroker_provision_tenant }}"
   PLATFORM: openshift
   PVC_STORAGE_CLASS_NAME: "{{ .Values.primary_storage_class }}"
@@ -25,8 +23,6 @@ data:
   MODEL_ID_UNIQUE_LENGTH: "{{ .Values.model_id_unique_length }}"
   MODEL_ID_PREFIX: "{{ .Values.model_id_prefix }}"
   AFFINITY_ENABLED: "false"
-  CONNECTOR_TTL: "10"
-
 
 ---
 apiVersion: v1


### PR DESCRIPTION
Removed unwanted code as per the Ansible changes. The update was required in the staging environment due to a model training issue
Removed the code kmodel-watcher.yaml 
  EXCLUDE_POD_NAMESPACES: "openshift-operators,openshift-pipelines"
  WATCHER_SENDER_DELAY: "5"
  EXCLUDE_JOB_NAMESPACES: "ibm-cpd"
  CONTROLLER_URL: "https://km-controller:8443"

Removed the code kmodel-controller.yaml
  CONNECTOR_TTL: "10"
  CONNECTOR_DEFAULT_TAG: "{{ .Values.mas_aibroker_connector_tag }}"

Need to update with value "1.0.4" PIPELINE_DEFAULT_STEP_TAG