### PR TITLE
[patch] add cli image parameter

### DIFF
--- a/cluster-applications/000-image-mirroring/templates/04-ecr-token-updater_CronJob.yaml
+++ b/cluster-applications/000-image-mirroring/templates/04-ecr-token-updater_CronJob.yaml
@@ -2,6 +2,7 @@
 
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -86,7 +87,7 @@ spec:
           serviceAccountName: "ecr-token-updater-sa"
           containers:
             - name: "ecr-token-updater"
-              image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+              image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
               imagePullPolicy: IfNotPresent
               env:
                 - name: REGION_ID

--- a/cluster-applications/000-image-mirroring/templates/04-mas_ImageDigestMirrorSet.yaml
+++ b/cluster-applications/000-image-mirroring/templates/04-mas_ImageDigestMirrorSet.yaml
@@ -17,3 +17,7 @@ spec:
         - "{{ .Values.ecr_host }}/{{ .Values.repo_path_prefix }}"
         - "{{ .Values.ecr_host }}/{{ .Values.repo_path_prefix }}/cp"
       source: docker-na-public.artifactory.swg-devops.com/wiotp-docker-local
+    - mirrorSourcePolicy: NeverContactSource
+      mirrors:
+        - "{{ .Values.ecr_host }}/{{ .Values.repo_path_prefix }}"
+      source: quay.io/ibmmas

--- a/cluster-applications/000-job-cleaner/templates/04-jobcleaner_CronJob.yaml
+++ b/cluster-applications/000-job-cleaner/templates/04-jobcleaner_CronJob.yaml
@@ -3,6 +3,7 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
 
 {{- $ns := "job-cleaner" }}
 
@@ -90,7 +91,7 @@ spec:
         spec:
           containers:
             - name: "mas-saas-job-cleaner"
-              image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+              image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh

--- a/cluster-applications/010-redhat-cert-manager/templates/04-postsync-update-sm_Job.yaml
+++ b/cluster-applications/010-redhat-cert-manager/templates/04-postsync-update-sm_Job.yaml
@@ -19,6 +19,8 @@ Included in $_job_hash (see below).
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
 Any changes to values in this dict will trigger a rerun of the job.
@@ -178,7 +180,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/cluster-applications/020-ibm-dro/templates/08-postsync-update-sm_Job.yaml
+++ b/cluster-applications/020-ibm-dro/templates/08-postsync-update-sm_Job.yaml
@@ -11,6 +11,8 @@ Included in $_job_hash (see below).
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
 Any changes to values in this dict will trigger a rerun of the job.
@@ -160,7 +162,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/cluster-applications/021-ibm-dro-cleanup/templates/postdelete-MarketplaceConfigs.yaml
+++ b/cluster-applications/021-ibm-dro-cleanup/templates/postdelete-MarketplaceConfigs.yaml
@@ -4,6 +4,7 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
 
 {{ $job_name := "postdelete-delete-marketplaceconfigs-job" }}
 
@@ -38,7 +39,7 @@ spec:
         - name: run
           # TODO: use a dedicated image with a smaller footprint for this sort of thing?
           # Just using cli for now since it has all the deps we need to talk with AWS SM
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/cluster-applications/030-ibm-cis-cert-manager/templates/00-3-ibm-cis-webhook_deployment.yml
+++ b/cluster-applications/030-ibm-cis-cert-manager/templates/00-3-ibm-cis-webhook_deployment.yml
@@ -1,7 +1,7 @@
 {{- if eq .Values.dns_provider "cis" }}
 
 {{ $cis_apiservice_group_name     :=   "acme.cis.ibm.com" }}
-{{ $cis_webhook_image_repository  :=   "quay.io/ibmmas/cert-manager-webhook-ibm-cis" }}
+{{ $cis_webhook_image_name  :=   "cert-manager-webhook-ibm-cis" }}
 {{ $cis_webhook_image_tag         :=   "1.0.0" }}
 {{ $cis_webhook_image_pullpolicy  :=   "Always" }}
 {{ $cis_webhook_service_type      :=   "ClusterIP" }}
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: "cert-manager-webhook-ibm-cis"
       containers:
         - name: webhook
-          image: "{{ $cis_webhook_image_repository }}:{{ $cis_webhook_image_tag }}"
+          image: "{{ .Values.ecr_image_repo }}/{{ $cis_webhook_image_name }}:{{ $cis_webhook_image_tag }}"
           imagePullPolicy: {{ $cis_webhook_image_pullpolicy }}
           args:
             - --tls-cert-file=/tls/tls.crt

--- a/cluster-applications/041-cis-compliance-cleanup/templates/postdelete-ProfileBundles.yaml
+++ b/cluster-applications/041-cis-compliance-cleanup/templates/postdelete-ProfileBundles.yaml
@@ -4,6 +4,8 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{ $job_name := "postdelete-delete-profilebundles-job" }}
 
 # NOTE: depends on resources created in the cis-compliance chart (psotdelete-ProfileBundles-resources)
