### PR TITLE
[patch]  Nest metric settings under metricCollection in Suite template

### DIFF
--- a/instance-applications/130-ibm-mas-suite/templates/04-ibm-mas_Suite.yaml
+++ b/instance-applications/130-ibm-mas-suite/templates/04-ibm-mas_Suite.yaml
@@ -47,10 +47,11 @@ spec:
 {{- if .Values.ingress_controller_name }}
     ingressControllerName: {{ .Values.ingress_controller_name }}
 {{- end }}
-    contractPerformance: {{ .Values.mas_contract_performance | default true }}
-    featureUse: {{ .Values.mas_feature_usage | default true }}
-    deploymentProgression: {{ .Values.mas_deployment_progression | default true }}
-    usability: {{ .Values.mas_usability_metrics | default true }}
+    metricCollection:
+      contractPerformance: {{ .Values.mas_contract_performance | default true }}
+      featureUse: {{ .Values.mas_feature_usage | default true }}
+      deploymentProgression: {{ .Values.mas_deployment_progression | default true }}
+      usability: {{ .Values.mas_usability_metrics | default true }}
     icr:
       cp: "{{ .Values.icr_cp }}"
       cpopen: "{{ .Values.icr_cp_open }}"


### PR DESCRIPTION
## Description
Update Suite CR template to use nested metricCollection structure for better organization and clarity of metric-related settings.


- https://jsw.ibm.com/browse/MASCORE-14119
## Testing
Installed MAS instance with updated template
Verified new nested structure in Suite CR spec
<img width="1283" height="781" alt="image" src="https://github.com/user-attachments/assets/96e596a1-b116-4d6c-a001-bfc750af396c" />
<img width="3456" height="2088" alt="image" src="https://github.com/user-attachments/assets/04e03901-5584-401a-86ef-033e21a43960" />
<img width="2956" height="1700" alt="image" src="https://github.com/user-attachments/assets/f2fd825d-335b-4b57-8d34-8e0f86ae5665" />


