### PR TITLE
[patch] Update 04-postsync-maximoit-verify.yaml

### DIFF
--- a/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-maximoit-verify.yaml
+++ b/instance-applications/510-550-ibm-mas-suite-app-config/templates/04-postsync-maximoit-verify.yaml
@@ -141,260 +141,313 @@ data:
     pytest
     kubernetes
     openshift
-    requests==2.31.0
-    urllib3==1.26.18
   tests.py: |-
-
-    from kubernetes import client,config
-    from kubernetes.client import Configuration
-    from openshift.dynamic import DynamicClient
-    import pytest
-    import os
-    import urllib3
-    import requests
-    import certifi
-    import logging
-    import tempfile
-    import base64
-
-
-    logger = logging.getLogger()
-
-    mas_instance_id = os.getenv("MAS_INSTANCE_ID")
-    if mas_instance_id is None:
-        raise Exception(f"Required MAS_INSTANCE_ID environment variable is not set")
-
-    mas_workspace_id = os.getenv("MAS_WORKSPACE_ID")
-    if mas_workspace_id is None:
-        raise Exception(f"Required MAS_WORKSPACE_ID environment variable is not set")
-
-    manageNamespace = os.getenv("MANAGE_NAMESPACE")
-    if manageNamespace is None:
-        raise Exception(f"Required MANAGE_NAMESPACE environment variable is not set")
+from kubernetes import client, config
+from kubernetes.client import Configuration
+from openshift.dynamic import DynamicClient
+import pytest
+import os
+import urllib3
+import requests
+import certifi
+import logging
+import tempfile
+import base64
 
 
-    MANAGE_URL = f'https://{mas_instance_id}-{mas_workspace_id}.mas-{mas_instance_id}-manage.svc'  # Use for cluster
-    # MANAGE_URL = 'https://localhost:9443'  # Use for local
+logger = logging.getLogger()
 
-    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-    session = requests.Session()
+mas_instance_id = os.getenv("MAS_INSTANCE_ID")
+if mas_instance_id is None:
+    raise Exception("Required MAS_INSTANCE_ID environment variable is not set")
+
+mas_workspace_id = os.getenv("MAS_WORKSPACE_ID")
+if mas_workspace_id is None:
+    raise Exception("Required MAS_WORKSPACE_ID environment variable is not set")
+
+manageNamespace = os.getenv("MANAGE_NAMESPACE")
+if manageNamespace is None:
+    raise Exception("Required MANAGE_NAMESPACE environment variable is not set")
 
 
-    @pytest.fixture(scope="session")
-    def dyn_client():
-        if "KUBERNETES_SERVICE_HOST" in os.environ:
-            config.load_incluster_config()
-            k8s_config = Configuration.get_default_copy()
-            k8s_client = client.ApiClient(configuration=k8s_config)
-        else:
-            k8s_client = config.new_client_from_config()
+MANAGE_URL = f"https://{mas_instance_id}-{mas_workspace_id}.mas-{mas_instance_id}-manage.svc"
+# MANAGE_URL = "https://localhost:9443"  # Use for local
 
-        dyn_client = DynamicClient(k8s_client)
-        dyn_client.namespace = manageNamespace
-        yield dyn_client
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-    @pytest.fixture(scope="session")
-    def v1_routes(dyn_client):
-        yield dyn_client.resources.get(api_version='route.openshift.io/v1', kind='Route')
 
-    @pytest.fixture(scope="session")
-    def manage_route(v1_routes):
-        yield v1_routes.get(name=f"{mas_instance_id}-manage-{mas_workspace_id}", namespace=manageNamespace)
+@pytest.fixture(scope="session")
+def dyn_client():
+    if "KUBERNETES_SERVICE_HOST" in os.environ:
+        config.load_incluster_config()
+        k8s_config = Configuration.get_default_copy()
+        k8s_client = client.ApiClient(configuration=k8s_config)
+    else:
+        k8s_client = config.new_client_from_config()
 