@@ -41,7 +43,7 @@ spec:
         - name: run
           # TODO: use a dedicated image with a smaller footprint for this sort of thing?
           # Just using cli for now since it has all the deps we need to talk with AWS SM
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/cluster-applications/055-instana-agent-operator/templates/08-CronJob.yaml
+++ b/cluster-applications/055-instana-agent-operator/templates/08-CronJob.yaml
@@ -4,6 +4,7 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
 
 ---
 apiVersion: batch/v1
@@ -49,7 +50,7 @@ spec:
           # Additionally, it writes the DB2 certificate to a persistent volume.
           initContainers:
             - name: update-agent-cr
-              image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+              image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
               imagePullPolicy: IfNotPresent              
               volumeMounts:
                 - name: instana-db2-jks

--- a/cluster-applications/060-custom-sa/templates/04-postsync-update-sm_Job.yaml
+++ b/cluster-applications/060-custom-sa/templates/04-postsync-update-sm_Job.yaml
@@ -11,6 +11,8 @@ Included in $_job_hash (see below).
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
 Any changes to values in this dict will trigger a rerun of the job.
@@ -82,7 +84,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/cluster-applications/200-cluster-promotion/templates/02-cluster-verify_Job.yaml
+++ b/cluster-applications/200-cluster-promotion/templates/02-cluster-verify_Job.yaml
@@ -9,6 +9,8 @@ Included in $_job_hash (see below).
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
 Any changes to values in this dict will trigger a rerun of the job.
@@ -113,7 +115,7 @@ spec:
     spec:
       containers:
         - name: cluster-verify
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           env:
             - name: ACCOUNT_ID

--- a/cluster-applications/200-cluster-promotion/templates/03-cluster-promoter_Job.yaml
+++ b/cluster-applications/200-cluster-promotion/templates/03-cluster-promoter_Job.yaml
@@ -9,6 +9,8 @@ Included in $_job_hash (see below).
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
 Any changes to values in this dict will trigger a rerun of the job.
@@ -80,7 +82,7 @@ spec:
     spec:
       containers:
         - name: cluster-promoter
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           env:
             - name: ACCOUNT_ID

--- a/instance-applications/010-ibm-sync-jobs/templates/00-aws-docdb-add-user_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/00-aws-docdb-add-user_Job.yaml
@@ -13,6 +13,8 @@ Included in $_job_hash (see below).
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
 Any changes to values in this dict will trigger a rerun of the job.
