### PR TITLE
Provision Standalone SLS Server

### DIFF
--- a/cluster-applications/060-custom-sa/templates/03-postsync-update-sm_rbac.yaml
+++ b/cluster-applications/060-custom-sa/templates/03-postsync-update-sm_rbac.yaml
@@ -43,8 +43,8 @@ metadata:
 {{- end }}    
 rules:
 - apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get", "watch", "list"]
+  resources: ["secrets","serviceaccounts/token"]
+  verbs: ["get", "watch", "list","create"]
 
 ---
 kind: RoleBinding

--- a/cluster-applications/060-custom-sa/templates/04-postsync-update-sm_Job.yaml
+++ b/cluster-applications/060-custom-sa/templates/04-postsync-update-sm_Job.yaml
@@ -127,9 +127,13 @@ spec:
               # Get name of secret generated for the custom service account
               echo "Fetching name of secret generated for custom service account ${CUSTOM_SA_NAME}"
               SECRET_NAME=$(oc get secret -n ${CUSTOM_SA_NAMESPACE} | grep ${CUSTOM_SA_NAME}-token | head -1 | cut -d' ' -f1)
+              # As of kubernetes 1.27, the token required is no longer generated
+              # OCP 4.18 ships with Kubernetes 1.31
+              # Create the token and the secret manually if it doesn't already exist.
               if [[ -z "${SECRET_NAME}" ]]; then
-                echo "Failed to fetch secret name"
-                exit 1
+                SECRET_NAME="${CUSTOM_SA_NAME}-token"
+                SECRET_TOKEN=$(oc create token ${CUSTOM_SA_NAME} --duration=$((24*365*10))h)
+                oc create secret generic ${SECRET_NAME} --from-literal=token=${SECRET_TOKEN}
               fi
               
               # Get secret token to store in sm

