### PR TITLE
[patch] SLS Compliance enforcement by default needs to be disabled

### DIFF
--- a/instance-applications/100-ibm-sls/templates/06-ibm-sls_LicenseService.yaml
+++ b/instance-applications/100-ibm-sls/templates/06-ibm-sls_LicenseService.yaml
@@ -22,6 +22,8 @@ spec:
       enforce: true
     registration:
       open: true
+    compliance:
+      enforce: false
     {{- if .Values.icr_cp_open }}
     registry: "{{ .Values.icr_cp_open }}"
     {{ end }}

--- a/sls-applications/100-ibm-sls/templates/06-ibm-sls_LicenseService.yaml
+++ b/sls-applications/100-ibm-sls/templates/06-ibm-sls_LicenseService.yaml
@@ -23,6 +23,8 @@ spec:
       enforce: true
     registration:
       open: true
+    compliance:
+      enforce: false
     {{- if .Values.icr_cp_open }}
     registry: "{{ .Values.icr_cp_open }}"
     {{ end }}


### PR DESCRIPTION
Issue: [MASCORE-14372](https://jsw.ibm.com/browse/MASCORE-14372)

## Description
By default, SLS product enforces app point limits
It should not be enabled for MAS SaaS