-    @pytest.fixture(scope="session")
-    def manage_host_ca_filepath(manage_route):
+    dyn_client = DynamicClient(k8s_client)
+    dyn_client.namespace = manageNamespace
+    yield dyn_client
 
-        # Read the certificate field from the Manage Route. 
-        # This may include CA certificates that we need in order to trust the certificates presented by the external Manage endpoint.
+
+@pytest.fixture(scope="session")
+def v1_routes(dyn_client):
+    yield dyn_client.resources.get(api_version="route.openshift.io/v1", kind="Route")
+
+
+@pytest.fixture(scope="session")
+def manage_route(v1_routes):
+    yield v1_routes.get(
+        name=f"{mas_instance_id}-manage-{mas_workspace_id}",
+        namespace=manageNamespace
+    )
+
+
+@pytest.fixture(scope="session")
+def manage_host_ca_filepath(manage_route):
+    manage_route_certificate = None
+    manage_route_caCertificate = None
+    manage_route_destinationCACertificate = None
+
+    # Read the certificate field from the Manage Route.
+    try:
+        manage_route_certificate = manage_route["spec"]["tls"]["certificate"]
+    except KeyError:
+        pass
+
+    # Read the caCertificate field from the Manage Route.
+    try:
+        manage_route_caCertificate = manage_route["spec"]["tls"]["caCertificate"]
+    except KeyError:
+        pass
+
+    # Read the destinationCACertificate field from the Manage Route.
+    try:
+        manage_route_destinationCACertificate = manage_route["spec"]["tls"]["destinationCACertificate"]
+    except KeyError:
+        pass
+
+    # Load default CA bundle.
+    with open(certifi.where(), "rb") as default_ca:
+        default_ca_content = default_ca.read()
+
+    # Combine all certs into a single .pem file.
+    chain_file = tempfile.NamedTemporaryFile(delete=False)
+
+    try:
+        if manage_route_certificate:
+            chain_file.write(manage_route_certificate.encode())
+
+        if manage_route_caCertificate:
+            chain_file.write(manage_route_caCertificate.encode())
+
+        if manage_route_destinationCACertificate:
+            chain_file.write(manage_route_destinationCACertificate.encode())
+
+        chain_file.write(default_ca_content)
+
+        chain_file.flush()
+        chain_file.close()
+
+        yield chain_file.name
+
+    finally:
+        os.remove(chain_file.name)
+
+
+@pytest.fixture(scope="session")
+def client_cert(dyn_client):
+    certSecretObj = dyn_client.resources.get(api_version="v1", kind="Secret")
+    certSecret = certSecretObj.get(
+        name=f"{mas_instance_id}-internal-manage-tls",
+        namespace=f"mas-{mas_instance_id}-manage"
+    )
+
+    internal_cert = certSecret.data["tls.crt"]
+    internal_key = certSecret.data["tls.key"]
+
+    decoded_internal_cert = base64.b64decode(internal_cert).decode("utf-8")
+    decoded_internal_key = base64.b64decode(internal_key).decode("utf-8")
+
+    internal_crt_path = "/tmp/internal.crt"
+    internal_key_path = "/tmp/internal.key"
+
+    with open(internal_crt_path, "w") as f:
+        f.write(decoded_internal_cert)
+
+    with open(internal_key_path, "w") as f:
+        f.write(decoded_internal_key)
+
+    return internal_crt_path, internal_key_path
+
+
+@pytest.fixture()
+def user_api_key(client_cert, manage_host_ca_filepath):
+    user_id = "maxadmin"
+
+    api_key = get_api_key(user_id, client_cert, manage_host_ca_filepath)
+
+    if api_key is None:
+        url = f"{MANAGE_URL}/maximo/api/os/mxapiapikey?ccm=1&lean=1"
+        logger.info("generate_api_key_URL: %s", url)
+        logger.info("generate_api_key_CERT: %s", str(client_cert))
+
         try:
-            manage_route_certificate = manage_route['spec']['tls']['certificate']
-        except KeyError as e:
-            pass
+            headers = {"content-type": "application/json"}
+            payload = {"expiration": "-1", "userid": user_id}
 
-        # Read the caCertificate field from the Manage Route. 
-        # This may include CA certificates that we need in order to trust the certificates presented by the external Manage endpoint.
-        try:
-            manage_route_caCertificate = manage_route['spec']['tls']['caCertificate']
-        except KeyError as e:
-            pass
-
-        # Read the destinationCACertificate field from the Manage Route. 
-        # This may include CA certificates that we need in order to trust the certificates presented by the internal Manage services.
-        try:
-            manage_route_destinationCACertificate = manage_route['spec']['tls']['destinationCACertificate']
-        except KeyError as e:
-            pass
-
-        # Load default CA bundle. This will include certs for well-known CAs. This ensures that we will
-        # trust the certificates presented by the external Manage endpoints when MAS is configured to use
-        # an external frontend like CIS.
-        with open(certifi.where(), 'rb') as default_ca:
-            default_ca_content = default_ca.read()
-
-        # Combine all of the above into a single .pem file that we can use when issuing HTTP requests
-        chain_file = tempfile.NamedTemporaryFile(delete=False)
-        try:
-        
-            if manage_route_certificate:
-                chain_file.write(manage_route_certificate.encode())
-            
-            if manage_route_caCertificate:
-                chain_file.write(manage_route_certificate.encode())
-
-            if manage_route_destinationCACertificate:
-                chain_file.write(manage_route_destinationCACertificate.encode())
-
-            chain_file.write(default_ca_content)
-
-            chain_file.flush()
-            chain_file.close()
-
-            yield chain_file.name
-
-        finally:
-            os.remove(chain_file.name)
-
-
-    @pytest.fixture(scope="session")
-    def client_cert(dyn_client):
-        certSecretObj = dyn_client.resources.get(api_version='v1', kind='Secret')
-        certSecret = certSecretObj.get(
-            f"{mas_instance_id}-internal-manage-tls", f"mas-{mas_instance_id}-manage"
-        )
-        internal_cert = certSecret.data["tls.crt"]
-        internal_key = certSecret.data["tls.key"]
-        decoded_internal_cert = base64.b64decode(internal_cert).decode('utf-8')
-        decoded_internal_key = base64.b64decode(internal_key).decode('utf-8')
-
-        with open("internal.crt", "w") as f:
-            f.write(decoded_internal_cert)
-        with open("internal.key", "w") as f:
-            f.write(decoded_internal_key)
-        client_cert = ("internal.crt", "internal.key")
-        
-        with open("internal.crt", "r") as f:
-            cert_content = f.read()
-            logger.info("Contents of cert:")
-            logger.info(cert_content)
-        with open("internal.key", "r") as f:
-            cert_content = f.read()
-            logger.info("Contents of cert:")
-            logger.info(cert_content)
-        return client_cert
-
-
-    @pytest.fixture()
-    def user_api_key(client_cert, manage_host_ca_filepath):
-        user_id="maxadmin"
-        api_key = get_api_key(user_id, client_cert, session, manage_host_ca_filepath)
-        if api_key is None:
-            url = MANAGE_URL + '/maximo/api/os/mxapiapikey?ccm=1&lean=1'
-            logger.info("generate_api_key_URL: " + url)
-            logger.info("generate_api_key_CERT" + str(client_cert))
-            resp = ""
-            try:
-                # resp=requests.post(url , data ={'expiration':'-1', 'user_id': user_id}, cert=client_cert, verify=manage_host_ca_filepath)
-                headers = {'content-type': 'application/json'}
-                payload = {'expiration': '-1', 'userid': user_id}
-                resp = session.post(url, headers=headers,
-                                    json=payload, cert=client_cert, timeout=600, verify=manage_host_ca_filepath)
-                if resp.status_code <= 201:
-                    api_key = get_api_key(user_id, client_cert, session, manage_host_ca_filepath)
-                    logger.info(f"GENERATED MXAPIKEY for {user_id} is: " + api_key)
-                    yield api_key
-                else:
-                    logger.info("Failed to Create APIKEY: " + user_id)
-                    logger.info(resp.status_code)
-                    logger.info(resp.text)
-                    yield None
-
-            except Exception as ex:
-                logger.info("Something wrong here")
-                logger.info(ex)
-        else:
-            logger.info(f"RETRIEVED MXAPIKEY for {user_id} is: " + api_key)
-            yield api_key
-
-
-    def get_api_key(user_id, client_cert, session, manage_host_ca_filepath):
-        api_key = None
-        try:
-            get_api_key_url=f'''{MANAGE_URL}/maximo/api/os/mxapiapikey?lean=1&ccm=1&oslc.select=*&oslc.where=userid%3D%22{user_id}%22'''
-            logger.info("get APIKEY URL: " + get_api_key_url)
-            resp = session.get(get_api_key_url, cert=client_cert, timeout=600, verify=manage_host_ca_filepath)
-            if resp.status_code == 200:
-                data = resp.json()
-                api_key = data['member'][0]['apikey']
-            else:
-                logger.info("Failed to Get APIKEY for: " + user_id)
-                logger.info(resp.status_code)
-                logger.info(resp.text)
-        except Exception as ex:
-            logger.info(ex)
-        return api_key
-
-    #Variables
-    # Headers for API requests
-    @pytest.fixture
-    def headers(user_api_key):
-        headers = {
-            'Accept': 'application/json',
-            'apikey': user_api_key
-        }
-        yield headers
-
-    
-    #***********************Test Functions***************  
-    # Function to check system info has Maximo IT
-    def test_fetch_system_info(session, headers,manage_host_ca_filepath):
-        response = session.get(f"{MANAGE_URL}/maximo/api/systeminfo", headers=headers, verify=manage_host_ca_filepath)
-        assert response.status_code == 200, f"Unexpected status code: {response.status_code}"
-        print("System info fetched successfully")
-
-        response_json = response.json()
-        response_text = str(response_json)
-        assert "Maximo-IT" in response_text, "Maximo-IT string is not present in system info response"
-        print("Maximo-IT is present in System Information")
-
-
-    # Function to check if an app exists in API response
-    def is_app_present(response_json, target_app):
-        if "member" in response_json and isinstance(response_json["member"], list):
-            return any(
-                "maxapps" in member and any(app["app"] == target_app for app in member["maxapps"])
-                for member in response_json["member"]
+            resp = requests.post(
+                url,
+                headers=headers,
+                json=payload,
+                cert=client_cert,
+                timeout=600,
+                verify=manage_host_ca_filepath
             )
-        return False
+
+            if resp.status_code <= 201:
+                api_key = get_api_key(user_id, client_cert, manage_host_ca_filepath)
+                logger.info("Generated MXAPIKEY for %s", user_id)
+                yield api_key
+            else:
+                logger.info("Failed to create APIKEY for: %s", user_id)
+                logger.info("Status code: %s", resp.status_code)
+                logger.info("Response body: %s", resp.text)
+                yield None
+
+        except Exception as ex:
+            logger.info("Something went wrong while creating API key")
+            logger.info(ex)
+            yield None
+
+    else:
+        logger.info("Retrieved existing MXAPIKEY for %s", user_id)
+        yield api_key
 
 
-    # Check if SELFSERVE app exists
-    @pytest.mark.parametrize("user_id, app", [("maxadmin", "SELFSERVE")])
-    def test_selserve_app_presence(user_id, app, headers, session, manage_host_ca_filepath):
-        group_url = f"{MANAGE_URL}/maximo/api/os/mxapigroup?lean=1&oslc.select=*&oslc.where=groupname=%22{user_id}%22"
+def get_api_key(user_id, client_cert, manage_host_ca_filepath):
+    api_key = None
 
-        response = session.get(group_url, headers=headers, verify=manage_host_ca_filepath)
-        assert response.status_code == 200, f"Unexpected status code: {response.status_code}"
+    try:
+        get_api_key_url = (
+            f"{MANAGE_URL}/maximo/api/os/mxapiapikey"
+            f"?lean=1&ccm=1&oslc.select=*&oslc.where=userid%3D%22{user_id}%22"
+        )
 
-        response_json = response.json()
-        app_found = is_app_present(response_json, app)
+        logger.info("get APIKEY URL: %s", get_api_key_url)
 
-        assert app_found, f"App {app} is not present in the response"
-        print(f"App {app} is present")
+        resp = requests.get(
+            get_api_key_url,
+            cert=client_cert,
+            timeout=600,
+            verify=manage_host_ca_filepath
+        )
+
+        if resp.status_code == 200:
+            data = resp.json()
+            api_key = data["member"][0]["apikey"]
+        else:
+            logger.info("Failed to get APIKEY for: %s", user_id)
+            logger.info("Status code: %s", resp.status_code)
+            logger.info("Response body: %s", resp.text)
+
+    except Exception as ex:
+        logger.info(ex)
+
+    return api_key
 
 
-    # Check if SERVICEVIEW app exists
-    @pytest.mark.parametrize("user_id, app", [("maxadmin", "SERVICEVIEW")])
-    def test_serviceview_app_presence(user_id, app, headers, session, manage_host_ca_filepath):
-        group_url = f"{MANAGE_URL}/maximo/api/os/mxapigroup?lean=1&oslc.select=*&oslc.where=groupname=%22{user_id}%22"
+@pytest.fixture
+def headers(user_api_key):
+    yield {
+        "Accept": "application/json",
+        "apikey": user_api_key
+    }
 
-        response = session.get(group_url, headers=headers, verify=manage_host_ca_filepath)
-        assert response.status_code == 200, f"Unexpected status code: {response.status_code}"
 
-        response_json = response.json()
-        app_found = is_app_present(response_json, app)
+def normalize_product_name(value):
+    return str(value).lower().replace("-", " ").replace("_", " ")
 
-        assert app_found, f"App {app} is not present in the response"
-        print(f"App {app} is present")
+
+# *********************** Test Functions ***************
+
+# Function to check system info has Maximo IT
+def test_fetch_system_info(headers, manage_host_ca_filepath):
+    response = requests.get(
+        f"{MANAGE_URL}/maximo/api/systeminfo",
+        headers=headers,
+        verify=manage_host_ca_filepath
+    )
+
+    assert response.status_code == 200, f"Unexpected status code: {response.status_code}. Body: {response.text}"
+
+    print("System info fetched successfully")
+
+    response_json = response.json()
+    response_text = normalize_product_name(response_json)
+
+    assert "maximo it" in response_text, "Maximo IT string is not present in system info response"
+
+    print("Maximo IT is present in System Information")
+
+
+# Function to check if an app exists in API response
+def is_app_present(response_json, target_app):
+    if "member" in response_json and isinstance(response_json["member"], list):
+        return any(
+            "maxapps" in member and any(app["app"] == target_app for app in member["maxapps"])
+            for member in response_json["member"]
+        )
+
+    return False
+
+
+# Check if SELFSERVE app exists
+@pytest.mark.parametrize("user_id, app", [("maxadmin", "SELFSERVE")])
+def test_selserve_app_presence(user_id, app, headers, manage_host_ca_filepath):
+    group_url = (
+        f"{MANAGE_URL}/maximo/api/os/mxapigroup"
+        f"?lean=1&oslc.select=*&oslc.where=groupname=%22{user_id}%22"
+    )
+
+    response = requests.get(
+        group_url,
+        headers=headers,
+        verify=manage_host_ca_filepath
+    )
+
+    assert response.status_code == 200, f"Unexpected status code: {response.status_code}. Body: {response.text}"
+
+    response_json = response.json()
+    app_found = is_app_present(response_json, app)
+
+    assert app_found, f"App {app} is not present in the response"
+
+    print(f"App {app} is present")
+
+
+# Check if SERVICEVIEW app exists
+@pytest.mark.parametrize("user_id, app", [("maxadmin", "SERVICEVIEW")])
+def test_serviceview_app_presence(user_id, app, headers, manage_host_ca_filepath):
+    group_url = (
+        f"{MANAGE_URL}/maximo/api/os/mxapigroup"
+        f"?lean=1&oslc.select=*&oslc.where=groupname=%22{user_id}%22"
+    )
+
+    response = requests.get(
+        group_url,
+        headers=headers,
+        verify=manage_host_ca_filepath
+    )
+
+    assert response.status_code == 200, f"Unexpected status code: {response.status_code}. Body: {response.text}"
+
+    response_json = response.json()
+    app_found = is_app_present(response_json, app)
+
+    assert app_found, f"App {app} is not present in the response"
+
+    print(f"App {app} is present")
 
 
 


### PR DESCRIPTION
Fix Maximo IT postsync verification tests

Update the Maximo IT postsync verification tests to use the requests module directly instead of an undefined pytest session fixture. This aligns the Maximo IT verification pattern with the existing Manage verification tests and prevents pytest setup failures.

Also make the Maximo IT product name check tolerant of hyphen differences, write temporary cert files under /tmp, and avoid logging internal TLS certificate/key contents.

Previous version would fail with Maximo IT installed on Manage 9.1.17

`Running tests... ============================= test session starts ============================== platform linux -- Python 3.12.12, pytest-9.0.3, pluggy-1.6.0 -- /mascli/.venv/bin/python3.12 cachedir: /tmp/__pycache__ rootdir: /tmp/tests collecting ... collected 3 items ../tmp/tests/tests.py::test_fetch_system_info ERROR [ 33%] ../tmp/tests/tests.py::test_selserve_app_presence[maxadmin-SELFSERVE] ERROR [ 66%] ../tmp/tests/tests.py::test_serviceview_app_presence[maxadmin-SERVICEVIEW] ERROR [100%] ==================================== ERRORS ==================================== ___________________ ERROR at setup of test_fetch_system_info ___________________ file /tmp/tests/tests.py, line 203 def test_fetch_system_info(session, headers,manage_host_ca_filepath): E fixture 'session' not found > available fixtures: cache, capfd, capfdbinary, caplog, capsys, capsysbinary, capteesys, client_cert, doctest_namespace, dyn_client, headers, manage_host_ca_filepath, manage_route, monkeypatch, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, subtests, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory, user_api_key, v1_routes > use 'pytest --fixtures [testpath]' for help on them.`

With Changes the post sync job is successful

```
============================= test session starts ==============================
platform linux -- Python 3.12.12, pytest-9.0.3, pluggy-1.6.0 -- /mascli/.venv/bin/python3.12
cachedir: /tmp/__pycache__
rootdir: /tmp/tests
collecting ... collected 3 items

../tmp/tests/tests.py::test_fetch_system_info PASSED                     [ 33%]
../tmp/tests/tests.py::test_selserve_app_presence[maxadmin-SELFSERVE] PASSED [ 66%]
../tmp/tests/tests.py::test_serviceview_app_presence[maxadmin-SERVICEVIEW] PASSED [100%]

------------- generated xml file: /mascli/junitxml_test_output.xml -------------
========================= 3 passed in 81.01s (0:01:21) =========================
```