--- a/root-applications/ibm-mas-cluster-root/templates/065-sls-appset.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/065-sls-appset.yaml
@@ -1,0 +1,111 @@
+---
+# IBM Maximo Application Suite Instance Application Set
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: sls-appset.{{ .Values.cluster.id }}
+  namespace: {{ .Values.argo.namespace }}
+  labels:
+    environment: '{{ .Values.account.id }}'
+    region: '{{ .Values.region.id }}'
+    cluster: '{{ .Values.cluster.id }}'
+  annotations:
+    argocd.argoproj.io/sync-wave: "065"
+spec:
+  goTemplate: true
+  generators:
+    - git:
+        repoURL: "{{ .Values.generator.repo_url }}"
+        revision: "{{ .Values.generator.revision }}"
+        files:
+        - path: "{{ .Values.account.id }}/icn/*/ibm-sls.yaml"
+  syncPolicy:
+    applicationsSync: "{{- if .Values.auto_delete }}sync{{- else }}create-update{{- end }}"
+  template:
+    metadata:
+      name: "sls.root.{{ `{{.ibm_sls_standalone.ibm_customer_number}}` }}.{{ `{{.ibm_sls_standalone.subscription_id}}` }}"
+      labels:
+        environment: '{{ .Values.account.id }}'
+        region: '{{ .Values.region.id }}'
+        cluster: '{{ .Values.cluster.id }}'
+        icn: "{{ `{{.ibm_sls_standalone.ibm_customer_number}}` }}"
+        subscription-id: "{{ `{{.ibm_sls_standalone.subscription_id}}` }}"
+{{- if .Values.custom_labels }}
+{{ .Values.custom_labels | toYaml | indent 8 }}
+{{- end }}
+      annotations:
+        healthCheckTimeout: "1800"
+        argocd.argoproj.io/sync-wave: "065"
+        {{- if and .Values.notifications .Values.notifications.slack_channel_id }}
+        notifications.argoproj.io/subscribe.on-sync-failed.workspace1: {{ .Values.notifications.slack_channel_id }}
+        notifications.argoproj.io/subscribe.on-sync-succeeded.workspace1: {{ .Values.notifications.slack_channel_id }}
+        {{- end }}
+    spec:
+      project: "{{ .Values.argo.projects.rootapps }}"
+      source:
+        repoURL: "{{ .Values.source.repo_url }}"
+        targetRevision: "{{ .Values.source.revision }}"
+        path: root-applications/ibm-mas-sls-root
+        helm:
+          releaseName: slsappset
+          values: "{{ `{{ toYaml . }}` }}"
+          parameters:
+              - name: "generator.repo_url"
+                value: "{{ .Values.generator.repo_url }}"
+              - name: "generator.revision"
+                value: "{{ .Values.generator.revision }}"
+              - name: "source.revision"
+                value: "{{ .Values.source.revision }}"
+              - name: "source.repo_url"
+                value: "{{ .Values.source.repo_url }}"
+              - name: argo.namespace
+                value: "{{ .Values.argo.namespace }}"
+                {{- if and .Values.notifications .Values.notifications.slack_channel_id }}
+              - name: "notifications.slack_channel_id"
+                value: "{{ .Values.notifications.slack_channel_id }}"
+                {{- end }}
+              - name: "mas_catalog_version"
+                value: "{{ .Values.ibm_operator_catalog.mas_catalog_version }}"
+              - name: argo.projects.rootapps
+                value: "{{ .Values.argo.projects.rootapps }}"
+              - name: argo.projects.apps
+                value: "{{ .Values.argo.projects.apps }}"
+              - name: avp.name
+                value: "{{ .Values.avp.name }}"
+              - name: avp.secret
+                value: "{{ .Values.avp.secret }}"
+              - name: avp.values_varname
+                value: "{{ .Values.avp.values_varname }}"
+              - name: auto_delete
+                value: "{{ .Values.auto_delete }}"
+              - name: devops.mongo_uri
+                value: "{{ .Values.devops.mongo_uri }}"
+              - name: devops.build_number
+                value: "{{ .Values.devops.build_number }}"
+              - name: override_dns_cis_flags_to_false
+                value: "{{ .Values.override_dns_cis_flags_to_false }}"
+      destination:
+        server: 'https://kubernetes.default.svc'
+        namespace: {{ .Values.argo.namespace }}
+      syncPolicy:
+        automated:
+          {{- if .Values.auto_delete }}
+          prune: true
+          {{- end }}
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=false
+          - RespectIgnoreDifferences=true
+        retry:
+          limit: -1
+      ignoreDifferences:
+        - group: '*'
+          kind: ServiceAccount
+          jsonPointers:
+            - /imagePullSecrets
+        - group: 'marketplace.redhat.com/v1alpha1'
+          kind: MarketplaceConfig
+          jsonPointers:
+            - /spec
+      # revisionHistoryLimit set to 1 due to size limit of what can be stored in etcd for anything larger
+      revisionHistoryLimit: 1

--- a/root-applications/ibm-mas-sls-root/Chart.yaml
+++ b/root-applications/ibm-mas-sls-root/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: ibm-mas-sls-root
+description: IBM MAS SLS root
+type: application
+version: 1.0.0

--- a/root-applications/ibm-mas-sls-root/README.md
+++ b/root-applications/ibm-mas-sls-root/README.md
@@ -1,0 +1,3 @@
+IBM MAS SLS Root Application
+===============================================================================
+Installs various ArgoCD Applications for managing instance-level MAS dependencies (e.g. SLS, DB2 Databases), MAS Core and MAS Applications (e.g. Manage, Monitor, etc) on the target cluster.

