### PR TITLE
Added addonIdentifier under spec.config

### DIFF
--- a/instance-applications/550-ibm-mas-addons-config/templates/01-allowlist-cr.yaml
+++ b/instance-applications/550-ibm-mas-addons-config/templates/01-allowlist-cr.yaml
@@ -17,6 +17,7 @@ spec:
   displayName: "{{ .Values.instance_id }}-AllowListing"
   addonType: allowlist
   config:
+    addonIdentifier: {{ .Values.instance_id }}
     instances:
       - name: "{{ .Values.instance_id }}-AllowList"
 {{- end }}

--- a/instance-applications/550-ibm-mas-addons-config/templates/02-additional-vpn-cr.yaml
+++ b/instance-applications/550-ibm-mas-addons-config/templates/02-additional-vpn-cr.yaml
@@ -17,6 +17,7 @@ spec:
   displayName: "{{ .Values.instance_id }}-Additionalvpn"
   addonType: additionalvpn
   config:
+    addonIdentifier: {{ .Values.instance_id }}
     instances:
       - name: "{{ .Values.instance_id }}-Additionalvpn"
 {{- end }}

--- a/instance-applications/550-ibm-mas-addons-config/templates/03-enhanced-dr-cr.yaml
+++ b/instance-applications/550-ibm-mas-addons-config/templates/03-enhanced-dr-cr.yaml
@@ -17,6 +17,7 @@ spec:
   displayName: "{{ .Values.instance_id }}-EnhancedDR"
   addonType: enhanceddr
   config:
+    addonIdentifier: {{ .Values.instance_id }}
     instances:
       - name: "{{ .Values.instance_id }}-EnhancedDR"
 {{- end }}

--- a/instance-applications/550-ibm-mas-addons-config/templates/04-extensions-cr.yaml
+++ b/instance-applications/550-ibm-mas-addons-config/templates/04-extensions-cr.yaml
@@ -17,6 +17,7 @@ spec:
   displayName: "{{ .Values.instance_id }}-Extensions"
   addonType: extensions
   config:
+    addonIdentifier: {{ .Values.instance_id }}
     instances:
       - name: "{{ .Values.instance_id }}-Extensions"
 {{- end }}

--- a/instance-applications/550-ibm-mas-addons-config/templates/05-replica-db-cr.yaml
+++ b/instance-applications/550-ibm-mas-addons-config/templates/05-replica-db-cr.yaml
@@ -17,6 +17,7 @@ spec:
   displayName: "{{ .Values.instance_id }}-Replicadb"
   addonType: replica-db
   config:
+    addonIdentifier: {{ .Values.instance_id }}
     instances:
     {{- range $key, $value := .Values.databases }}
       - name: "{{ $.Values.instance_id }}-{{ $value.mas_application_id }}"

--- a/instance-applications/550-ibm-mas-addons-config/templates/06-nonshared-cluster-cr.yaml
+++ b/instance-applications/550-ibm-mas-addons-config/templates/06-nonshared-cluster-cr.yaml
@@ -17,6 +17,7 @@ spec:
   displayName: "{{ .Values.instance_id }}-NonsharedCluster"
   addonType: nonsharedcluster
   config:
+    addonIdentifier: {{ .Values.cluster_id }}
     instances:
       - name: "{{ .Values.instance_id }}-NonsharedCluster"
 {{- end }}


### PR DESCRIPTION
## Issue
https://jsw.ibm.com/browse/MASCORE-9235

## Description
A new field named "addonIdentifier" has been added under spec.config for generic add-ons to explicitly identify the usage of the add-on (e.g., instance level, cluster level, etc.).
## Test Results
<!-- Please describe how the change has been tested. If you have not performed any testing please explain why. Provide links to any relevant automated test cases not contained in this pull request. -->

## Related Pull Requests
ibm-mas : 
Adoption usage API : https://github.ibm.com/maximoappsuite/adoptionusageapi/pull/344

<hr/>

### :warning: Notes for Reviewers
* Ensure you have understood the [guidelines](https://pages.github.ibm.com/maximoappsuite/playbook/tools/github/#guidelines) before proceeding with a review.
* Ensure all sections in the PR template are appropriately completed.