### PR TITLE
[minor] add conditional private NLB service for DB2 instances via ROSA LoadBalancer

### DIFF
--- a/instance-applications/120-ibm-db2u-database/README.md
+++ b/instance-applications/120-ibm-db2u-database/README.md
@@ -24,6 +24,7 @@ Contains a job that runs last (`05-postsync-setup-db2_Job.yaml`). This registers
 | `ConfigMap` | Db2 script/config maps | DB2 application namespace | Always | `application_admin_role` |
 | `Route` | Db2 TLS route | DB2 application namespace | When route exposure is enabled | `application_admin_role` |
 | `Service` | Db2 services, including HADR services | DB2 application namespace | Always | `application_admin_role` |
+| `Service` | Private NLB service | DB2 application namespace | When `private_nlb.enabled` is true | `application_admin_role` |
 | `Secret` | Post-sync DB2 generated secret | DB2 application namespace | Always | `application_admin_role` |
 | `NetworkPolicy` | HADR network policy | DB2 application namespace | When HADR is enabled | `application_admin_role` |
 | `Job` | Pre/post-sync DB2 setup jobs | DB2 application namespace | Always | `application_admin_role` |
@@ -130,6 +131,14 @@ allow_list: string (optional)
 # Production Database Access (optional)
 production_database_access:
   type: string
+
+
+# Private NLB for customer TGW connectivity (optional)
+private_nlb:
+  enabled: boolean         # default: false
+  subnet_ids: list(string) # required when enabled: true
+  allowed_cidrs: list(string) # required when enabled: true
+  port: number             # default: 50001
 ```
 
 **Note**: Values marked with "(secret reference)" should use the format `<path:secrets/path:key>` to reference secrets stored in the Secrets Vault.
@@ -160,4 +169,47 @@ sm:                             # Secrets Manager configuration
   aws_secret_access_key: string (secret reference)
 ```
 
-For complete documentation of all base instance values including optional fields like `custom_labels`, `argocluster_instance`, `application_admin_service_account`, `mas_wipe_mongo_data`, `allow_list`, `additional_vpn`, `application_configuration`, `use_postdelete_hooks`, `additional_resources`, `extensions`, `enhanced_dr`, and `cli_image_repo`, see the [Instance Base Values Reference](../../docs/reference/instance-base-values.md).
+For complete documentation of all base instance values including optional fields like `custom_labels`, `argocluster_instance`, `application_admin_service_account`, `mas_wipe_mongo_data`, `allow_list`, `additional_vpn`, `application_configuration`, `use_postdelete_hooks`, `additional_resources`, `extensions`, `enhanced_dr`, and `cli_image_repo`, see the [Instance Base Values Reference](../../docs/reference/instance-base-values.md)
+
+## Private NLB for Customer TGW Connectivity
+
+When `private_nlb.enabled: true`, this chart creates a Kubernetes `Service` of
+`type: LoadBalancer` that causes ROSA to provision an internal AWS NLB in the
+specified subnets. This is the recommended approach for exposing Db2 to a customer
+network via the TGW and hub-firewall path (A.4 Option 2).
+
+ROSA automatically manages the required EC2 worker node security group rules.
+No manual security group changes are needed.
+
+| Value | Description | Required when enabled |
+|---|---|---|
+| `private_nlb.enabled` | Toggle NLB creation on/off | — |
+| `private_nlb.subnet_ids` | Private-connectivity-edge subnet IDs, one per AZ | Yes |
+| `private_nlb.allowed_cidrs` | Customer CIDRs for `loadBalancerSourceRanges` | Yes |
+| `private_nlb.port` | NLB listener port, defaults to 50001 | No |
+
+### Example — enabling for a customer-connected instance
+
+```yaml
+private_nlb:
+  enabled: true
+  subnet_ids:
+    - subnet-0e40955c9b8865e7a   # us-gov-east-1a
+    - subnet-0e53a1f9071b8d9ba   # us-gov-east-1b
+    - subnet-04eba2a3f36ec0e7c   # us-gov-east-1c
+  allowed_cidrs:
+    - 10.200.20.0/24             # customer network CIDR
+  port: 50001
+```
+
+Each Db2 instance (facilities, manage) gets its own NLB because the ArgoCD
+application is deployed separately per instance with its own `db2_instance_name`.
+Both can use port 50001 without conflict since they are separate AWS NLB resources.
+
+The NLB is created independently for each instance (e.g. facilities, manage) using the instance-specific selector.
+
+### Validation
+
+If `private_nlb.enabled: true` and either `subnet_ids` or `allowed_cidrs` is
+empty, Helm will fail immediately with a clear error message before rendering
+any resources. This prevents a broken or unrestricted NLB from being deployed..

--- a/instance-applications/120-ibm-db2u-database/templates/11-private-nlb-service.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/11-private-nlb-service.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.private_nlb.enabled }}
+{{- if not .Values.private_nlb.subnet_ids }}
+{{- fail "private_nlb.subnet_ids must be provided when private_nlb.enabled is true" }}
+{{- end }}
+{{- if not .Values.private_nlb.allowed_cidrs }}
+{{- fail "private_nlb.allowed_cidrs must be provided when private_nlb.enabled is true — restrict access to customer CIDRs only" }}
+{{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.db2_instance_name }}-private-nlb
+  namespace: {{ .Values.db2_namespace }}
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+    service.beta.kubernetes.io/aws-load-balancer-subnets: {{ .Values.private_nlb.subnet_ids | join "," | quote }}
+    service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol: "TCP"
+    service.beta.kubernetes.io/aws-load-balancer-healthcheck-port: "traffic-port"
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Cluster
+  loadBalancerSourceRanges:
+    {{- range .Values.private_nlb.allowed_cidrs }}
+    - {{ . }}
+    {{- end }}
+  ports:
+    - name: db2-ssl
+      protocol: TCP
+      port: {{ .Values.private_nlb.port | default 50001 }}
+      targetPort: 50001
+  selector:
+    app: {{ .Values.db2_instance_name }}
+    component: db2wh
+    formation_id: {{ .Values.db2_instance_name }}
+    name: dashmpp-head-0
+    role: db
+    type: engine
+{{- end }}

--- a/instance-applications/120-ibm-db2u-database/values.yaml
+++ b/instance-applications/120-ibm-db2u-database/values.yaml
@@ -6,3 +6,13 @@ db2_instance_home_path: /mnt/blumeta0/home/db2inst1
 
 sm_aws_access_key_id: xxx
 sm_aws_secret_access_key: xxxx
+
+# Private NLB for customer TGW connectivity (A.4 Option 2)
+# When enabled, ROSA provisions an internal AWS NLB in the specified subnets.
+# ROSA automatically manages the required EC2 worker node security group rules.
+# Default: disabled — existing instances are unaffected.
+private_nlb:
+  enabled: false
+  subnet_ids: []    # private-connectivity-edge subnet IDs, one per AZ
+  allowed_cidrs: [] # customer CIDRs — restricts NLB access via loadBalancerSourceRanges
+  port: 50001       # Db2 SSL port


### PR DESCRIPTION
Adds conditional private NLB support for DB2 instances via ROSA LoadBalancer.

- Introduces a new Helm template to create type=LoadBalancer Service per DB2 instance
- Controlled via private_nlb.enabled flag (default: false)
- Accepts subnet_ids and allowed_cidrs as inputs
- Keeps existing ClusterIP services unchanged

Validated locally using helm template to confirm conditional rendering and input validation.