### PR TITLE
[path]update secret path fix for ssp

### DIFF
--- a/instance-applications/130-ibm-jdbc-config/templates/00-presync-create-db2-rds-user-Job.yaml
+++ b/instance-applications/130-ibm-jdbc-config/templates/00-presync-create-db2-rds-user-Job.yaml
@@ -437,7 +437,7 @@ spec:
                 
                 # Determine the secret path based on app_type
                 if [ "${app_type}" = "rds-ssp" ]; then
-                  SECRET_PATH="${ACCOUNT_ID}/${CLUSTER_ID}/${MAS_INSTANCE_ID}/db2rds-ssp/credentials"
+                  SECRET_PATH="${ACCOUNT_ID}/${CLUSTER_ID}/${MAS_INSTANCE_ID}/db2rds-ssp/${MAS_APP_ID}/credentials"
                 else
                   SECRET_PATH="${ACCOUNT_ID}/${CLUSTER_ID}/${MAS_INSTANCE_ID}/jdbc/rds-${MAS_INSTANCE_ID}-${app_type}/credentials"
                 fi


### PR DESCRIPTION
Jira: https://jsw.ibm.com/browse/MASCORE-14178
Description: Previously we were creating secret path without app id so we were getting secret already exist due to different app id db under same instance.
Fix: We added app id to the path to avoid this error.