@@ -91,7 +93,7 @@ spec:
     spec:
       containers:
         - name: aws-docdb-process-user
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           env:
 

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_certs_Job.yaml
@@ -12,6 +12,8 @@ Included in $_job_hash (see below).
 */}}
 {{- $_cli_image_digest := "sha256:834dffd4da534c01daea4e0a6d9db7d00a9ad9b18b054cc034985fcaceedeacd" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
 Any changes to values in this dict will trigger a rerun of the job.
@@ -82,7 +84,7 @@ spec:
     spec:
       containers:
         - name: suite-certs-role-run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
 
           env:

--- a/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/01-ibm-mas_suite_dns_Job.yaml
@@ -11,6 +11,8 @@ Included in $_job_hash (see below).
 */}}
 {{- $_cli_image_digest := "sha256:834dffd4da534c01daea4e0a6d9db7d00a9ad9b18b054cc034985fcaceedeacd" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
 Any changes to values in this dict will trigger a rerun of the job.
@@ -82,7 +84,7 @@ spec:
     spec:
       containers:
         - name: suite-dns-role-run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
 
           env:

--- a/instance-applications/010-ibm-sync-jobs/templates/PostDelete-aws-docdb-remove-user_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/PostDelete-aws-docdb-remove-user_Job.yaml
@@ -9,6 +9,7 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
 
 # Deletes user "masinst_${MAS_INSTANCE_ID}" from docdb an deletes the acc/cluster/instance/mongo#password secret from AWS SM
 
@@ -34,7 +35,7 @@ spec:
     spec:
       containers:
         - name: aws-docdb-process-user
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           env:
 

--- a/instance-applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
+++ b/instance-applications/100-ibm-sls/templates/07-postsync-update-sm_Job.yaml
@@ -11,6 +11,8 @@ Included in $_job_hash (see below).
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
 Any changes to values in this dict will trigger a rerun of the job.
@@ -191,7 +193,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/101-ibm-sync-jobs-cp4d/templates/00-ibm-cp4d-presync.yaml
+++ b/instance-applications/101-ibm-sync-jobs-cp4d/templates/00-ibm-cp4d-presync.yaml
@@ -11,6 +11,8 @@ Included in $_job_hash (see below).
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
 Any changes to values in this dict will trigger a rerun of the job.
@@ -143,7 +145,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_prereqs_ops.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_prereqs_ops.yaml
@@ -9,6 +9,8 @@ Included in $_job_hash (see below).
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
 Any changes to values in this dict will trigger a rerun of the job.
@@ -146,7 +148,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_upg_cleanup.yaml
+++ b/instance-applications/110-ibm-cp4d-operators/templates/04-ibm-cp4d_upg_cleanup.yaml
@@ -9,6 +9,8 @@ Included in $_job_hash (see below).
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
 Any changes to values in this dict will trigger a rerun of the job.
@@ -84,7 +86,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/110-ibm-cp4d/templates/03-ibm-cp4d-mcs_patch_sa.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/03-ibm-cp4d-mcs_patch_sa.yaml
@@ -16,6 +16,8 @@ Included in $_job_hash (see below).
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
 Any changes to values in this dict will trigger a rerun of the job.
@@ -85,7 +87,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_patch_zenservice.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/07-ibm-cp4d_patch_zenservice.yaml
@@ -10,6 +10,8 @@ Included in $_job_hash (see below).
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
 Any changes to values in this dict will trigger a rerun of the job.
@@ -80,7 +82,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/110-ibm-cp4d/templates/08-ibm-cp4d-post-verify.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/08-ibm-cp4d-post-verify.yaml
@@ -9,6 +9,8 @@ Included in $_job_hash (see below).
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
 Any changes to values in this dict will trigger a rerun of the job.
@@ -78,7 +80,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
@@ -9,6 +9,8 @@ Included in $_job_hash (see below).
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
 Any changes to values in this dict will trigger a rerun of the job.
@@ -79,7 +81,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/120-ibm-db2u-database/templates/00-presync-await-crd_Job.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/00-presync-await-crd_Job.yaml
@@ -3,6 +3,8 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 ---
 # Service account that is authorized to read k8s secrets (needed by the job)
 kind: ServiceAccount
@@ -85,7 +87,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/120-ibm-db2u-database/templates/04-db2u-Backup_Cron.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/04-db2u-Backup_Cron.yaml
@@ -5,6 +5,8 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 #apiVersion: batch/v1beta1
 kind: CronJob
 apiVersion: batch/v1
@@ -27,7 +29,7 @@ spec:
         spec:
           containers:
             - name: "db2-backup-job-v1-{{ .Values.db2_instance_name }}"
-              image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+              image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
               command:
                 - oc
                 - rsh

--- a/instance-applications/120-ibm-db2u-database/templates/07-postsync-setup-db2_Job.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/07-postsync-setup-db2_Job.yaml
@@ -11,6 +11,8 @@ Included in $_job_hash (see below).
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
 Any changes to values in this dict will trigger a rerun of the job.
@@ -186,7 +188,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/10-postsync-setup-hadr.yaml
@@ -12,6 +12,8 @@ Included in $_job_hash (see below).
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
 Any changes to values in this dict will trigger a rerun of the job.
@@ -161,7 +163,7 @@ spec:
       serviceAccountName: "postsync-hadr-sa-{{ .Values.db2_instance_name }}"
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/120-ibm-spark/templates/02-ibm-spark-control-plane.yaml
+++ b/instance-applications/120-ibm-spark/templates/02-ibm-spark-control-plane.yaml
@@ -9,6 +9,8 @@ Included in $_job_hash (see below).
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
 Any changes to values in this dict will trigger a rerun of the job.
@@ -131,7 +133,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/120-ibm-spss/templates/02-ibm-spss-post-verify.yaml
+++ b/instance-applications/120-ibm-spss/templates/02-ibm-spss-post-verify.yaml
@@ -9,6 +9,8 @@ Included in $_job_hash (see below).
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
 Any changes to values in this dict will trigger a rerun of the job.
@@ -167,7 +169,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/120-ibm-wsl/templates/02-ibm-wsl-post-verify.yaml
+++ b/instance-applications/120-ibm-wsl/templates/02-ibm-wsl-post-verify.yaml
@@ -9,6 +9,8 @@ Included in $_job_hash (see below).
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
 Any changes to values in this dict will trigger a rerun of the job.
@@ -151,7 +153,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/130-ibm-jdbc-config/templates/00-presync-create-db2-user_Job.yaml
+++ b/instance-applications/130-ibm-jdbc-config/templates/00-presync-create-db2-user_Job.yaml
@@ -5,6 +5,8 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{ $ns := printf "mas-%s-core" .Values.instance_id }}
 {{ $prefix := printf "pre-jdbc-usr-%s" .Values.mas_config_name }}
 {{ $secret := printf "%s-creds" $prefix }}
@@ -170,7 +172,7 @@ spec:
         - name: run
           # TODO: use a dedicated image with a smaller footprint for this sort of thing?
           # Just using cli for now since it has all the deps we need to talk with AWS SM
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/130-ibm-jdbc-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-jdbc-config/templates/postdelete-delete-cr.yaml
@@ -5,6 +5,8 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{ $cr_name := .Values.mas_config_name }}
 {{ $cr_kind := .Values.mas_config_kind }}
 {{ $cr_api_version := .Values.mas_config_api_version }}
@@ -45,7 +47,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/130-ibm-jdbc-config/templates/postdelete-delete-db2-user_Job.yaml
+++ b/instance-applications/130-ibm-jdbc-config/templates/postdelete-delete-db2-user_Job.yaml
@@ -5,6 +5,8 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{ $ns := printf "mas-%s-syncres" .Values.instance_id }}
 {{ $prefix := printf "post-jdbc-usr-%s" .Values.mas_config_name }}
 {{ $secret := printf "%s-creds" $prefix }}
@@ -35,7 +37,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/130-ibm-kafka-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-kafka-config/templates/postdelete-delete-cr.yaml
@@ -20,6 +20,8 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 ---
 apiVersion: batch/v1
 kind: Job
