### PR TITLE
[patch] Label length fix for Post delete jobs

### DIFF
--- a/instance-applications/130-ibm-jdbc-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-jdbc-config/templates/postdelete-delete-cr.yaml
@@ -9,7 +9,11 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 {{ $cr_kind := .Values.mas_config_kind }}
 {{ $cr_api_version := .Values.mas_config_api_version }}
 
-{{ $job_name := printf "postdelete-delete-cr-job-%s" $cr_name }}
+{{- /* Truncate job name to stay under 63 character limit for labels */ -}}
+{{- /* postdelete-cr-job- (18) + name (38) + - (1) + hash (6) = 63 chars */ -}}
+{{ $name_hash := $cr_name | sha256sum | trunc 6 }}
+{{ $truncated_name := trunc 38 $cr_name }}
+{{ $job_name := printf "postdelete-cr-job-%s-%s" $truncated_name $name_hash }}
 
 # NOTE: depends on resources created in ibm-mas-suite chart (01-postdelete-crs-resources)
 # The values below must align with the values in that file

--- a/instance-applications/130-ibm-kafka-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-kafka-config/templates/postdelete-delete-cr.yaml
@@ -4,7 +4,11 @@
 {{ $cr_kind := .Values.mas_config_kind }}
 {{ $cr_api_version := .Values.mas_config_api_version }}
 
-{{ $job_name := printf "postdelete-delete-cr-job-%s" $cr_name }}
+{{- /* Truncate job name to stay under 63 character limit for labels */ -}}
+{{- /* postdelete-cr-job- (18) + name (38) + - (1) + hash (6) = 63 chars */ -}}
+{{ $name_hash := $cr_name | sha256sum | trunc 6 }}
+{{ $truncated_name := trunc 38 $cr_name }}
+{{ $job_name := printf "postdelete-cr-job-%s-%s" $truncated_name $name_hash }}
 
 # NOTE: depends on resources created in ibm-mas-suite chart (01-postdelete-crs-resources)
 # The values below must align with the values in that file

--- a/instance-applications/130-ibm-mas-bas-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-mas-bas-config/templates/postdelete-delete-cr.yaml
@@ -9,7 +9,11 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 {{ $cr_kind := .Values.mas_config_kind }}
 {{ $cr_api_version := .Values.mas_config_api_version }}
 
-{{ $job_name := printf "postdelete-delete-cr-job-%s" $cr_name }}
+{{- /* Truncate job name to stay under 63 character limit for labels */ -}}
+{{- /* postdelete-cr-job- (18) + name (38) + - (1) + hash (6) = 63 chars */ -}}
+{{ $name_hash := $cr_name | sha256sum | trunc 6 }}
+{{ $truncated_name := trunc 38 $cr_name }}
+{{ $job_name := printf "postdelete-cr-job-%s-%s" $truncated_name $name_hash }}
 
 # NOTE: depends on resources created in ibm-mas-suite chart (01-postdelete-crs-resources)
 # The values below must align with the values in that file

--- a/instance-applications/130-ibm-mas-idp-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-mas-idp-config/templates/postdelete-delete-cr.yaml
@@ -9,7 +9,11 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 {{ $cr_kind := .Values.mas_config_kind }}
 {{ $cr_api_version := .Values.mas_config_api_version }}
 
-{{ $job_name := printf "postdelete-delete-cr-job-%s" $cr_name }}
+{{- /* Truncate job name to stay under 63 character limit for labels */ -}}
+{{- /* postdelete-cr-job- (18) + name (38) + - (1) + hash (6) = 63 chars */ -}}
+{{ $name_hash := $cr_name | sha256sum | trunc 6 }}
+{{ $truncated_name := trunc 38 $cr_name }}
+{{ $job_name := printf "postdelete-cr-job-%s-%s" $truncated_name $name_hash }}
 
 # NOTE: depends on resources created in ibm-mas-suite chart (01-postdelete-crs-resources)
 # The values below must align with the values in that file

--- a/instance-applications/130-ibm-mas-mongo-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-mas-mongo-config/templates/postdelete-delete-cr.yaml
@@ -9,7 +9,11 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 {{ $cr_kind := .Values.mas_config_kind }}
 {{ $cr_api_version := .Values.mas_config_api_version }}
 
