### PR TITLE
[patch] Make DB2u Backup Retention Configurable

### DIFF
--- a/instance-applications/120-ibm-db2u-database/templates/07-postsync-setup-db2_Job.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/07-postsync-setup-db2_Job.yaml
@@ -239,6 +239,8 @@ spec:
               value: "{{ .Values.db2_backup_bucket_endpoint }}"
             - name: SLACKURL
               value: "{{ .Values.db2_backup_notify_slack_url }}"
+            - name: NUM_DB_BACKUPS
+              value: "{{ .Values.db2_database_db_config.NUM_DB_BACKUPS | default "60" }}"
 {{- end }}
 
           volumeMounts:
@@ -828,7 +830,7 @@ spec:
                 echo "SERVER=${COS_SERVER}" >> /tmp/${PROPS_FILE_NAME}
                 echo "SLACKURL=${SLACKURL}" >> /tmp/${PROPS_FILE_NAME}
                 echo "DAYOFFULL=Sat" >> /tmp/${PROPS_FILE_NAME}
-                echo "NUMOFBKUPTOKEEP=60" >> /tmp/${PROPS_FILE_NAME}
+                echo "NUMOFBKUPTOKEEP=${NUM_DB_BACKUPS}" >> /tmp/${PROPS_FILE_NAME}
                 echo "ICD_AUTH_KEY=${ICD_AUTH_KEY}" >> /tmp/${PROPS_FILE_NAME}
 
                 echo ""

--- a/instance-applications/120-ibm-db2u-database/templates/07-postsync-setup-db2_Job.yaml
+++ b/instance-applications/120-ibm-db2u-database/templates/07-postsync-setup-db2_Job.yaml
@@ -35,7 +35,7 @@ Increment this value whenever you make a change to an immutable field of the Job
 E.g. passing in a new environment variable.
 Included in $_job_hash (see below).
 */}}
-{{- $_job_version := "v15" }}
+{{- $_job_version := "v16" }}
 
 {{- /*
 10 char hash appended to the job name taking into account $_job_config_values, $_job_version and $_cli_image_digest


### PR DESCRIPTION
# Make DB2u Backup Retention Configurable

## Summary
This PR makes the DB2u backup retention count configurable via the `NUM_DB_BACKUPS` parameter in `db2_database_db_config`, replacing the hardcoded value of 60 in the `.PROPS` file generation script.

## Problem Statement
Previously, the number of DB2u backups to retain was hardcoded to 60 in the postsync Job template at line 831:
```bash
echo "NUMOFBKUPTOKEEP=60" >> /tmp/${PROPS_FILE_NAME}
```

This prevented environments from having different backup retention policies. For FedRAMP compliance, we need:
- **Non-production environments**: 14 days retention
- **Production environments**: 38 days retention

## Changes Made

### 1. Added Environment Variable (Line 242-243)
```yaml
- name: NUM_DB_BACKUPS
  value: "{{ .Values.db2_database_db_config.NUM_DB_BACKUPS | default "60" }}"
```
- Extracts `NUM_DB_BACKUPS` from the `db2_database_db_config` configuration
- Defaults to "60" for backward compatibility if not specified

### 2. Updated .PROPS File Generation (Line 833)
```bash
echo "NUMOFBKUPTOKEEP=${NUM_DB_BACKUPS}" >> /tmp/${PROPS_FILE_NAME}
```
- Changed from hardcoded `60` to use the `${NUM_DB_BACKUPS}` environment variable

### 3. Incremented Job Version (Line 38)
```go
{{- $_job_version := "v16" }}
```
- Bumped from `v15` to `v16` to force creation of new Job resources
- Prevents ArgoCD immutability errors when updating existing Jobs

## Usage

To configure backup retention for a DB2u instance, set `NUM_DB_BACKUPS` in the `db2_database_db_config` section of your `ibm-db2u-databases.yaml`:

```yaml
db2_database_db_config:
  # ... other config ...
  NUM_DB_BACKUPS: '38'  # For production
  # or
  NUM_DB_BACKUPS: '14'  # For non-production
```

## Testing

Testing was done the AWS GovCloud pre-prod account for MAS FedRAMP. I tested changing NUM_DB_BACKUPS for two instances of db2 and all went well.

- ✅ Verified template renders correctly with new environment variable
- ✅ Confirmed Job version increment prevents ArgoCD immutability errors
- ✅ Tested with default value (60) when `NUM_DB_BACKUPS` not specified
- ✅ Validated `.PROPS` file generation uses configurable value

## Backward Compatibility
- ✅ Fully backward compatible - defaults to 60 if `NUM_DB_BACKUPS` not specified
- ✅ Existing deployments without this parameter will continue to work unchanged

## Related Issues
- Resolves FedRAMP backup retention requirements
- Fixes ArgoCD Job immutability error when updating backup configuration

## Deployment Notes
1. After merging, ArgoCD will create new Jobs with updated hash
2. Old Jobs will be automatically cleaned up by the cleanup CronJob
3. Update `NUM_DB_BACKUPS` in environment-specific `ibm-db2u-databases.yaml` files as needed

## Files Changed
- `instance-applications/120-ibm-db2u-database/templates/07-postsync-setup-db2_Job.yaml`
  - Added `NUM_DB_BACKUPS` environment variable
  - Updated `.PROPS` file generation to use variable
  - Incremented job version to v16