--- a/root-applications/ibm-mas-sls-root/templates/100-ibm-sls-app.yaml
+++ b/root-applications/ibm-mas-sls-root/templates/100-ibm-sls-app.yaml
@@ -1,0 +1,91 @@
+{{- if not (empty .Values.ibm_sls_standalone) }}
+---
+# IBM Maximo Operator Catalog
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sls.{{ .Values.ibm_sls_standalone.ibm_customer_number }}.{{ .Values.ibm_sls_standalone.subscription_id }}
+  namespace: {{ .Values.argo.namespace }}
+  labels:
+    environment: '{{ .Values.account.id }}'
+    cluster: '{{ .Values.cluster.id }}'
+  annotations:
+    argocd.argoproj.io/sync-wave: "100"
+    {{- if and .Values.notifications .Values.notifications.slack_channel_id }}
+    notifications.argoproj.io/subscribe.on-sync-failed.workspace1: {{ .Values.notifications.slack_channel_id }}
+    notifications.argoproj.io/subscribe.on-sync-succeeded.workspace1: {{ .Values.notifications.slack_channel_id }}
+    {{- end }}
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  ignoreDifferences:
+  - group: '*'
+    kind: ServiceAccount
+    jsonPointers:
+    - /imagePullSecrets
+  project: "{{ .Values.argo.projects.apps }}"
+  destination:
+    server: {{ .Values.cluster.url }}
+    namespace: mas-{{ .Values.ibm_sls_standalone.ibm_customer_number }}-{{ .Values.ibm_sls_standalone.subscription_id }}-sls
+  source:
+    repoURL: "{{ .Values.source.repo_url }}"
+    path: sls-applications/100-ibm-sls
+    targetRevision: "{{ .Values.source.revision }}"
+    plugin:
+      name: {{ .Values.avp.name }} 
+      env:
+        - name: {{ .Values.avp.values_varname }}
+          value: |
+            account_id: "{{ .Values.account.id }}"
+            region_id: "{{ .Values.region.id }}"
+            cluster_id: "{{ .Values.cluster.id }}"
+            ibm_customer_number: "{{ .Values.ibm_sls_standalone.ibm_customer_number }}"
+            subscription_id: "{{ .Values.ibm_sls_standalone.subscription_id }}"
+            sls_domain: "{{ .Values.ibm_sls_standalone.sls_domain }}"
+            argo_namespace: "{{ .Values.argo.namespace }}"
+            sm_aws_access_key_id: "{{ .Values.sm.aws_access_key_id }}"
+            sm_aws_secret_access_key: "{{ .Values.sm.aws_secret_access_key }}"
+            run_sync_hooks: {{.Values.ibm_sls_standalone.run_sync_hooks }}
+            sls_channel: "{{ .Values.ibm_sls_standalone.sls_channel }}"
+            ibm_entitlement_key: "{{ .Values.ibm_sls_standalone.ibm_entitlement_key }}"
+            sls_mongo_secret_name: "{{ .Values.ibm_sls_standalone.sls_mongo_secret_name }}"
+            sls_mongo_username: "{{ .Values.ibm_sls_standalone.sls_mongo_username }}"
+            sls_mongo_password: "{{ .Values.ibm_sls_standalone.sls_mongo_password }}"
+            sls_entitlement_file: "{{ .Values.ibm_sls_standalone.sls_entitlement_file }}"
+            icr_cp_open: "{{ .Values.ibm_sls_standalone.icr_cp_open }}"
+            sls_install_plan: "{{ .Values.ibm_sls_standalone.sls_install_plan }}"
+            mongo_spec: {{ .Values.ibm_sls_standalone.mongo_spec | toYaml | nindent 14}}
+            {{- if .Values.custom_labels }}
+            custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
+            {{- end }}
+            junitreporter:
+              reporter_name: "ibm-sls-{{ .Values.ibm_sls_standalone.ibm_customer_number }}-{{ .Values.ibm_sls_standalone.subscription_id}}"
+              cluster_id: "{{ .Values.cluster.id }}"
+              customer_id: "{{ .Values.ibm_sls_standalone.ibm_customer_number }}"
+              subscription_id: "{{ .Values.ibm_sls_standalone.subscription_id }}"
+              devops_mongo_uri: "{{ .Values.devops.mongo_uri }}"
+              devops_build_number: "{{ .Values.devops.build_number }}"
+              gitops_version: "{{ .Values.source.revision }}"
+        - name: ARGOCD_APP_NAME
+          value: slsapp
+        {{- if not (empty .Values.avp.secret) }}
+        - name: AVP_SECRET
+          value: {{ .Values.avp.secret }}
+        {{- end }}
+  syncPolicy:
+    automated:
+      {{- if .Values.auto_delete }}
+      prune: true
+      {{- end }}
+      selfHeal: true
+    retry:
+      limit: 20
+    syncOptions:
+      - CreateNamespace=true
+      - RespectIgnoreDifferences=true
+    managedNamespaceMetadata:
+      labels:
+{{- if .Values.custom_labels }}
+{{ .Values.custom_labels | toYaml | indent 8 }}
+{{- end }}
+{{- end }}

