### PR TITLE
[patch] Ensure uniqueness of aws-db2-user-job role and rolebinding resource names

### DIFF
--- a/instance-applications/120-ibm-db2u-database/templates/08-postdelete-db2-user-job-rbac.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/08-postdelete-db2-user-job-rbac.yaml
@@ -73,4 +73,3 @@ roleRef:
   kind: Role
   name: aws-db2-user-job-{{ .Values.instance_id }}-{{ .Values.mas_application_id }}-role-db2
 {{- end }}
-

--- a/instance-applications/120-ibm-db2u-database/templates/08-postdelete-db2-user-job-rbac.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/08-postdelete-db2-user-job-rbac.yaml
@@ -16,7 +16,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: aws-db2-user-job-{{ .Values.instance_id }}-role-db2
+  name: aws-db2-user-job-{{ .Values.instance_id }}-{{ .Values.mas_application_id }}-role-db2
   namespace: {{ .Values.db2_namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: "121"
@@ -56,7 +56,7 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: aws-db2-user-job-{{ .Values.instance_id }}-rolebinding-db2
+  name: aws-db2-user-job-{{ .Values.instance_id }}-{{ .Values.mas_application_id }}-rolebinding-db2
   namespace: {{ .Values.db2_namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: "122"
@@ -71,6 +71,6 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: aws-db2-user-job-{{ .Values.instance_id }}-role-db2
+  name: aws-db2-user-job-{{ .Values.instance_id }}-{{ .Values.mas_application_id }}-role-db2
 {{- end }}
 


### PR DESCRIPTION
## Description

Fixes issue seen when an instance has more than one DB2-DB application attempting to render a role and role binding with the same name in the same namespace, causing ArgoCD SharedResourceWarnings.

<img width="866" height="1561" alt="image" src="https://github.com/user-attachments/assets/eaa4d16b-e232-4082-bbb0-373fb00d6edb" />

---

<img width="1534" height="206" alt="image" src="https://github.com/user-attachments/assets/b9bb77d1-115f-4914-b59b-5aae1cf1be0d" />


## Testing

With the changes in this PR, separate roles and rolebindings are rendered by the manager and facilities db2 db apps:

<img width="561" height="248" alt="image" src="https://github.com/user-attachments/assets/50b837ee-01bc-495e-a434-52ebc1ab235d" />

---

<img width="437" height="253" alt="image" src="https://github.com/user-attachments/assets/946fcb71-e941-43cb-a382-a511b2d7c4ea" />

---

Both roles are bound to the `aws-db2-user-job` ServiceAccount in the syncres namespace as before.
