### PR TITLE
[patch] Resolve OperatorGroup naming conflict for cluster-logging-operator

### DIFF
--- a/cluster-applications/000-efs-csi-driver/templates/01-efs_OperatorGroup.yaml
+++ b/cluster-applications/000-efs-csi-driver/templates/01-efs_OperatorGroup.yaml
@@ -2,7 +2,7 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: openshift-operators
+  name: openshift-cluster-csi-drivers
   namespace: "{{ .Values.subscription_source_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "016"

--- a/cluster-applications/000-efs-csi-driver/templates/01-efs_OperatorGroup.yaml
+++ b/cluster-applications/000-efs-csi-driver/templates/01-efs_OperatorGroup.yaml
@@ -2,7 +2,7 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: openshift-cluster-csi-drivers
+  name: openshift-operators
   namespace: "{{ .Values.subscription_source_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "016"

--- a/cluster-applications/000-efs-csi-driver/templates/01-efs_OperatorGroup.yaml
+++ b/cluster-applications/000-efs-csi-driver/templates/01-efs_OperatorGroup.yaml
@@ -2,11 +2,10 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: openshift-cluster-csi-drivers
+  name: openshift-operators
   namespace: "{{ .Values.subscription_source_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "016"
-    argocd.argoproj.io/sync-options: ServerSideApply=true
 {{- if .Values.custom_labels }}
   labels:
 {{ .Values.custom_labels | toYaml | indent 4 }}

--- a/cluster-applications/000-efs-csi-driver/templates/01-efs_OperatorGroup.yaml
+++ b/cluster-applications/000-efs-csi-driver/templates/01-efs_OperatorGroup.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: "{{ .Values.subscription_source_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "016"
+    argocd.argoproj.io/sync-options: ServerSideApply=true
 {{- if .Values.custom_labels }}
   labels:
 {{ .Values.custom_labels | toYaml | indent 4 }}

--- a/cluster-applications/000-efs-csi-driver/templates/01-efs_OperatorGroup.yaml
+++ b/cluster-applications/000-efs-csi-driver/templates/01-efs_OperatorGroup.yaml
@@ -2,7 +2,7 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  generateName: openshift-cluster-csi-drivers-
+  name: openshift-cluster-csi-drivers
   namespace: "{{ .Values.subscription_source_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "016"

--- a/cluster-applications/000-efs-csi-driver/templates/01-efs_OperatorGroup.yaml
+++ b/cluster-applications/000-efs-csi-driver/templates/01-efs_OperatorGroup.yaml
@@ -2,7 +2,7 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: openshift-operators
+  generateName: openshift-cluster-csi-drivers-
   namespace: "{{ .Values.subscription_source_namespace }}"
   annotations:
     argocd.argoproj.io/sync-wave: "016"

--- a/cluster-applications/054-cluster-logging-operator/templates/01-OperatorGroup.yaml
+++ b/cluster-applications/054-cluster-logging-operator/templates/01-OperatorGroup.yaml
@@ -1,4 +1,6 @@
 ---
+# OperatorGroup for OpenShift Logging Operator
+# Name matches the default created by manual installation to avoid conflicts
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:

--- a/cluster-applications/054-cluster-logging-operator/templates/01-OperatorGroup.yaml
+++ b/cluster-applications/054-cluster-logging-operator/templates/01-OperatorGroup.yaml
@@ -2,7 +2,7 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: cluster-logging-operator
+  name: openshift-logging
   namespace: openshift-logging
   annotations:
     argocd.argoproj.io/sync-wave: "054"

--- a/cluster-applications/054-cluster-logging-operator/templates/01-OperatorGroup.yaml
+++ b/cluster-applications/054-cluster-logging-operator/templates/01-OperatorGroup.yaml
@@ -1,6 +1,4 @@
 ---
-# OperatorGroup for OpenShift Logging Operator
-# Name matches the default created by manual installation to avoid conflicts
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:


### PR DESCRIPTION
**Issue**
https://jsw.ibm.com/browse/MASCORE-13413

**Problem**
Manual installation of OpenShift Logging Operator creates an OperatorGroup named `openshift-logging`, but GitOps tries to create one named `cluster-logging-operator`, causing conflicts.

**Fix**
Changed OperatorGroup name to `openshift-logging` to match the default name.

<img width="1728" height="1117" alt="Screenshot 2026-04-24 at 11 48 35 AM" src="https://github.com/user-attachments/assets/ddb209af-cb11-429c-aaa9-70a94750086d" />
<img width="1728" height="1117" alt="Screenshot 2026-04-24 at 11 48 50 AM" src="https://github.com/user-attachments/assets/21de40c2-7357-460a-a398-7a09c4d3667d" />
<img width="1728" height="1117" alt="Screenshot 2026-04-24 at 11 49 01 AM" src="https://github.com/user-attachments/assets/0b566c29-0d7b-4b72-85ed-60c2335b94f2" />