--- a/root-applications/ibm-mas-sls-root/values.yaml
+++ b/root-applications/ibm-mas-sls-root/values.yaml
@@ -1,0 +1,49 @@
+---
+
+avp:
+  name: "argocd-vault-plugin-helm"
+  secret: ""
+  values_varname: "HELM_VALUES"
+
+account:
+  id: dev
+
+cluster:
+  id: cluster1
+
+region:
+  id: region1 
+
+instance:
+  id: inst1
+
+source:
+  repo_url: "https://github.com/ibm-mas/gitops"
+  revision: "poc"
+
+# Customers will definitely need to customise this (our gitops-envs/mas-dev repos are private),
+# So deliberately not specifying defaults here; we want charts to refuse to render if these are not specified
+# Both of these correspond to requirement arguments of the gitops-bootstrap CLI function (--github-url and --github-revision)
+# generator:
+#   repo_url: ""
+#   revision: ""
+
+# These defaults align with the ArgoCD worker setup by gitops-bootstrap
+# (openshift-gitops with a single ArgoCD project "mas")
+argo:
+  namespace: "openshift-gitops"
+  projects:
+    rootapps: "mas"
+    apps: "mas"
+
+
+auto_delete: false
+
+sm:
+  aws_access_key_id: xxxx
+
+run_sanity_test: false
+
+devops:
+  mongo_uri:
+  build_number:

--- a/sls-applications/100-ibm-sls/Chart.yaml
+++ b/sls-applications/100-ibm-sls/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: ibm-sls
+description: IBM Suite License Service
+type: application
+version: 1.0.0
+
+dependencies:
+- name: junitreporter
+  version: 1.0.0
+  repository: "file://../../sub-charts/junitreporter/"
+  condition: junitreporter.devops_mongo_uri != ""

--- a/sls-applications/100-ibm-sls/README.md
+++ b/sls-applications/100-ibm-sls/README.md
@@ -1,0 +1,5 @@
+IBM Suite License Service
+===============================================================================
+Installs the `ibm-sls` operator and creates an instance of the `LicenseService`.
+
+Contains a job that runs last (`07-postsync-update-sm_Job.yaml`). This registers the `${ACCOUNT_ID}/${ICN}/${SAAS_SUB_ID}/sls` secret in the **Secrets Vault** used to share some information that is generated at runtime with other ArgoCD Applications.

--- a/sls-applications/100-ibm-sls/templates/01-ibm-sls_OperatorGroup.yaml
+++ b/sls-applications/100-ibm-sls/templates/01-ibm-sls_OperatorGroup.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: operators.coreos.com/v1alpha2
+kind: OperatorGroup
+metadata:
+  name: operatorgroup
+  namespace: mas-{{ .Values.ibm_customer_number }}-{{ .Values.subscription_id }}-sls
+  annotations:
+    argocd.argoproj.io/sync-wave: "101"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+spec:
+  targetNamespaces:
+    - mas-{{ .Values.ibm_customer_number }}-{{ .Values.subscription_id }}-sls

--- a/sls-applications/100-ibm-sls/templates/02-ibm-sls_Subscription.yaml
+++ b/sls-applications/100-ibm-sls/templates/02-ibm-sls_Subscription.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: ibm-sls
+  namespace: mas-{{ .Values.ibm_customer_number }}-{{ .Values.subscription_id }}-sls
+  annotations:
+    argocd.argoproj.io/sync-wave: "102"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+spec:
+  channel: "{{ .Values.sls_channel }}"
+  installPlanApproval: {{ .Values.sls_install_plan | default "Automatic" | quote }}
+  name: ibm-sls
+  source: ibm-operator-catalog
+  sourceNamespace: openshift-marketplace

--- a/sls-applications/100-ibm-sls/templates/03-ibm-entitlement_Secret.yaml
+++ b/sls-applications/100-ibm-sls/templates/03-ibm-entitlement_Secret.yaml
@@ -1,0 +1,16 @@
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: ibm-entitlement
+  namespace: mas-{{ .Values.ibm_customer_number }}-{{ .Values.subscription_id }}-sls
+  annotations:
+    argocd.argoproj.io/sync-wave: "102"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: >-
+    {{ .Values.ibm_entitlement_key }}

