### PR TITLE
[patch] InstanaAgent db2 plugin configuration

### DIFF
--- a/cluster-applications/055-instana-agent-operator/templates/08-CronJob.yaml
+++ b/cluster-applications/055-instana-agent-operator/templates/08-CronJob.yaml
@@ -133,13 +133,19 @@ spec:
                     local db2_username="${2}"
                     local db2_password="${3}"
                     local jdbc_secret=$(sm_get_secret "${secret_name}")
-                    local url=$(extract_secret_value "${jdbc_secret}" jdbc_connection_url)           
+                    local url=$(extract_secret_value "${jdbc_secret}" jdbc_connection_url)
                     local yaml=$(set_yaml_string_field "${DB2_PLUGIN_REMOTE_TEMPLATE}" host $(echo "${url}" | cut -d'/' -f3 | cut -d':' -f1))
-                    local yaml=$(set_yaml_string_field "${yaml}" user ${db2_username})   
+                    local yaml=$(set_yaml_string_field "${yaml}" user ${db2_username})
                     local yaml=$(set_yaml_string_field "${yaml}" password ${db2_password})
                     local yaml=$(set_yaml_string_field "${yaml}" availabilityZone "${CLUSTER_ID}:db2")
-                    local db_name=$(extract_secret_value "${jdbc_secret}" db2_dbname)              
-                    local yaml=$(set_yaml_array_field "${yaml}" databases "${db_name}")  
+                    local db_name=$(extract_secret_value "${jdbc_secret}" db2_dbname)
+                    # Fallback: extract database name from JDBC URL if not found in secret
+                    if [[ -z "${db_name}" || "${db_name}" == "null" ]]; then
+                      # Format: jdbc:db2://host:port/DBNAME:params or jdbc:db2://host:port/DBNAME;params
+                      db_name=$(echo "${url}" | sed -n 's|.*://[^/]*/\([^:;]*\).*|\1|p')
+                      echo "[WARN] db2_dbname not found in secret, extracted '${db_name}' from URL"
+                    fi
+                    local yaml=$(set_yaml_array_field "${yaml}" databases "${db_name}")
                     echo "${yaml}"
                   }
 


### PR DESCRIPTION
Instana Agent db2 plugin config wouldn't detect DB name if the Connection url string has additional params. Added regex to parse the DB name properly from the url string. Verified change after installing the Instana agent again after applying the Regex in the Cron job.
<img width="1379" height="127" alt="Screenshot 2026-04-13 at 2 35 42 PM" src="https://github.com/user-attachments/assets/2ef21f5e-1f2a-4694-b749-e69bd81993c4" />
<img width="1718" height="941" alt="Screenshot 2026-04-13 at 2 50 28 PM" src="https://github.com/user-attachments/assets/b35b80bb-996b-48f9-9e04-99580c5c9fb1" />
<img width="1310" height="252" alt="Screenshot 2026-04-13 at 2 53 35 PM" src="https://github.com/user-attachments/assets/16953f1d-a60b-4eeb-91b1-7971b161bcab" />



https://jsw.ibm.com/browse/MASCORE-12017