-{{ $job_name := printf "postdelete-delete-cr-job-%s" $cr_name }}
+{{- /* Truncate job name to stay under 63 character limit for labels */ -}}
+{{- /* postdelete-cr-job- (18) + name (38) + - (1) + hash (6) = 63 chars */ -}}
+{{ $name_hash := $cr_name | sha256sum | trunc 6 }}
+{{ $truncated_name := trunc 38 $cr_name }}
+{{ $job_name := printf "postdelete-cr-job-%s-%s" $truncated_name $name_hash }}
 
 # NOTE: depends on resources created in ibm-mas-suite chart (01-postdelete-crs-resources)
 # The values below must align with the values in that file

--- a/instance-applications/130-ibm-mas-sls-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-mas-sls-config/templates/postdelete-delete-cr.yaml
@@ -9,7 +9,11 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 {{ $cr_kind := .Values.mas_config_kind }}
 {{ $cr_api_version := .Values.mas_config_api_version }}
 
-{{ $job_name := printf "postdelete-delete-cr-job-%s" $cr_name }}
+{{- /* Truncate job name to stay under 63 character limit for labels */ -}}
+{{- /* postdelete-cr-job- (18) + name (38) + - (1) + hash (6) = 63 chars */ -}}
+{{ $name_hash := $cr_name | sha256sum | trunc 6 }}
+{{ $truncated_name := trunc 38 $cr_name }}
+{{ $job_name := printf "postdelete-cr-job-%s-%s" $truncated_name $name_hash }}
 
 # NOTE: depends on resources created in ibm-mas-suite chart (01-postdelete-crs-resources)
 # The values below must align with the values in that file

--- a/instance-applications/130-ibm-mas-smtp-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-mas-smtp-config/templates/postdelete-delete-cr.yaml
@@ -9,7 +9,11 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 {{ $cr_kind := .Values.mas_config_kind }}
 {{ $cr_api_version := .Values.mas_config_api_version }}
 
-{{ $job_name := printf "postdelete-delete-cr-job-%s" $cr_name }}
+{{- /* Truncate job name to stay under 63 character limit for labels */ -}}
+{{- /* postdelete-cr-job- (18) + name (38) + - (1) + hash (6) = 63 chars */ -}}
+{{ $name_hash := $cr_name | sha256sum | trunc 6 }}
+{{ $truncated_name := trunc 38 $cr_name }}
+{{ $job_name := printf "postdelete-cr-job-%s-%s" $truncated_name $name_hash }}
 
 # NOTE: depends on resources created in ibm-mas-suite chart (01-postdelete-crs-resources)
 # The values below must align with the values in that file

--- a/instance-applications/130-ibm-objectstorage-config/templates/postdelete-delete-cr.yaml
+++ b/instance-applications/130-ibm-objectstorage-config/templates/postdelete-delete-cr.yaml
@@ -9,7 +9,11 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 {{ $cr_kind := .Values.mas_config_kind }}
 {{ $cr_api_version := .Values.mas_config_api_version }}
 
-{{ $job_name := printf "postdelete-delete-cr-job-%s" $cr_name }}
+{{- /* Truncate job name to stay under 63 character limit for labels */ -}}
+{{- /* postdelete-cr-job- (18) + name (38) + - (1) + hash (6) = 63 chars */ -}}
+{{ $name_hash := $cr_name | sha256sum | trunc 6 }}
+{{ $truncated_name := trunc 38 $cr_name }}
+{{ $job_name := printf "postdelete-cr-job-%s-%s" $truncated_name $name_hash }}
 
 # NOTE: depends on resources created in ibm-mas-suite chart (01-postdelete-crs-resources)
 # The values below must align with the values in that file


### PR DESCRIPTION
Postdelete jobs of some instance applications were not getting removed at the time of deprovisioning as the length exceeded 63 characters. Hence truncated job name to stay under 63 character limit for labels with following logic for creating the label:
Prefix `postdelete-cr-job-`: 18 characters
Truncated CR name: Max 38 characters
Tuncated CR name hash(for unique job name): max 6 characters