--- a/sls-applications/100-ibm-sls/templates/04-mongo-credentials_Secret.yaml
+++ b/sls-applications/100-ibm-sls/templates/04-mongo-credentials_Secret.yaml
@@ -1,0 +1,16 @@
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: "{{ .Values.sls_mongo_secret_name }}"
+  namespace: mas-{{ .Values.ibm_customer_number }}-{{ .Values.subscription_id }}-sls
+  annotations:
+    argocd.argoproj.io/sync-wave: "103"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+type: Opaque
+stringData:
+  username: "{{ .Values.sls_mongo_username }}"
+  password: "{{ .Values.sls_mongo_password }}"

--- a/sls-applications/100-ibm-sls/templates/05-ibm-sls-sls-entitlement_Secret.yaml
+++ b/sls-applications/100-ibm-sls/templates/05-ibm-sls-sls-entitlement_Secret.yaml
@@ -1,0 +1,16 @@
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: ibm-sls-sls-entitlement
+  namespace: mas-{{ .Values.ibm_customer_number }}-{{ .Values.subscription_id }}-sls
+  annotations:
+    argocd.argoproj.io/sync-wave: "104"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+type: Opaque
+stringData:
+  entitlement: >-
+    {{ .Values.sls_entitlement_file }}

--- a/sls-applications/100-ibm-sls/templates/06-ibm-sls_LicenseService.yaml
+++ b/sls-applications/100-ibm-sls/templates/06-ibm-sls_LicenseService.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: sls.ibm.com/v1
+kind: LicenseService
+metadata:
+  name: sls
+  namespace: mas-{{ .Values.ibm_customer_number }}-{{ .Values.subscription_id }}-sls
+  annotations:
+    argocd.argoproj.io/sync-wave: "105"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+spec:
+  domain: {{ .Values.sls_domain }}
+  mongo: 
+{{  .Values.mongo_spec | toYaml | indent 4 }}
+  license:
+    accept: true
+  settings:
+    auth:
+      enforce: true
+    registration:
+      open: true
+    {{- if .Values.icr_cp_open }}
+    registry: "{{ .Values.icr_cp_open }}"
+    {{ end }}