@@ -46,7 +48,7 @@ spec:
         - name: run
           # TODO: use a dedicated image with a smaller footprint for this sort of thing?
           # Just using cli for now since it has all the deps we need to talk with AWS SM
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/130-ibm-mas-bas-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-mas-bas-config/templates/postdelete-delete-cr.yaml
@@ -5,6 +5,8 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{ $cr_name := .Values.mas_config_name }}
 {{ $cr_kind := .Values.mas_config_kind }}
 {{ $cr_api_version := .Values.mas_config_api_version }}
@@ -47,7 +49,7 @@ spec:
         - name: run
           # TODO: use a dedicated image with a smaller footprint for this sort of thing?
           # Just using cli for now since it has all the deps we need to talk with AWS SM
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/130-ibm-mas-idp-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-mas-idp-config/templates/postdelete-delete-cr.yaml
@@ -5,6 +5,8 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{ $cr_name := .Values.mas_config_name }}
 {{ $cr_kind := .Values.mas_config_kind }}
 {{ $cr_api_version := .Values.mas_config_api_version }}
@@ -47,7 +49,7 @@ spec:
         - name: run
           # TODO: use a dedicated image with a smaller footprint for this sort of thing?
           # Just using cli for now since it has all the deps we need to talk with AWS SM
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/130-ibm-mas-mongo-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-mas-mongo-config/templates/postdelete-delete-cr.yaml
@@ -5,6 +5,8 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{ $cr_name := .Values.mas_config_name }}
 {{ $cr_kind := .Values.mas_config_kind }}
 {{ $cr_api_version := .Values.mas_config_api_version }}
@@ -47,7 +49,7 @@ spec:
         - name: run
           # TODO: use a dedicated image with a smaller footprint for this sort of thing?
           # Just using cli for now since it has all the deps we need to talk with AWS SM
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/130-ibm-mas-sls-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-mas-sls-config/templates/postdelete-delete-cr.yaml
@@ -5,6 +5,8 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{ $cr_name := .Values.mas_config_name }}
 {{ $cr_kind := .Values.mas_config_kind }}
 {{ $cr_api_version := .Values.mas_config_api_version }}
@@ -47,7 +49,7 @@ spec:
         - name: run
           # TODO: use a dedicated image with a smaller footprint for this sort of thing?
           # Just using cli for now since it has all the deps we need to talk with AWS SM
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/130-ibm-mas-smtp-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-mas-smtp-config/templates/postdelete-delete-cr.yaml
@@ -5,6 +5,8 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{ $cr_name := .Values.mas_config_name }}
 {{ $cr_kind := .Values.mas_config_kind }}
 {{ $cr_api_version := .Values.mas_config_api_version }}
@@ -47,7 +49,7 @@ spec:
         - name: run
           # TODO: use a dedicated image with a smaller footprint for this sort of thing?
           # Just using cli for now since it has all the deps we need to talk with AWS SM
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/05-postsync-add-label_Job.yaml
@@ -10,6 +10,8 @@ Included in $_job_hash (see below).
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
 Any changes to values in this dict will trigger a rerun of the job.
@@ -168,7 +170,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/130-ibm-mas-suite/templates/06-postsync-configtool-oidc.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/06-postsync-configtool-oidc.yaml
@@ -12,6 +12,8 @@ Included in $_job_hash (see below).
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
 Any changes to values in this dict will trigger a rerun of the job.
@@ -164,7 +166,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/130-ibm-objectstorage-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-objectstorage-config/templates/postdelete-delete-cr.yaml
@@ -5,6 +5,8 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{ $cr_name := .Values.mas_config_name }}
 {{ $cr_kind := .Values.mas_config_kind }}
 {{ $cr_api_version := .Values.mas_config_api_version }}
@@ -47,7 +49,7 @@ spec:
         - name: run
           # TODO: use a dedicated image with a smaller footprint for this sort of thing?
           # Just using cli for now since it has all the deps we need to talk with AWS SM
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/220-ibm-mas-workspace/templates/05-postsync-add-label_Job.yaml
+++ b/instance-applications/220-ibm-mas-workspace/templates/05-postsync-add-label_Job.yaml
@@ -5,6 +5,8 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 ---
 # Permit outbound communication by the Job pods
 # (Needed to communicate with the K8S HTTP API and AWS SM)
@@ -127,7 +129,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/500-540-ibm-mas-suite-app-install/templates/00-presync-add-mvi-scc_Job.yaml
+++ b/instance-applications/500-540-ibm-mas-suite-app-install/templates/00-presync-add-mvi-scc_Job.yaml
@@ -6,6 +6,7 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
 
 {{ $ns := .Values.mas_app_namespace }}
 {{ $np_name :=    "presync-np-add-mvi-scc-np" }}
@@ -105,7 +106,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/500-540-ibm-mas-suite-app-install/templates/06-postsync-add-mvi-scc_Job.yaml
+++ b/instance-applications/500-540-ibm-mas-suite-app-install/templates/06-postsync-add-mvi-scc_Job.yaml
@@ -6,6 +6,7 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
 
 {{ $ns := .Values.mas_app_namespace }}
 {{ $np_name :=    "postsync-np-add-mvi-scc-np" }}
