### PR TITLE
[major] Change secret name droai to dro change for AI SaaS flow

### DIFF
--- a/cluster-applications/030-ibm-dro/templates/14-postsync-update-sm_Job.yaml
+++ b/cluster-applications/030-ibm-dro/templates/14-postsync-update-sm_Job.yaml
@@ -26,7 +26,7 @@ Increment this value whenever you make a change to an immutable field of the Job
 E.g. passing in a new environment variable.
 Included in $_job_hash (see below).
 */}}
-{{- $_job_version := "v4" }}
+{{- $_job_version := "v5" }}
 
 {{- /*
 10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_digest

--- a/cluster-applications/030-ibm-dro/templates/14-postsync-update-sm_Job.yaml
+++ b/cluster-applications/030-ibm-dro/templates/14-postsync-update-sm_Job.yaml
@@ -238,6 +238,13 @@ spec:
               fi
               export DRO_URL="https://${DRO_HOST}"
 
+              echo "Fetching ca from ibm-data-reporter-operator-api-token Secret in ${DRO_NAMESPACE}"
+              DRO_CA_B64ENC=$(cat /etc/mas/creds/ibm-data-reporter-operator-api-token/ca | base64 -w0)
+              if [[ -z "${DRO_CA_B64ENC}" ]]; then
+                echo "Failed to fetch ca"
+                exit 1
+              fi
+
               echo "Fetching token from ibm-data-reporter-operator-api-token Secret in ${DRO_NAMESPACE}"
               export DRO_API_TOKEN=$(cat /etc/mas/creds/ibm-data-reporter-operator-api-token/token)
               if [[ -z "${DRO_API_TOKEN}" ]]; then
@@ -270,7 +277,7 @@ spec:
               # aws secretsmanager create-secret --name ${SECRET_NAME} --secret-string "${SECRET_VALUE}"
               SECRET_NAME_DRO=${ACCOUNT_ID}/${CLUSTER_ID}/dro
               TAGS="[{\"Key\": \"source\", \"Value\": \"postsync-ibm-dro-update-sm-job\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
-              sm_update_secret $SECRET_NAME_DRO "{\"dro_api_token\": \"$DRO_API_TOKEN\", \"dro_url\": \"$DRO_URL\", \"dro_ca_b64enc\": \"$DRO_API_TOKEN\", }" "${TAGS}"
+              sm_update_secret $SECRET_NAME_DRO "{\"dro_api_token\": \"$DRO_API_TOKEN\", \"dro_url\": \"$DRO_URL\", \"dro_ca_b64enc\": \"$DRO_CA_B64ENC\", }" "${TAGS}"
 
 
       restartPolicy: Never

--- a/cluster-applications/030-ibm-dro/templates/14-postsync-update-sm_Job.yaml
+++ b/cluster-applications/030-ibm-dro/templates/14-postsync-update-sm_Job.yaml
@@ -239,7 +239,7 @@ spec:
               export DRO_URL="https://${DRO_HOST}"
 
               echo "Fetching ca from ibm-data-reporter-operator-api-token Secret in ${DRO_NAMESPACE}"
-              export DRO_CA_B64ENC=$(cat /etc/mas/creds/ibm-data-reporter-operator-api-token/ca | base64 -w0)
+              export DRO_CA_B64ENC=$(cat /etc/mas/creds/ibm-data-reporter-operator-api-token/ca.crt | base64 -w0)
               if [[ -z "${DRO_CA_B64ENC}" ]]; then
                 echo "Failed to fetch ca"
                 exit 1

--- a/cluster-applications/030-ibm-dro/templates/14-postsync-update-sm_Job.yaml
+++ b/cluster-applications/030-ibm-dro/templates/14-postsync-update-sm_Job.yaml
@@ -277,7 +277,7 @@ spec:
               # aws secretsmanager create-secret --name ${SECRET_NAME} --secret-string "${SECRET_VALUE}"
               SECRET_NAME_DRO=${ACCOUNT_ID}/${CLUSTER_ID}/dro
               TAGS="[{\"Key\": \"source\", \"Value\": \"postsync-ibm-dro-update-sm-job\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
-              sm_update_secret $SECRET_NAME_DRO "{\"dro_api_token\": \"$DRO_API_TOKEN\", \"dro_url\": \"$DRO_URL\", \"dro_ca_b64enc\": \"$DRO_CA_B64ENC\", }" "${TAGS}"
+              sm_update_secret $SECRET_NAME_DRO "{\"dro_api_token\": \"$DRO_API_TOKEN\", \"dro_url\": \"$DRO_URL\", \"dro_ca_b64enc\": \"$DRO_CA_B64ENC\" }" "${TAGS}"
 
 
       restartPolicy: Never

--- a/cluster-applications/030-ibm-dro/templates/14-postsync-update-sm_Job.yaml
+++ b/cluster-applications/030-ibm-dro/templates/14-postsync-update-sm_Job.yaml
@@ -277,8 +277,7 @@ spec:
               # aws secretsmanager create-secret --name ${SECRET_NAME} --secret-string "${SECRET_VALUE}"
               SECRET_NAME_DRO=${ACCOUNT_ID}/${CLUSTER_ID}/dro
               TAGS="[{\"Key\": \"source\", \"Value\": \"postsync-ibm-dro-update-sm-job\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
-              sm_update_secret $SECRET_NAME_DRO "{\"dro_api_token\": \"$DRO_API_TOKEN\", \"dro_url\": \"$DRO_URL\", \"dro_ca_b64enc\": \"$DRO_CA_B64ENC\" }" "${TAGS}"
-
+              sm_update_secret $SECRET_NAME_DRO "{\"dro_api_token\": \"$DRO_API_TOKEN\", \"dro_url\": \"$DRO_URL\", \"dro_client_tls_tls_crt_b64\": \"$DRO_CLIENT_TLS_TLS_CRT\", \"dro_client_tls_tls_key_b64\": \"$DRO_CLIENT_TLS_TLS_KEY\", \"dro_ca_b64enc\": \"$DRO_CA_B64ENC\" }" "${TAGS}"
 
       restartPolicy: Never
 

--- a/cluster-applications/030-ibm-dro/templates/14-postsync-update-sm_Job.yaml
+++ b/cluster-applications/030-ibm-dro/templates/14-postsync-update-sm_Job.yaml
@@ -239,7 +239,7 @@ spec:
               export DRO_URL="https://${DRO_HOST}"
 
               echo "Fetching ca from ibm-data-reporter-operator-api-token Secret in ${DRO_NAMESPACE}"
-              DRO_CA_B64ENC=$(cat /etc/mas/creds/ibm-data-reporter-operator-api-token/ca | base64 -w0)
+              export DRO_CA_B64ENC=$(cat /etc/mas/creds/ibm-data-reporter-operator-api-token/ca | base64 -w0)
               if [[ -z "${DRO_CA_B64ENC}" ]]; then
                 echo "Failed to fetch ca"
                 exit 1

--- a/cluster-applications/030-ibm-dro/templates/14-postsync-update-sm_Job.yaml
+++ b/cluster-applications/030-ibm-dro/templates/14-postsync-update-sm_Job.yaml
@@ -270,7 +270,7 @@ spec:
               # aws secretsmanager create-secret --name ${SECRET_NAME} --secret-string "${SECRET_VALUE}"
               SECRET_NAME_DRO=${ACCOUNT_ID}/${CLUSTER_ID}/dro
               TAGS="[{\"Key\": \"source\", \"Value\": \"postsync-ibm-dro-update-sm-job\"}, {\"Key\": \"account\", \"Value\": \"${ACCOUNT_ID}\"}, {\"Key\": \"cluster\", \"Value\": \"${CLUSTER_ID}\"}]"
-              sm_update_secret $SECRET_NAME_DRO "{\"dro_api_token\": \"$DRO_API_TOKEN\", \"dro_url\": \"$DRO_URL\", \"dro_client_tls_tls_crt_b64\": \"$DRO_CLIENT_TLS_TLS_CRT\", \"dro_client_tls_tls_key_b64\": \"$DRO_CLIENT_TLS_TLS_KEY\" }" "${TAGS}"
+              sm_update_secret $SECRET_NAME_DRO "{\"dro_api_token\": \"$DRO_API_TOKEN\", \"dro_url\": \"$DRO_URL\", \"dro_ca_b64enc\": \"$DRO_API_TOKEN\", }" "${TAGS}"
 
 
       restartPolicy: Never

--- a/instance-applications/113-ibm-aiservice/templates/02-aiservice-dro.yaml
+++ b/instance-applications/113-ibm-aiservice/templates/02-aiservice-dro.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "142"
 data:
-  DRO_API_TOKEN: {{ .Values.dro_api_token  | default "" | toString | b64enc | quote }}
+  DRO_TOKEN: {{ .Values.dro_api_token  | default "" | toString | b64enc | quote }}
 type: Opaque
 
 ---

--- a/instance-applications/113-ibm-aiservice/templates/02-aiservice-dro.yaml
+++ b/instance-applications/113-ibm-aiservice/templates/02-aiservice-dro.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "142"
 data:
-  DRO_TOKEN: {{ .Values.drocfg_registration_key  | default "" | toString | b64enc | quote }}
+  DRO_API_TOKEN: {{ .Values.dro_api_token  | default "" | toString | b64enc | quote }}
 type: Opaque
 
 ---

--- a/instance-applications/113-ibm-aiservice/templates/02-aiservice-dro.yaml
+++ b/instance-applications/113-ibm-aiservice/templates/02-aiservice-dro.yaml
@@ -19,5 +19,5 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "143"
 data:
-  ca.crt: {{ .Values.drocfg_ca_b64enc }}
+  ca.crt: {{ .Values.dro_ca_b64enc }}
 type: Opaque

--- a/instance-applications/113-ibm-aiservice/templates/06-aiservice-app.yaml
+++ b/instance-applications/113-ibm-aiservice/templates/06-aiservice-app.yaml
@@ -17,9 +17,9 @@ spec:
             cp: "{{ .Values.mas_icr_cp }}"
             cpopen: "{{ .Values.mas_icr_cpopen }}"
         dro:
-            url: "{{ .Values.drocfg_url }}"
+            url: "{{ .Values.dro_url }}"
             secretName: "{{ .Values.aiservice_dro_token_secret }}"
-            ca: "{{ .Values.drocfg_ca_b64enc }}"
+            ca: "{{ .Values.dro_ca_b64enc }}"
         jdbc:
             url: "{{ .Values.jdbccfg_url }}"
             secretName: "{{ .Values.aiservice_jdbc_secret }}"

--- a/instance-applications/113-ibm-aiservice/values.yaml
+++ b/instance-applications/113-ibm-aiservice/values.yaml
@@ -42,7 +42,7 @@ mas_aiservice_dro_token_secret: "dro-token"
 mas_aiservice_dro_cacert_secret: "dro-certificates"
 
 dro_ca_b64enc: "ca.crt"
-dro_api_token: "DRO_TOKEN"
+dro_api_token: "DRO_API_TOKEN"
 dro_url: "dro_url"
 
 # JDBC

--- a/instance-applications/113-ibm-aiservice/values.yaml
+++ b/instance-applications/113-ibm-aiservice/values.yaml
@@ -42,7 +42,7 @@ mas_aiservice_dro_token_secret: "dro-token"
 mas_aiservice_dro_cacert_secret: "dro-certificates"
 
 drocfg_ca: "ca.crt"
-drocfg_registration_key: "DRO_TOKEN"
+dro_api_token: "DRO_TOKEN"
 drocfg_url: "drocfg_url"
 
 # JDBC

--- a/instance-applications/113-ibm-aiservice/values.yaml
+++ b/instance-applications/113-ibm-aiservice/values.yaml
@@ -41,7 +41,7 @@ mas_aiservice_storage_templates_bucket: "MAS_AISERVICE_STORAGE_TEMPLATES_BUCKET"
 mas_aiservice_dro_token_secret: "dro-token"
 mas_aiservice_dro_cacert_secret: "dro-certificates"
 
-drocfg_ca: "ca.crt"
+dro_ca_b64enc: "ca.crt"
 dro_api_token: "DRO_TOKEN"
 dro_url: "dro_url"
 

--- a/instance-applications/113-ibm-aiservice/values.yaml
+++ b/instance-applications/113-ibm-aiservice/values.yaml
@@ -43,7 +43,7 @@ mas_aiservice_dro_cacert_secret: "dro-certificates"
 
 drocfg_ca: "ca.crt"
 dro_api_token: "DRO_TOKEN"
-drocfg_url: "drocfg_url"
+dro_url: "dro_url"
 
 # JDBC
 mas_aiservice_db2_jdbc_secret: "aiservice-jdbccfg"

--- a/instance-applications/115-ibm-aiservice-tenant/templates/03-aiservice-dro-secret.yaml
+++ b/instance-applications/115-ibm-aiservice-tenant/templates/03-aiservice-dro-secret.yaml
@@ -15,4 +15,4 @@ metadata:
     argocd.argoproj.io/sync-wave: "303"
 type: Opaque
 data:
-  DRO_API_TOKEN: {{ .Values.dro_api_token   | default "" | toString | b64enc }}
+  DRO_TOKEN: {{ .Values.dro_api_token   | default "" | toString | b64enc }}

--- a/instance-applications/115-ibm-aiservice-tenant/templates/03-aiservice-dro-secret.yaml
+++ b/instance-applications/115-ibm-aiservice-tenant/templates/03-aiservice-dro-secret.yaml
@@ -15,4 +15,4 @@ metadata:
     argocd.argoproj.io/sync-wave: "303"
 type: Opaque
 data:
-  DRO_TOKEN: {{ .Values.drocfg_registration_key   | default "" | toString | b64enc }}
+  DRO_API_TOKEN: {{ .Values.dro_api_token   | default "" | toString | b64enc }}

--- a/instance-applications/115-ibm-aiservice-tenant/templates/07-aiservice-workspace.yaml
+++ b/instance-applications/115-ibm-aiservice-tenant/templates/07-aiservice-workspace.yaml
@@ -25,9 +25,9 @@ spec:
       cp: "{{ .Values.mas_icr_cp }}"
       cpopen: "{{ .Values.mas_icr_cpopen }}"
     dro:
-      url: "{{ .Values.drocfg_url }}"
+      url: "{{ .Values.dro_url }}"
       secretName: "{{ .Values.tenantNamespace }}----dro-secret"
-      ca: "{{ .Values.drocfg_ca_b64enc }}"
+      ca: "{{ .Values.dro_ca_b64enc }}"
     sls:
       url: "{{ .Values.slscfg_url }}"
       secretName: "{{ .Values.tenantNamespace }}----sls-secret"

--- a/instance-applications/115-ibm-aiservice-tenant/values.yaml
+++ b/instance-applications/115-ibm-aiservice-tenant/values.yaml
@@ -14,7 +14,7 @@ ibm_aiservice_tenant:
   # dro
   drocfg_url: "drocfg_url"
   drocfg_ca: "drocfg_ca"
-  drocfg_registration_key: "drocfg_registration_key"
+  dro_api_token: "dro_api_token"
 
   # sls
   slscfg_ca_tenant: "slscfg_ca_tenant"

--- a/instance-applications/115-ibm-aiservice-tenant/values.yaml
+++ b/instance-applications/115-ibm-aiservice-tenant/values.yaml
@@ -13,7 +13,7 @@ ibm_aiservice_tenant:
 
   # dro
   dro_url: "dro_url"
-  drocfg_ca: "drocfg_ca"
+  dro_ca_b64enc: "dro_ca_b64enc"
   dro_api_token: "dro_api_token"
 
   # sls

--- a/instance-applications/115-ibm-aiservice-tenant/values.yaml
+++ b/instance-applications/115-ibm-aiservice-tenant/values.yaml
@@ -12,7 +12,7 @@ ibm_aiservice_tenant:
   mas_icr_cpopen: "icr.io/cpopen"
 
   # dro
-  drocfg_url: "drocfg_url"
+  dro_url: "dro_url"
   drocfg_ca: "drocfg_ca"
   dro_api_token: "dro_api_token"
 

--- a/root-applications/ibm-aiservice-instance-root/templates/040-ibm-aiservice-app.yaml
+++ b/root-applications/ibm-aiservice-instance-root/templates/040-ibm-aiservice-app.yaml
@@ -45,7 +45,7 @@ spec:
             aiservice_s3_host: "{{ .Values.ibm_aiservice.aiservice_s3_host }}"
             aiservice_s3_port: "{{ .Values.ibm_aiservice.aiservice_s3_port }}"
 
-            drocfg_ca_b64enc: "{{ .Values.ibm_aiservice.drocfg_ca_b64enc }}"
+            dro_ca_b64enc: "{{ .Values.ibm_aiservice.dro_ca_b64enc }}"
             jdbccfg_ca_b64enc: "{{ .Values.ibm_aiservice.jdbccfg_ca_b64enc }}"
             aiservice_dro_token_secret: "{{ .Values.ibm_aiservice.aiservice_dro_token_secret }}"
             aiservice_dro_cacert_secret: "{{ .Values.ibm_aiservice.aiservice_dro_cacert_secret }}"

--- a/root-applications/ibm-aiservice-instance-root/templates/040-ibm-aiservice-app.yaml
+++ b/root-applications/ibm-aiservice-instance-root/templates/040-ibm-aiservice-app.yaml
@@ -53,7 +53,7 @@ spec:
             drocfg_ca: "{{ .Values.ibm_aiservice.drocfg_ca }}"
             drocfg_ca_tenant: "{{ .Values.ibm_aiservice.drocfg_ca_tenant }}"
             dro_api_token: "{{ .Values.ibm_aiservice.dro_api_token }}"
-            drocfg_url: "{{ .Values.ibm_aiservice.drocfg_url }}"
+            dro_url: "{{ .Values.ibm_aiservice.dro_url }}"
 
             aiservice_jdbc_secret: "{{ .Values.ibm_aiservice.aiservice_jdbc_secret }}"
             use_aws_db2: "{{ .Values.ibm_aiservice.use_aws_db2 }}"

--- a/root-applications/ibm-aiservice-instance-root/templates/040-ibm-aiservice-app.yaml
+++ b/root-applications/ibm-aiservice-instance-root/templates/040-ibm-aiservice-app.yaml
@@ -52,7 +52,7 @@ spec:
 
             drocfg_ca: "{{ .Values.ibm_aiservice.drocfg_ca }}"
             drocfg_ca_tenant: "{{ .Values.ibm_aiservice.drocfg_ca_tenant }}"
-            drocfg_registration_key: "{{ .Values.ibm_aiservice.drocfg_registration_key }}"
+            dro_api_token: "{{ .Values.ibm_aiservice.dro_api_token }}"
             drocfg_url: "{{ .Values.ibm_aiservice.drocfg_url }}"
 
             aiservice_jdbc_secret: "{{ .Values.ibm_aiservice.aiservice_jdbc_secret }}"

--- a/root-applications/ibm-aiservice-instance-root/values.yaml
+++ b/root-applications/ibm-aiservice-instance-root/values.yaml
@@ -209,7 +209,7 @@ ibm_aiservice:
 
   drocfg_ca: "drocfg_ca"
   dro_api_token: "dro_api_token"
-  drocfg_url: "drocfg_url"
+  dro_url: "dro_url"
 
 
   # JDBC

--- a/root-applications/ibm-aiservice-instance-root/values.yaml
+++ b/root-applications/ibm-aiservice-instance-root/values.yaml
@@ -207,7 +207,7 @@ ibm_aiservice:
   mas_aiservice_dro_token_secret: "dro-token"
   mas_aiservice_dro_cacert_secret: "dro-certificates"
 
-  drocfg_ca: "drocfg_ca"
+  dro_ca_b64enc: "dro_ca_b64enc"
   dro_api_token: "dro_api_token"
   dro_url: "dro_url"
 
@@ -262,9 +262,9 @@ ibm_aiservice_tenant:
   mas_icr_cpopen: "icr.io/cpopen"
 
   # dro
-  drocfg_url: "drocfg_url"
+  dro_url: "dro_url"
   drocfg_ca: "drocfg_ca"
-  drocfg_registration_key: "drocfg_registration_key"
+  dro_api_token: "dro_api_token"
 
   # sls
   slscfg_ca_tenant: "slscfg_ca_tenant"

--- a/root-applications/ibm-aiservice-instance-root/values.yaml
+++ b/root-applications/ibm-aiservice-instance-root/values.yaml
@@ -208,7 +208,7 @@ ibm_aiservice:
   mas_aiservice_dro_cacert_secret: "dro-certificates"
 
   drocfg_ca: "drocfg_ca"
-  drocfg_registration_key: "drocfg_registration_key"
+  dro_api_token: "dro_api_token"
   drocfg_url: "drocfg_url"
 
 

--- a/root-applications/ibm-aiservice-tenant-root/templates/100-ibm-aiservice-tenant-app.yaml
+++ b/root-applications/ibm-aiservice-tenant-root/templates/100-ibm-aiservice-tenant-app.yaml
@@ -66,7 +66,7 @@ spec:
             # DRO
             drocfg_ca: "{{ .Values.ibm_aiservice_tenant.drocfg_ca }}"
             drocfg_ca_b64enc: "{{ .Values.ibm_aiservice_tenant.drocfg_ca_b64enc }}"
-            drocfg_registration_key: "{{ .Values.ibm_aiservice_tenant.drocfg_registration_key }}"
+            dro_api_token: "{{ .Values.ibm_aiservice_tenant.dro_api_token }}"
             drocfg_url: "{{ .Values.ibm_aiservice_tenant.drocfg_url }}"
 
             #sls

--- a/root-applications/ibm-aiservice-tenant-root/templates/100-ibm-aiservice-tenant-app.yaml
+++ b/root-applications/ibm-aiservice-tenant-root/templates/100-ibm-aiservice-tenant-app.yaml
@@ -65,7 +65,7 @@ spec:
 
             # DRO
             drocfg_ca: "{{ .Values.ibm_aiservice_tenant.drocfg_ca }}"
-            drocfg_ca_b64enc: "{{ .Values.ibm_aiservice_tenant.drocfg_ca_b64enc }}"
+            dro_ca_b64enc: "{{ .Values.ibm_aiservice_tenant.dro_ca_b64enc }}"
             dro_api_token: "{{ .Values.ibm_aiservice_tenant.dro_api_token }}"
             dro_url: "{{ .Values.ibm_aiservice_tenant.dro_url }}"
 

--- a/root-applications/ibm-aiservice-tenant-root/templates/100-ibm-aiservice-tenant-app.yaml
+++ b/root-applications/ibm-aiservice-tenant-root/templates/100-ibm-aiservice-tenant-app.yaml
@@ -67,7 +67,7 @@ spec:
             drocfg_ca: "{{ .Values.ibm_aiservice_tenant.drocfg_ca }}"
             drocfg_ca_b64enc: "{{ .Values.ibm_aiservice_tenant.drocfg_ca_b64enc }}"
             dro_api_token: "{{ .Values.ibm_aiservice_tenant.dro_api_token }}"
-            drocfg_url: "{{ .Values.ibm_aiservice_tenant.drocfg_url }}"
+            dro_url: "{{ .Values.ibm_aiservice_tenant.dro_url }}"
 
             #sls
             slscfg_registration_key: "{{ .Values.ibm_aiservice_tenant.slscfg_registration_key }}"

--- a/root-applications/ibm-aiservice-tenant-root/values.yaml
+++ b/root-applications/ibm-aiservice-tenant-root/values.yaml
@@ -209,7 +209,7 @@ ibm_aiservice:
 
   drocfg_ca: "drocfg_ca"
   dro_api_token: "dro_api_token"
-  drocfg_url: "drocfg_url"
+  dro_url: "dro_url"
 
 
   # JDBC

--- a/root-applications/ibm-aiservice-tenant-root/values.yaml
+++ b/root-applications/ibm-aiservice-tenant-root/values.yaml
@@ -207,7 +207,7 @@ ibm_aiservice:
   mas_aiservice_dro_token_secret: "dro-token"
   mas_aiservice_dro_cacert_secret: "dro-certificates"
 
-  drocfg_ca: "drocfg_ca"
+  dro_ca_b64enc: "dro_ca_b64enc"
   dro_api_token: "dro_api_token"
   dro_url: "dro_url"
 
@@ -276,8 +276,8 @@ ibm_aiservice_tenant:
   # mas_aiservice_dro_token_secret: "dro-token"
   mas_aiservice_dro_cacert_secret: "dro-certificates"
 
-  drocfg_ca: "drocfg_ca"
-  drocfg_registration_key: "drocfg_registration_key"
+  dro_ca_b64enc: "dro_ca_b64enc"
+  dro_api_token: "dro_api_token"
   drocfg_url: "drocfg_url"
 
   #sls

--- a/root-applications/ibm-aiservice-tenant-root/values.yaml
+++ b/root-applications/ibm-aiservice-tenant-root/values.yaml
@@ -208,7 +208,7 @@ ibm_aiservice:
   mas_aiservice_dro_cacert_secret: "dro-certificates"
 
   drocfg_ca: "drocfg_ca"
-  drocfg_registration_key: "drocfg_registration_key"
+  dro_api_token: "dro_api_token"
   drocfg_url: "drocfg_url"
 
 


### PR DESCRIPTION
Ticket: [MASAIB-2072](https://jsw.ibm.com/browse/MASAIB-2072)

Changes:

- AI Service needs to point to the dro secret name instead of the droai secret name.
- The changes are related to migrating from droai to dro. Previously, it was linked to the droai secret name, so the keys were    different. I have updated them accordingly (e.g., drocfg_url, dro_url) for the AI Service.
- Exported the dro CA certificate in base64-encoded format, as the AI Service consumes it in this format.

Test Result:

- I have tested this in our GitOps dev cluster, and it is working fine. I have also attached a screenshot for reference.

<img width="2049" height="930" alt="Screenshot 2026-04-14 at 11 23 36 AM" src="https://github.com/user-attachments/assets/bd13a936-bfae-44bb-991b-6bd9505859a2" />
<img width="1978" height="1147" alt="Screenshot 2026-04-09 at 12 47 01 PM" src="https://github.com/user-attachments/assets/05f6cc2c-fa6c-4038-bf29-4cad76d55fcc" />
<img width="1751" height="746" alt="Screenshot 2026-04-09 at 12 47 09 PM" src="https://github.com/user-attachments/assets/ae880979-79e6-42aa-9e9e-f8578a4d6712" />
<img width="1758" height="809" alt="Screenshot 2026-04-10 at 11 33 58 AM" src="https://github.com/user-attachments/assets/c1d96453-36b7-4240-accc-cd81b9352a4c" />
<img width="1988" height="891" alt="Screenshot 2026-04-10 at 11 57 52 AM" src="https://github.com/user-attachments/assets/5189c00b-aeb2-41cf-8730-5c2891a346d6" />
<img width="1990" height="770" alt="Screenshot 2026-04-10 at 11 58 07 AM" src="https://github.com/user-attachments/assets/04702ba2-128e-4276-bc08-d6f9ff539316" />
