### PR TITLE
[patch] Cluster issuer not to be created if public DRO is not enabled

### DIFF
--- a/cluster-applications/030-ibm-dro/templates/12-0-dro-cluster-issuer-staging.yaml
+++ b/cluster-applications/030-ibm-dro/templates/12-0-dro-cluster-issuer-staging.yaml
@@ -1,7 +1,7 @@
-{{- if (eq .Values.dns_provider "cis") }}
+{{- if and (eq .Values.dns_provider "cis") (not (empty .Values.cis_crn)) (not (empty .Values.dro_public_domain)) }}
 
 {{ $cis_apiservice_group_name := "acme.cis.ibm.com" }}
-{{ $cis_stg_issuer_name       := printf "%s-cis-le-stg" .Values.cluster_id }}
+{{ $cis_stg_issuer_name       := printf "%s-dro-cis-le-stg" .Values.cluster_id }}
 
 ---
 apiVersion: cert-manager.io/v1

--- a/cluster-applications/030-ibm-dro/templates/12-1-dro-cluster-issuer-prod.yaml
+++ b/cluster-applications/030-ibm-dro/templates/12-1-dro-cluster-issuer-prod.yaml
@@ -1,6 +1,6 @@
-{{- if (eq .Values.dns_provider "cis") }}
+{{- if and (eq .Values.dns_provider "cis") (not (empty .Values.cis_crn)) (not (empty .Values.dro_public_domain)) }}
 {{ $cis_apiservice_group_name :=  "acme.cis.ibm.com" }}
-{{ $cis_prod_issuer_name      :=  printf "%s-cis-le-prod" .Values.cluster_id }}
+{{ $cis_prod_issuer_name      :=  printf "%s-dro-cis-le-prod" .Values.cluster_id }}
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer


### PR DESCRIPTION
## Description
- Cluster issuers should not be created if public DRO is not enabled
- Renamed cluster issuer to avoid conflicts in case both cluster and instance name are same (issue faced in fvtsaas)