### PR TITLE
[patch] Revert ApplyOutOfSyncOnly in application sets

### DIFF
--- a/root-applications/ibm-aiservice-instance-root/templates/070-aiservice-tenant-appset.yaml
+++ b/root-applications/ibm-aiservice-instance-root/templates/070-aiservice-tenant-appset.yaml
@@ -121,7 +121,6 @@ spec:
           - CreateNamespace=false
           - RespectIgnoreDifferences=true
           - ServerSideApply=true
-          - ApplyOutOfSyncOnly=true
         retry:
           limit: -1
       ignoreDifferences:

--- a/root-applications/ibm-mas-account-root/templates/000-cluster-appset.yaml
+++ b/root-applications/ibm-mas-account-root/templates/000-cluster-appset.yaml
@@ -190,4 +190,3 @@ spec:
           - CreateNamespace=false
           - RespectIgnoreDifferences=true
           - ServerSideApply=true
-          - ApplyOutOfSyncOnly=true

--- a/root-applications/ibm-mas-cluster-root/templates/065-sls-appset.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/065-sls-appset.yaml
@@ -112,7 +112,6 @@ spec:
           - CreateNamespace=false
           - RespectIgnoreDifferences=true
           - ServerSideApply=true
-          - ApplyOutOfSyncOnly=true
         retry:
           limit: -1
       ignoreDifferences:

--- a/root-applications/ibm-mas-cluster-root/templates/099-aiservice-instance-appset.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/099-aiservice-instance-appset.yaml
@@ -124,7 +124,6 @@ spec:
           - CreateNamespace=false
           - RespectIgnoreDifferences=true
           - ServerSideApply=true
-          - ApplyOutOfSyncOnly=true
         retry:
           limit: -1
       ignoreDifferences:

--- a/root-applications/ibm-mas-cluster-root/templates/099-instance-appset.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/099-instance-appset.yaml
@@ -250,7 +250,6 @@ spec:
           - CreateNamespace=false
           - RespectIgnoreDifferences=true
           - ServerSideApply=true
-          - ApplyOutOfSyncOnly=true
         retry:
           limit: -1
       ignoreDifferences:


### PR DESCRIPTION
## Description
Revert ApplyOutOfSyncOnly in application sets as even if an app is synced but not healthy, it is not waiting for the app to be healthy before starting the next app's sync