### PR TITLE
[patch] Fix sanity and verify manage tests

### DIFF
--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-sanity.yaml
@@ -92,6 +92,8 @@ rules:
       - manageapp
       - manageworkspaces
       - manageapps
+      - managedeployment
+      - managedeployments
   - verbs:
       - get
       - list
@@ -100,6 +102,13 @@ rules:
       - ""
     resources:
       - configmaps
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - ""
+    resources:
+      - secrets
   - verbs:
       - get
       - list
@@ -163,6 +172,13 @@ rules:
       - "core.mas.ibm.com"
     resources:
       - suites
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - "route.openshift.io"
+    resources:
+      - routes
 
 ---
 kind: RoleBinding
@@ -188,8 +204,6 @@ roleRef:
   name: {{ $core_role_name }}
 # -------------------------------------
 
-{{- if .Values.cluster_admin_role }}
-
 ---
 # -------------------------------------
 # Manage Sanity tests need cluster-level permissions to discover API groups
@@ -207,11 +221,14 @@ metadata:
 {{ .Values.custom_labels | toYaml | indent 4 }}
 {{- end }}
 rules:
+  # Minimal permissions for Kubernetes client API discovery
   - verbs:
       - get
     nonResourceURLs:
       - /apis
       - /apis/*
+      - /api
+      - /api/*
 
 ---
 kind: ClusterRoleBinding
@@ -235,8 +252,6 @@ roleRef:
   kind: ClusterRole
   name: {{ printf "%s-%s" $core_role_name .Values.instance_id }}
 # -------------------------------------
-
-{{- end }}
 
 ---
 kind: ConfigMap

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-sanity.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-sanity.yaml
@@ -188,6 +188,56 @@ roleRef:
   name: {{ $core_role_name }}
 # -------------------------------------
 
+{{- if .Values.cluster_admin_role }}
+
+---
+# -------------------------------------
+# Manage Sanity tests need cluster-level permissions to discover API groups
+# This is required by the Kubernetes Python client's DynamicClient
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ printf "%s-%s" $core_role_name .Values.instance_id }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "600"
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded,BeforeHookCreation
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+rules:
+  - verbs:
+      - get
+    nonResourceURLs:
+      - /apis
+      - /apis/*
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ printf "%s-%s" $core_rb_name .Values.instance_id }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "601"
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded,BeforeHookCreation
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $sa_name }}
+    namespace: {{ $ns }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ printf "%s-%s" $core_role_name .Values.instance_id }}
+# -------------------------------------
+
+{{- end }}
+
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-manage-verify.yaml
@@ -12,8 +12,10 @@ Use the build/bin/set-cli-image-digest.sh script to update this value across all
 {{ $ns               :=  .Values.mas_app_namespace }}
 {{ $np_name          :=  "postsync-verify-manage-np" }}
 {{ $role_name        :=  "postsync-verify-manage-role" }}
+{{ $crole_name       :=  "postsync-verify-manage-crole" }}
 {{ $sa_name          :=  "postsync-verify-manage-sa" }}
 {{ $rb_name          :=  "postsync-verify-manage-rb" }}
+{{ $crb_name         :=  "postsync-verify-manage-crb" }}
 {{ $tests_cm_name    :=  "postsync-verify-tests-manage-cm" }}
 {{ $record_cm_name   :=  "postsync-verify-tests-manage-record-cm" }}
 {{ $job_name         :=  "postsync-verify-manage-job" }}
@@ -126,6 +128,53 @@ roleRef:
   kind: Role
   name: {{ $role_name }}
 # -------------------------------------
+
+
+---
+# ClusterRole for API discovery - needed by Kubernetes client
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ $crole_name }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "600"
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded,BeforeHookCreation
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+rules:
+  # Minimal permissions for Kubernetes client API discovery
+  - verbs:
+      - get
+    nonResourceURLs:
+      - /apis
+      - /apis/*
+      - /api
+      - /api/*
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ $crb_name }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "601"
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded,BeforeHookCreation
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $sa_name }}
+    namespace: {{ $ns }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $crole_name }}
 
 
 ---


### PR DESCRIPTION
## Description
Both sanity and verify tests were failing due to restricted permissions. 
Had to add clusterroles to resolve the permission error

## Testing
Tested in fvtsaas run today where verify tests are passing and sanity tests related to permission are passing (1 test failing due to manage unrelated to permissions)