--- a/sls-applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
+++ b/sls-applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
@@ -1,0 +1,290 @@
+{{- if .Values.run_sync_hooks }}
+
+{{- /*
+Meaningful prefix for the job resource name. Must be under 52 chars in length to leave room for the 11 chars reserved for '-' and $_job_hash.
+*/}}
+{{- $_job_name_prefix := "postsync-ibm-sls-update-sm-job" }}
+
+{{- /*
+Use the build/bin/set-cli-image-digest.sh script to update this value across all charts.
+Included in $_job_hash (see below).
+*/}}
+{{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
+
+{{- /*
+A dict of values that influence the behaviour of the job in some way.
+Any changes to values in this dict will trigger a rerun of the job.
+Since jobs must be idemopotent, it's generally safe to pass in values here that are not
+strictly necessary (i.e. including some values that don't actually influence job behaviour).
+We may want to refine this further though for jobs that can take a long time to complete.
+Included in $_job_hash (see below).
+*/}}
+{{- $_job_config_values := omit .Values "junitreporter" }}
+
+{{- /*
+Increment this value whenever you make a change to an immutable field of the Job resource.
+E.g. passing in a new environment variable.
+Included in $_job_hash (see below).
+*/}}
+{{- $_job_version := "v3" }}
+
+{{- /*
+10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_digest
+This is to ensure ArgoCD will create a new job resource intead of attempting (and failing) to update an
+immutable field of any existing Job resource.
+*/}}
+{{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_digest $_job_version | adler32sum }}
+
+{{- $_job_name := join "-" (list $_job_name_prefix $_job_hash )}}
+
+{{- /*
+Set as the value for the mas.ibm.com/job-cleanup-group label on the Job resource.
+
+When the auto_delete flag is not set on the root application, a CronJob in the cluster uses this label 
+to identify old Job resources that should be pruned on behalf of ArgoCD.
+
+Any Job resources in the same namespace that have the mas.ibm.com/job-cleanup-group with this value
+will be considered to belong to the same cleanup group. All but the most recent (i.e. with the latest "creation_timestamp")
+Jobs will be automatically deleted.
+
+$_job_cleanup_group can usually just be based on $_job_name_prefix. There are some special cases
+where multiple Jobs are created in our templates using a Helm loop. In those cases, additional descriminators
+must be added to $_job_cleanup_group.
+
+By convention, we sha1sum this value to guarantee we never exceed the 63 char limit regardless of which discriminators
+are required here.
+
+*/}}
+{{- $_job_cleanup_group := cat $_job_name_prefix | sha1sum }}
+
+
+
+{{ $ns := printf "mas-%s-%s-sls" .Values.ibm_customer_number .Values.subscription_id }}
+{{ $instance := printf "%s-%s" .Values.ibm_customer_number .Values.subscription_id }}
+
+{{ $aws_secret := "aws"}}
+{{ $np_name :=    "postsync-ibm-sls-update-sm-np" }}
+{{ $role_name :=  "postsync-ibm-sls-update-sm-r" }}
+{{ $sa_name :=    "postsync-ibm-sls-update-sm-sa" }}
+{{ $rb_name :=    "postsync-ibm-sls-update-sm-rb" }}
+{{ $job_label :=  "postsync-ibm-sls-update-sm-job" }}
+
+
+
+---
+# Permit outbound communication by the Job pods
+# (Needed to communicate with the K8S HTTP API and AWS SM)
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ $np_name }}
+  namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "110"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $job_label }}
+  egress:
+    - {}
+  policyTypes:
+    - Egress
+
+
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ $aws_secret }}
+  namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "110"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+data:
+  aws_access_key_id: {{ .Values.sm_aws_access_key_id | b64enc }}
+  aws_secret_access_key: {{ .Values.sm_aws_secret_access_key | b64enc }}
+type: Opaque
+
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: {{ $sa_name }}
+  namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "110"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ $role_name }}
+  namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "110"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+rules:
+  - verbs:
+      - get
+    apiGroups:
+      - ""
+    resources:
+      - configmaps
+
+
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ $rb_name }}
+  namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "111"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $sa_name }}
+    namespace: {{ $ns }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $role_name }}
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $_job_name }}
+  namespace: {{ $ns }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "112"
+    argocd.argoproj.io/sync-options: Prune=true
+  labels:
+    mas.ibm.com/job-cleanup-group: {{ $_job_cleanup_group }}
+{{- if .Values.custom_labels }}
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ $job_label }}
+{{- if .Values.custom_labels }}
+{{ .Values.custom_labels | toYaml | indent 8 }}
+{{- end }}
+    spec:
+      containers:
+        - name: run
+          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          imagePullPolicy: IfNotPresent
+          resources:
+            limits:
+              cpu: 200m
+              memory: 512Mi
+            requests:
+              cpu: 10m
+              memory: 64Mi
+          env:
+            - name: ACCOUNT_ID
+              value: {{ .Values.account_id }}
+            - name: REGION_ID
+              value: {{ .Values.region_id }}
+            - name: ICN
+              value: '{{ .Values.ibm_customer_number }}'
+            - name: SUBSCRIPTION_ID
+              value: '{{ .Values.subscription_id }}'
+            - name: DOMAIN
+              value: '{{ .Values.sls_domain }}'
+
+            # Hard-coded for now:
+            - name: AVP_TYPE
+              value: "aws"
+          volumeMounts:
+            - name: aws
+              mountPath: /etc/mas/creds/aws
+            - name: sls-suite-registration
+              mountPath: /etc/mas/creds/sls-suite-registration
+          command:
+            - /bin/sh
+            - -c
+            - |
+
+              set -e
+
+              # NOTE: cannot just render AWS secrets into here, as it will be exposed in the ArgoCD UI
+              # Instead, we pass them into a secret (ArgoCD knows to hide any data fields in k8s secrets),
+              # mount the secret on the jobs filesystem, and read them in here
+              SM_AWS_ACCESS_KEY_ID=$(cat /etc/mas/creds/aws/aws_access_key_id)
+              SM_AWS_SECRET_ACCESS_KEY=$(cat /etc/mas/creds/aws/aws_secret_access_key)
+
+              echo "Fetching registrationKey from sls-suite-registration ConfigMap in mas-${ICN}-${SUBSCRIPTION_ID}-sls"
+              SLS_REGISTRATION_KEY=$(cat /etc/mas/creds/sls-suite-registration/registrationKey)
+              if [[ -z "${SLS_REGISTRATION_KEY}" ]]; then
+                echo "Failed to fetch registrationKey"
+                exit 1
+              fi
+
+              echo "Fetching ca from sls-suite-registration ConfigMap in mas-${ICN}-${SUBSCRIPTION_ID}-sls"
+              SLS_CA=$(cat /etc/mas/creds/sls-suite-registration/ca | base64 -w0)
+              if [[ -z "${SLS_CA}" ]]; then
+                echo "Failed to fetch ca"
+                exit 1
+              fi
+
+              echo "Setting SLS URL"
+              SLS_URL="https://sls.mas-${ICN}-${SUBSCRIPTION_ID}-sls.${DOMAIN}"
+
+              # might as well take advantage of gitops_utils for sm_ functions as we're using the cli image
+              source /mascli/functions/gitops_utils
+
+              # aws configure set aws_access_key_id $SM_AWS_ACCESS_KEY_ID
+              # aws configure set aws_secret_access_key $SM_AWS_SECRET_ACCESS_KEY
+              # aws configure set default.region $REGION_ID
+              # aws configure list
+              export SM_AWS_REGION=${REGION_ID}
+              sm_login
+
+              # aws secretsmanager create-secret --name ${SECRET_NAME} --secret-string "${SECRET_VALUE}"
+              ## Why is the secreet name here sls and not license as it is in gitops_license function
+              SECRET_NAME_SLS=${ACCOUNT_ID}/${ICN}/${SUBSCRIPTION_ID}/sls
+              TAGS="[{\"Key\": \"source\", \"Value\": \"postsync-ibm-sls-update-sm-job\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"subscription_id\", \"Value\": \"${SUBSCRIPTION_ID}\"}]"
+              sm_update_secret $SECRET_NAME_SLS "{\"registration_key\": \"$SLS_REGISTRATION_KEY\", \"ca_b64\": \"$SLS_CA\", \"sls_url\":\"$SLS_URL\" }" "${TAGS}"
+
+
+      restartPolicy: Never
+
+      # TODO: is this the correct SA to use here?
+      # No, probably want to add a more restricted SA that can just do things that these post-sync jobs need to do
+      serviceAccountName: {{ $sa_name }}
+      volumes:
+        - name: aws
+          secret:
+            secretName: {{ $aws_secret }}
+            defaultMode: 420
+            optional: false
+        - name: sls-suite-registration
+          configMap:
+            name: sls-suite-registration
+            optional: false
+
+  backoffLimit: 4
+{{- end }}
+