@@ -105,7 +106,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/02-ibm-manage-update_Job.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/02-ibm-manage-update_Job.yaml
@@ -7,6 +7,8 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{ $ns        :=  .Values.mas_app_namespace }}
 {{ $prefix := printf "%s-manage-update" .Values.mas_workspace_id}}
 {{ $np_name   := printf "%s-np" $prefix }}
@@ -129,7 +131,7 @@ spec:
         spec:
           containers:
             - name: run
-              image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+              image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
               imagePullPolicy: IfNotPresent
               resources:
                 limits:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-add-label_Job.yaml
@@ -3,6 +3,8 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{ $ns        :=  .Values.mas_app_namespace }}
 {{ $job_label :=  "mas-app-route-patch" }}
 
@@ -138,7 +140,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-sanity.yaml
@@ -6,6 +6,8 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 # A sanity test is one that can be disruptive i.e. it can create new users, call authenticated apis, creates resources 
 # in the application. This type of test should only be run in a downstream environment such as a dev or staging env
 # The control over if these tests run or not is controlled by the `run_sanity_test` boolean in the values
@@ -1296,7 +1298,7 @@ spec:
       imagePullSecrets: []
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -5,6 +5,8 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 # A verify test is one that is non disruptive i.e. it won't create new users, i won't call authenticated apis, and it won't creates resources 
 # in the application. This type of test is run on every environment and allows a layer of verification of the app
 
@@ -271,7 +273,7 @@ spec:
       imagePullSecrets: []
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-maximoit-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-maximoit-sanity.yaml
@@ -7,6 +7,8 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 # A sanity test is one that can be disruptive i.e. it can create new users, call authenticated apis, creates resources 
 # in the application. This type of test should only be run in a downstream environment such as a dev or staging env
 # The control over if these tests run or not is controlled by the `run_sanity_test` boolean in the values
@@ -1845,7 +1847,7 @@ spec:
       imagePullSecrets: []
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-maximoit-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-maximoit-verify.yaml
@@ -6,6 +6,8 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 # A verify test is one that is non disruptive i.e. it won't create new users, i won't call authenticated apis, and it won't creates resources 
 # in the application. This type of test is run on every environment and allows a layer of verification of the app
 
@@ -444,7 +446,7 @@ spec:
       imagePullSecrets: []
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-sanity.yaml
@@ -5,6 +5,8 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{ $ns               :=  .Values.mas_app_namespace }}
 {{ $np_name          :=  "postsync-sanity-mvi-np" }}
 {{ $role_name        :=  "postsync-sanity-mvi-role" }}
@@ -542,7 +544,7 @@ spec:
       imagePullSecrets: []
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-mvi-verify.yaml
@@ -6,6 +6,7 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
 
 {{ $ns               :=  .Values.mas_app_namespace }}
 {{ $np_name          :=  "postsync-verify-mvi-np" }}
@@ -493,7 +494,7 @@ spec:
       imagePullSecrets: []
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/700-702-postsync-db2-manage.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/700-702-postsync-db2-manage.yaml
@@ -88,6 +88,8 @@ Included in $_job_hash (see below).
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
 Any changes to values in this dict will trigger a rerun of the job.
