### PR TITLE
[patch] Mongo secret creation/updation trigger twice.

### DIFF
--- a/instance-applications/010-ibm-sync-jobs/templates/00-aws-docdb-add-user_Job.yaml
+++ b/instance-applications/010-ibm-sync-jobs/templates/00-aws-docdb-add-user_Job.yaml
@@ -26,7 +26,7 @@ Increment this value whenever you make a change to an immutable field of the Job
 E.g. passing in a new environment variable.
 Included in $_job_hash (see below).
 */}}
-{{- $_job_version := "v3" }}
+{{- $_job_version := "v4" }}
 
 {{- /*
 10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_digest
@@ -110,12 +110,6 @@ spec:
                 secretKeyRef:
                   name: aws-docdb
                   key: docdb_master_password
-            - name: DOCDB_INSTANCE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: aws-docdb
-                  key: docdb_instance_password
-                  optional: true
             - name: DOCDB_MASTER_INFO
               valueFrom:
                 secretKeyRef:
@@ -165,6 +159,14 @@ spec:
               # remove trailing comma
               export DOCDB_HOSTS=${DOCDB_HOSTS%,}
 
+              # Get docdb instance password from aws secrets manager
+              SECRETS_KEY_SEPERATOR="/"
+              SECRET_NAME_MONGO=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}mongo
+              source /mascli/functions/gitops_utils
+              sm_login
+              docdb_instance_secret=$(sm_get_secret "${SECRET_NAME_MONGO}")
+              export DOCDB_INSTANCE_PASSWORD=$(echo "${docdb_instance_secret}" | yq .password)
+
               echo "Params:"
               echo "    - MAS_INSTANCE_ID         ................... ${MAS_INSTANCE_ID}"
               echo "    - MAS_CONFIG_DIR          ................... ${MAS_CONFIG_DIR}"
@@ -192,8 +194,6 @@ spec:
               echo "Updating Instance Mongo Secret"
               echo "================================================================================"
 
-              SECRETS_KEY_SEPERATOR="/"
-              SECRET_NAME_MONGO=${ACCOUNT_ID}${SECRETS_KEY_SEPERATOR}${CLUSTER_ID}${SECRETS_KEY_SEPERATOR}${MAS_INSTANCE_ID}${SECRETS_KEY_SEPERATOR}mongo
               DOCDB_MASTER_INFO_ESCAPED=${DOCDB_MASTER_INFO//\"/\\\"}
               DOCDB_MASTER_INFO_ESCAPED=${DOCDB_MASTER_INFO_ESCAPED//$'\n'/\\n}
 
@@ -211,8 +211,6 @@ spec:
               echo
 
 
-              source /mascli/functions/gitops_utils
-              sm_login
               TAGS="[{\"Key\": \"source\", \"Value\": \"aws-docdb-add-user\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
               sm_update_secret $SECRET_NAME_MONGO "{\"info\":\"$DOCDB_MASTER_INFO_ESCAPED\", \"username\":\"$DOCDB_INSTANCE_USERNAME\", \"password\":\"$DOCDB_INSTANCE_PASSWORD\"}" "${TAGS}" || exit $?
 


### PR DESCRIPTION
Issue: [MASCORE-9478](https://jsw.ibm.com/browse/MASCORE-9478)

## Problem
oc secret sls-mongo-credentials was created initially with the values from aws secret but the aws secret got changed again which led to mismatch and SREs had to do hard refresh again

## RCA
When sync retry of instance.<clusterid>.<instancename> argo app happens because any of other argo apps failed for some reason, the retry of aws-docdb-add-user job **regenerated** the docdb instance password again since it was trying to read from the oc secret value which hasn't been updated (ie. It gets updated after a hard refresh later though)

## Solution
Instead of reading from oc secret which may contain outdated value, we directly read from AWS secrers manager for the latest value and hence avoid the credential to be regenerated

## Testing
Tested in mcspkvn4 by creating a job manually

### Password generation for the first time
<img width="1107" height="809" alt="Screenshot 2025-09-24 at 7 17 09 PM" src="https://github.com/user-attachments/assets/9f68f340-de62-4cc6-ac5a-f88cffec445c" />
<img width="999" height="843" alt="Screenshot 2025-09-24 at 7 17 35 PM" src="https://github.com/user-attachments/assets/7a09b10f-8e52-4b02-af84-874fda3e8e92" />

### Second job execution which doesn't regenerate the password
<img width="882" height="852" alt="Screenshot 2025-09-24 at 7 20 05 PM" src="https://github.com/user-attachments/assets/e77f651e-e982-48a9-97ff-589854fef61e" />
