### PR TITLE
[patch] Refactor condition to check catalog_channel

### DIFF
--- a/instance-applications/115-ibm-aiservice-tenant/templates/07-aiservice-workspace.yaml
+++ b/instance-applications/115-ibm-aiservice-tenant/templates/07-aiservice-workspace.yaml
@@ -49,7 +49,7 @@ spec:
           type: "{{ .Values.tenant_entitlement_type }}"
           startDate: "{{ .Values.tenant_entitlement_start_date }}"
           endDate: "{{ .Values.tenant_entitlement_end_date }}"
-{{- if hasPrefix "9.2." (toString .Values.catalog_channel) }}
+{{- if not (hasPrefix "9.1." (toString .Values.catalog_channel)) }}
 {{- if not (empty .Values.tenant_scheduling_config) }}
     scheduling:
 {{ .Values.tenant_scheduling_config | toYaml | indent 6 }}


### PR DESCRIPTION
## Description

- The previous implementation only allowed tenant scheduling for catalog channel 9.2.x, which would require updating the condition for every new major/minor version (9.3.x, 9.4.x, etc.). The updated condition excludes only 9.1.x versions.


## Testing

Successful sync on Argo.

<img width="1194" height="883" alt="Screenshot 2026-05-14 at 8 26 42 PM" src="https://github.com/user-attachments/assets/0de0bc4b-335b-476d-a6ca-361e8a593370" />