@@ -226,7 +228,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/instance-applications/600-ibm-post-sync-jobs/templates/001-ibm-create-initial-users.yaml
+++ b/instance-applications/600-ibm-post-sync-jobs/templates/001-ibm-create-initial-users.yaml
@@ -13,6 +13,8 @@ Included in $_job_hash (see below).
 */}}
 {{- $_cli_image_digest := "sha256:3735885b3b9d46fcf6408c008768cc04faf2e28c1fa5f6da7c5f969931e2d3cd" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{- /*
 A dict of values that influence the behaviour of the job in some way.
 Any changes to values in this dict will trigger a rerun of the job.
@@ -255,7 +257,7 @@ spec:
     spec:
       containers:
         - name: {{ $_job_name_prefix }}
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
 
           env:

--- a/root-applications/ibm-mas-cluster-root/templates/000-image-mirroring.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/000-image-mirroring.yaml
@@ -38,10 +38,10 @@ spec:
       env:
         - name: {{ .Values.avp.values_varname }}
           value: |
-
             region_id: {{ .Values.region.id }}
             ecr_host: {{ .Values.image_mirroring.ecr_host }}
             repo_path_prefix: {{ .Values.image_mirroring.repo_path_prefix }}
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
 
             aws_access_key_id: "{{ .Values.sm.aws_access_key_id }}"
             aws_secret_access_key: "{{ .Values.sm.aws_secret_access_key }}"

--- a/root-applications/ibm-mas-cluster-root/templates/000-job-cleaner.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/000-job-cleaner.yaml
@@ -37,6 +37,7 @@ spec:
       env:
         - name: {{ .Values.avp.values_varname }}
           value: |
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
             junitreporter:
               reporter_name: "job-cleaner"
               cluster_id: "{{ .Values.cluster.id }}"

--- a/root-applications/ibm-mas-cluster-root/templates/010-ibm-redhat-cert-manager-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/010-ibm-redhat-cert-manager-app.yaml
@@ -33,6 +33,7 @@ spec:
       env:
         - name: {{ .Values.avp.values_varname }}
           value: |
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
             account_id: "{{ .Values.account.id }}"
             region_id: "{{ .Values.region.id }}"
             cluster_id: "{{ .Values.cluster.id }}"

--- a/root-applications/ibm-mas-cluster-root/templates/020-ibm-dro-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/020-ibm-dro-app.yaml
@@ -38,6 +38,7 @@ spec:
       env:
         - name: {{ .Values.avp.values_varname }}
           value: |
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
             account_id: "{{ .Values.account.id }}"
             region_id: "{{ .Values.region.id }}"
             cluster_id: "{{ .Values.cluster.id }}"

--- a/root-applications/ibm-mas-cluster-root/templates/021-ibm-dro-cleanup.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/021-ibm-dro-cleanup.yaml
@@ -35,6 +35,7 @@ spec:
       env:
         - name: {{ .Values.avp.values_varname }}
           value: |
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
             dro_namespace: "{{ .Values.ibm_dro.dro_namespace }}"
             junitreporter:
               reporter_name: "ibm-dro-cleanup"

--- a/root-applications/ibm-mas-cluster-root/templates/030-ibm-cis-cert-manager.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/030-ibm-cis-cert-manager.yaml
@@ -34,7 +34,7 @@ spec:
         - name: {{ .Values.avp.values_varname }}
           value: |
             argo_namespace: "{{ .Values.argo.namespace }}"
-
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
             {{- if .Values.custom_labels }}
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}

--- a/root-applications/ibm-mas-cluster-root/templates/041-cis-compliance-cleanup.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/041-cis-compliance-cleanup.yaml
@@ -35,6 +35,7 @@ spec:
       env:
         - name: {{ .Values.avp.values_varname }}
           value: |
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
             argo_namespace: "{{ .Values.argo.namespace }}"
             junitreporter:
               reporter_name: "cis-compliance-cleanup"

--- a/root-applications/ibm-mas-cluster-root/templates/055-instana-agent-operator-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/055-instana-agent-operator-app.yaml
@@ -37,6 +37,7 @@ spec:
       env:
         - name: {{ .Values.avp.values_varname }}
           value: |
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
             account_id: "{{ .Values.account.id }}"
             region_id: "{{ .Values.region.id }}"
             cluster_id: "{{ .Values.cluster.id }}"

--- a/root-applications/ibm-mas-cluster-root/templates/060-custom-sa.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/060-custom-sa.yaml
@@ -33,6 +33,7 @@ spec:
       env:
         - name: {{ .Values.avp.values_varname }}
           value: |
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
             account_id: "{{ .Values.account.id }}"
             region_id: "{{ .Values.region.id }}"
             cluster_id: "{{ .Values.cluster.id }}"

--- a/root-applications/ibm-mas-cluster-root/templates/200-cluster-promotion-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/200-cluster-promotion-app.yaml
@@ -33,6 +33,7 @@ spec:
       env:
         - name: {{ .Values.avp.values_varname }}
           value: |
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
             account_id: "{{ .Values.account.id }}"
             region_id: "{{ .Values.region.id }}"
             cluster_id: "{{ .Values.cluster.id }}"

--- a/root-applications/ibm-mas-cluster-root/templates/300-mas-provisioner-app.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/300-mas-provisioner-app.yaml
@@ -34,6 +34,7 @@ spec:
       env:
         - name: {{ .Values.avp.values_varname }}
           value: |
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
             account_alias: "{{ .Values.mas_provisioner.account_alias }}"
             provisioner_domain: "{{ .Values.mas_provisioner.provisioner_domain }}"
             ibm_entitlement_key: "{{ .Values.mas_provisioner.ibm_entitlement }}"

--- a/root-applications/ibm-mas-instance-root/templates/010-ibm-sync-jobs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/010-ibm-sync-jobs.yaml
@@ -38,6 +38,7 @@ spec:
       env:
         - name: {{ .Values.avp.values_varname }}
           value: |
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
             account_id: "{{ .Values.account.id }}"
             region_id: "{{ .Values.region.id }}"
             cluster_id: "{{ .Values.cluster.id }}"

--- a/root-applications/ibm-mas-instance-root/templates/100-ibm-sls-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/100-ibm-sls-app.yaml
@@ -38,6 +38,7 @@ spec:
       env:
         - name: {{ .Values.avp.values_varname }}
           value: |
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
             account_id: "{{ .Values.account.id }}"
             region_id: "{{ .Values.region.id }}"
             cluster_id: "{{ .Values.cluster.id }}"

--- a/root-applications/ibm-mas-instance-root/templates/101-ibm-sync-jobs-cp4d.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/101-ibm-sync-jobs-cp4d.yaml
@@ -39,6 +39,7 @@ spec:
       env:
         - name: {{ .Values.avp.values_varname }}
           value: |
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
             account_id: "{{ .Values.account.id }}"
             region_id: "{{ .Values.region.id }}"
             cluster_id: "{{ .Values.cluster.id }}"

--- a/root-applications/ibm-mas-instance-root/templates/110-ibm-cp4d-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/110-ibm-cp4d-app.yaml
@@ -42,6 +42,7 @@ spec:
       env:
         - name: {{ .Values.avp.values_varname }}
           value: |
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
             argo_namespace: "{{ .Values.argo.namespace }}"
             instance_id: "{{ .Values.instance.id }}"
             ibm_entitlement_key: "{{ .Values.ibm_cp4d.ibm_entitlement_key }}"

--- a/root-applications/ibm-mas-instance-root/templates/110-ibm-cp4d-operator-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/110-ibm-cp4d-operator-app.yaml
@@ -33,6 +33,7 @@ spec:
       env:
         - name: {{ .Values.avp.values_varname }}
           value: |
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
             argo_namespace: "{{ .Values.argo.namespace }}"
             instance_id: "{{ .Values.instance.id }}"
             ibm_entitlement_key: "{{ .Values.ibm_cp4d.ibm_entitlement_key }}"

--- a/root-applications/ibm-mas-instance-root/templates/120-db2-databases-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-db2-databases-app.yaml
@@ -42,6 +42,7 @@ spec:
       env:
         - name: {{ $.Values.avp.values_varname }}
           value: |
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
             account_id: "{{ $.Values.account.id }}"
             region_id: "{{ $.Values.region.id }}"
             cluster_id: "{{ $.Values.cluster.id }}"

--- a/root-applications/ibm-mas-instance-root/templates/120-ibm-spark-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-ibm-spark-app.yaml
@@ -38,6 +38,7 @@ spec:
       env:
         - name: {{ .Values.avp.values_varname }}
           value: |
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
             instance_id: "{{ .Values.instance.id }}"
             ccs_version: "{{ .Values.ibm_spark.ccs_version }}"
             cpd_instance_namespace: "{{ .Values.ibm_cp4d.cpd_instance_namespace }}"

--- a/root-applications/ibm-mas-instance-root/templates/120-ibm-spss-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-ibm-spss-app.yaml
@@ -34,6 +34,7 @@ spec:
       env:
         - name: {{ .Values.avp.values_varname }}
           value: |
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
             account_id: "{{ .Values.account.id }}"
             region_id: "{{ .Values.region.id }}"
             cluster_id: "{{ .Values.cluster.id }}"

--- a/root-applications/ibm-mas-instance-root/templates/120-ibm-wsl-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/120-ibm-wsl-app.yaml
@@ -34,6 +34,7 @@ spec:
       env:
         - name: {{ .Values.avp.values_varname }}
           value: |
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
             account_id: "{{ .Values.account.id }}"
             region_id: "{{ .Values.region.id }}"
             cluster_id: "{{ .Values.cluster.id }}"

--- a/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-app.yaml
@@ -38,6 +38,7 @@ spec:
       env:
         - name: {{ .Values.avp.values_varname }}
           value: |
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
             account_id: "{{ .Values.account.id }}"
             region_id: "{{ .Values.region.id }}"
             cluster_id: "{{ .Values.cluster.id }}"

--- a/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-configs-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-configs-app.yaml
@@ -44,6 +44,7 @@ spec:
       env:
         - name: {{ $.Values.avp.values_varname }}
           value: |
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
             account_id: "{{ $.Values.account.id }}"
             region_id: "{{ $.Values.region.id }}"
             cluster_id: "{{ $.Values.cluster.id }}"

--- a/root-applications/ibm-mas-instance-root/templates/200-ibm-mas-workspaces.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/200-ibm-mas-workspaces.yaml
@@ -38,6 +38,7 @@ spec:
       env:
         - name: {{ $.Values.avp.values_varname }}
           value: |
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
             instance_id: "{{ $.Values.instance.id }}"
             mas_workspace_id: "{{ $value.mas_workspace_id }}"
             mas_workspace_name: "{{ $value.mas_workspace_name }}"

--- a/root-applications/ibm-mas-instance-root/templates/500-ibm-mas-masapp-manage-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/500-ibm-mas-masapp-manage-install.yaml
@@ -34,6 +34,7 @@ spec:
       env:
         - name: {{ .Values.avp.values_varname }}
           value: |
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
             instance_id: "{{ .Values.instance.id }}"
             argo_namespace: "{{ .Values.argo.namespace }}"
             mas_app_api_version: "{{ .Values.ibm_suite_app_manage_install.mas_app_api_version }}"

--- a/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
@@ -55,6 +55,7 @@ spec:
       env:
         - name: {{ $.Values.avp.values_varname }}
           value: |
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
             instance_id: "{{ $.Values.instance.id }}"
             mas_catalog_version: "{{ $.Values.mas_catalog_version }}"
             mas_app_id: "{{ $value.mas_app_id }}"

--- a/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-assist-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-assist-install.yaml
@@ -34,6 +34,7 @@ spec:
       env:
         - name: {{ .Values.avp.values_varname }}
           value: |
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
             instance_id: "{{ .Values.instance.id }}"
             argo_namespace: "{{ .Values.argo.namespace }}"
             mas_app_api_version: "{{ .Values.ibm_suite_app_assist_install.mas_app_api_version }}"

--- a/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-facilities-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-facilities-install.yaml
@@ -34,6 +34,7 @@ spec:
       env:
         - name: {{ .Values.avp.values_varname }}
           value: |
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
             instance_id: "{{ .Values.instance.id }}"
             argo_namespace: "{{ .Values.argo.namespace }}"
             mas_app_api_version: "{{ .Values.ibm_suite_app_facilities_install.mas_app_api_version }}"

--- a/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-iot-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-iot-install.yaml
@@ -34,6 +34,7 @@ spec:
       env:
         - name: {{ .Values.avp.values_varname }}
           value: |
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
             instance_id: "{{ .Values.instance.id }}"
             argo_namespace: "{{ .Values.argo.namespace }}"
             mas_app_api_version: "{{ .Values.ibm_suite_app_iot_install.mas_app_api_version }}"

--- a/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-visualinspection-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-visualinspection-install.yaml
@@ -34,6 +34,7 @@ spec:
       env:
         - name: {{ .Values.avp.values_varname }}
           value: |
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
             instance_id: "{{ .Values.instance.id }}"
             argo_namespace: "{{ .Values.argo.namespace }}"
             mas_app_api_version: "{{ .Values.ibm_suite_app_visualinspection_install.mas_app_api_version }}"

--- a/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-health-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-health-install.yaml
@@ -34,6 +34,7 @@ spec:
       env:
         - name: {{ .Values.avp.values_varname }}
           value: |
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
             instance_id: "{{ .Values.instance.id }}"
             argo_namespace: "{{ .Values.argo.namespace }}"
             mas_app_api_version: "{{ .Values.ibm_suite_app_health_install.mas_app_api_version }}"

--- a/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-monitor-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-monitor-install.yaml
@@ -34,6 +34,7 @@ spec:
       env:
         - name: {{ .Values.avp.values_varname }}
           value: |
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
             instance_id: "{{ .Values.instance.id }}"
             argo_namespace: "{{ .Values.argo.namespace }}"
             mas_app_api_version: "{{ .Values.ibm_suite_app_monitor_install.mas_app_api_version }}"

--- a/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-optimizer-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-optimizer-install.yaml
@@ -34,6 +34,7 @@ spec:
       env:
         - name: {{ .Values.avp.values_varname }}
           value: |
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
             instance_id: "{{ .Values.instance.id }}"
             argo_namespace: "{{ .Values.argo.namespace }}"
             mas_app_api_version: "{{ .Values.ibm_suite_app_optimizer_install.mas_app_api_version }}"

--- a/root-applications/ibm-mas-instance-root/templates/540-ibm-mas-masapp-predict-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/540-ibm-mas-masapp-predict-install.yaml
@@ -34,6 +34,7 @@ spec:
       env:
         - name: {{ .Values.avp.values_varname }}
           value: |
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
             instance_id: "{{ .Values.instance.id }}"
             argo_namespace: "{{ .Values.argo.namespace }}"
             mas_app_api_version: "{{ .Values.ibm_suite_app_predict_install.mas_app_api_version }}"

--- a/root-applications/ibm-mas-instance-root/templates/600-ibm-post-sync-jobs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/600-ibm-post-sync-jobs.yaml
@@ -48,7 +48,8 @@ spec:
             region_id: "{{ .Values.region.id }}"
             cluster_id: "{{ .Values.cluster.id }}"
             instance_id: "{{ .Values.instance.id }}"
-
+            ecr_image_repo: "{{ .Values.ecr.ecr_image_repo }}"
+            
             sm_aws_access_key_id: "{{ .Values.sm.aws_access_key_id }}"
             sm_aws_secret_access_key: "{{ .Values.sm.aws_secret_access_key }}"
             sm_aws_region: "{{ .Values.region.id }}"

--- a/sub-charts/junitreporter/templates/00-presync-report-starter.yaml
+++ b/sub-charts/junitreporter/templates/00-presync-report-starter.yaml
@@ -5,6 +5,7 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
 
 {{ $prefix := printf "pre-jreporter-%s" .Values.reporter_name }}
 {{ $secret := printf "%s-devopsuri" $prefix }}
@@ -127,7 +128,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:

--- a/sub-charts/junitreporter/templates/10-postsync-report-starter.yaml
+++ b/sub-charts/junitreporter/templates/10-postsync-report-starter.yaml
@@ -5,6 +5,8 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 */}}
 {{- $_cli_image_digest := "sha256:b3ecce096368c967bbc6bac2f074473a65418462417b6e550ad4777427c3b06b" }}
 
+{{- $_cli_image_name := "cli" }}
+
 {{ $preprefix := printf "pre-jreporter-%s" .Values.reporter_name }}
 {{ $time_cm := printf "%s-synctime" $preprefix }}
 
@@ -127,7 +129,7 @@ spec:
     spec:
       containers:
         - name: run
-          image: quay.io/ibmmas/cli@{{ $_cli_image_digest }}
+          image: "{{ .Values.ecr_image_repo }}/{{ $_cli_image_name }}@{{ $_cli_image_digest }}"
           imagePullPolicy: IfNotPresent
           resources:
             limits:


### PR DESCRIPTION
Changes to add a parameter for cli image repo since govcloud will be mirroring images to ecr. 
replace `quay.io/ibmmas` with `ecr_image_repo`
set cli image name variable 
Added image mirroring for `quay.io/ibmmas`