### PR TITLE
 [patch] Permit suite-config apps to create core namespace to eliminate race condition that can cause sync to hang

### DIFF
--- a/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-configs-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-configs-app.yaml
@@ -91,3 +91,4 @@ spec:
       - RespectIgnoreDifferences=true
 {{- end }}
 {{- end }}
+

--- a/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-configs-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/130-ibm-mas-suite-configs-app.yaml
@@ -85,7 +85,9 @@ spec:
     retry:
       limit: 20
     syncOptions:
-      - CreateNamespace=false
+      {{- if $.Values.cluster_admin_role }}
+      - CreateNamespace=true
+      {{- end }}
       - RespectIgnoreDifferences=true
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description

The suite app is responsible for creating the `mas-inst-core `namespace (it has `CreateNamespace=True` in its app definition), the suite-config apps do not. 

When suite and suite-config yamls are established at the same time (as they are in GovCloud, but not Commercial), there is a chance that the suite-config app syncs are initiated before the suite app itself. 

If this happens, the `mas-inst-core` namespace will not be in place when ArgoCD attempts to run pre-sync jobs in any of the suite-config apps (such as the pre-sync hook in the jdbc-suite-config apps), and the pre-sync hooks get stuck indefinitely forcing a manual re-triggering of the sync process.

> NOTE: The suite and suite-config apps must be in the same sync wave, as some of the suite-config apps must be synced in order for the suite CR (and thus the suite app itself) to become healthy.

## Testing
Without this change, the race condition was hit first time. With this change, I successfully provisioned a MAS instance 4 times in a row without hitting the race condition. No unintended consequences were observed.