### PR TITLE
[patch] Ensure Monitor is installed and activated before IoT is installed

### DIFF
--- a/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-550-ibm-mas-masapp-configs.yaml
@@ -19,7 +19,7 @@ metadata:
     {{- else if eq $value.mas_app_id "facilities" }}
     argocd.argoproj.io/sync-wave: "510"
     {{- else if eq $value.mas_app_id "iot" }}
-    argocd.argoproj.io/sync-wave: "515"
+    argocd.argoproj.io/sync-wave: "530"
     {{- else if eq $value.mas_app_id "manage" }}
     argocd.argoproj.io/sync-wave: "510"
     {{- else if eq $value.mas_app_id "visualinspection" }}
@@ -27,7 +27,7 @@ metadata:
     {{- else if eq $value.mas_app_id "health" }}
     argocd.argoproj.io/sync-wave: "530"
     {{- else if eq $value.mas_app_id "monitor" }}
-    argocd.argoproj.io/sync-wave: "530"
+    argocd.argoproj.io/sync-wave: "515"
     {{- else if eq $value.mas_app_id "optimizer" }}
     argocd.argoproj.io/sync-wave: "530"
     {{- else if eq $value.mas_app_id "predict" }}

--- a/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-iot-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/510-ibm-mas-masapp-iot-install.yaml
@@ -16,7 +16,7 @@ metadata:
     instance: '{{ .Values.instance.id }}'
     masapp: 'iot'
   annotations:
-    argocd.argoproj.io/sync-wave: "510"
+    argocd.argoproj.io/sync-wave: "520"
     {{- if and .Values.notifications .Values.notifications.slack_channel_id }}
     notifications.argoproj.io/subscribe.on-sync-failed.workspace1: {{ .Values.notifications.slack_channel_id }}
     notifications.argoproj.io/subscribe.on-sync-succeeded.workspace1: {{ .Values.notifications.slack_channel_id }}

--- a/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-monitor-install.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/520-ibm-mas-masapp-monitor-install.yaml
@@ -16,7 +16,7 @@ metadata:
     instance: '{{ .Values.instance.id }}'
     masapp: 'monitor'
   annotations:
-    argocd.argoproj.io/sync-wave: "520"
+    argocd.argoproj.io/sync-wave: "510"
     {{- if and .Values.notifications .Values.notifications.slack_channel_id }}
     notifications.argoproj.io/subscribe.on-sync-failed.workspace1: {{ .Values.notifications.slack_channel_id }}
     notifications.argoproj.io/subscribe.on-sync-succeeded.workspace1: {{ .Values.notifications.slack_channel_id }}


### PR DESCRIPTION
This is a quick workaround for pending fvtsaas 9.2. runs. The proper fix (which is being worked on) will ensure these syncwave changes are only applied for 9.2 onwards.

This PR is for reference only and should not be merged.

https://jsw.ibm.com/browse/MASCORE-14483