--- a/sls-applications/100-ibm-sls/values.yaml
+++ b/sls-applications/100-ibm-sls/values.yaml
@@ -1,0 +1,8 @@
+---
+ibm_entitlement_key: xxx
+sls_mongo_username: xxx
+sls_mongo_password: xxx
+sls_mongo_secret_name: sls-mongo-credentials
+mongo_spec: {}
+sls_entitlement_file: xxx
+sls_channel: 3.x


### PR DESCRIPTION
JIRA: [MASCORE-5475](https://jsw.ibm.com/browse/MASCORE-5475)

This PR is for implementation of a pipeline to support provisioning of an SLS server on a cluster without MAS installed. This SLS server is setup so that both MAS and non-MAS products can use this SLS server. This will support both supplying a license file via saas-envs repo or allowing the code to generate a license. 

** Implementation of Stand Alone SLS Server **
Implementation of new SLS Application Set and applications for provisioning SLS server that can be used for licensing applications
<img width="775" height="149" alt="image" src="https://github.com/user-attachments/assets/faa5c9ba-7bdb-476a-a753-c7b7faeb7e08" />

<img width="1242" height="738" alt="image" src="https://github.com/user-attachments/assets/37ee50df-768d-4962-9843-f49b8d75915f" />

** Testing Completed **
Provisioning of multiple sls servers
deprovisioning of single sls server.

** Related Pull Requests **
MAS CLI: [Implementation of Pipeline and CLI for Standalone SLS Server](https://github.com/ibm-mas/cli/pull/1725)












