### PR TITLE
[patch]Decouple production-db-access addon from ibm_db2u_databases and update ProductionDBAccess CR

### DIFF
--- a/instance-applications/120-ibm-db2u-database/README.md
+++ b/instance-applications/120-ibm-db2u-database/README.md
@@ -128,11 +128,6 @@ db2_backup_icd_auth_key: string (secret reference, optional, when backup enabled
 
 allow_list: string (optional)
 
-# Production Database Access (optional)
-production_database_access:
-  type: string
-
-
 # Private NLB for customer TGW connectivity (optional)
 private_nlb:
   enabled: boolean         # default: false

--- a/instance-applications/550-ibm-mas-addons-config/README.md
+++ b/instance-applications/550-ibm-mas-addons-config/README.md
@@ -49,7 +49,7 @@ databases:
     replica_db: boolean
 
 production_database_access:
-  key: value
+  type: string
 
 custom_labels:
   key: value

--- a/instance-applications/550-ibm-mas-addons-config/templates/09-production_db_access-cr.yaml
+++ b/instance-applications/550-ibm-mas-addons-config/templates/09-production_db_access-cr.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.application_admin_role }}
 {{- if .Values.production_database_access }}
 ---
 apiVersion: addons.mas.ibm.com/v1
@@ -21,4 +22,5 @@ spec:
     instances:
       - name: "{{ $.Values.instance_id }}-ProductionDatabaseAccess"
         accessType: "{{ $.Values.production_database_access.type }}"
+{{- end }}
 {{- end }}

--- a/instance-applications/550-ibm-mas-addons-config/templates/09-production_db_access-cr.yaml
+++ b/instance-applications/550-ibm-mas-addons-config/templates/09-production_db_access-cr.yaml
@@ -17,10 +17,11 @@ metadata:
 spec:
   displayName: "{{ $.Values.instance_id }}-ProductionDatabaseAccess"
   addonType: production-database-access
+  settings:
+    accessType: "{{ $.Values.production_database_access.type }}"
   config:
     addonIdentifier: {{ $.Values.instance_id }}
     instances:
       - name: "{{ $.Values.instance_id }}-ProductionDatabaseAccess"
-        accessType: "{{ $.Values.production_database_access.type }}"
 {{- end }}
 {{- end }}

--- a/root-applications/ibm-mas-instance-root/templates/550-ibm-mas-addons-config.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/550-ibm-mas-addons-config.yaml
@@ -1,6 +1,6 @@
 {{ $app_dest_ns := printf "mas-%s-core" .Values.instance.id }}
 
-{{ if and (.Values.application_admin_role) (or (not (empty .Values.allow_list)) (.Values.enhanced_dr) (.Values.extensions) (.Values.additional_vpn) (.Values.application_configuration) (not (empty .Values.ibm_db2u_databases)) (.Values.cluster_nonshared) (.Values.additional_resources)) }}
+{{ if and (.Values.application_admin_role) (or (not (empty .Values.allow_list)) (.Values.enhanced_dr) (.Values.extensions) (.Values.additional_vpn) (.Values.application_configuration) (not (empty .Values.ibm_db2u_databases)) (.Values.cluster_nonshared) (.Values.additional_resources) (.Values.production_database_access)) }}
 ---
 # IBM Maximo Operator Catalog
 apiVersion: argoproj.io/v1alpha1
@@ -64,10 +64,8 @@ spec:
               replica_db: {{ $val.replica_db }}
             {{- end }}
             {{- end }}
-            {{- range $val := .Values.ibm_db2u_databases }}
-            {{- if and (eq $val.mas_application_id "manage") ($val.production_database_access) }}
-            production_database_access: {{ $val.production_database_access | toYaml | nindent 14 }}
-            {{- end }}
+            {{- if .Values.production_database_access }}
+            production_database_access: {{ .Values.production_database_access | toYaml | nindent 14 }}
             {{- end }}
             {{- if .Values.custom_labels }}
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}

--- a/root-applications/ibm-mas-instance-root/templates/550-ibm-mas-addons-config.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/550-ibm-mas-addons-config.yaml
@@ -57,15 +57,15 @@ spec:
             {{- if .Values.additional_resources }}
             additional_resources: {{ .Values.additional_resources | toYaml | nindent 14 }}
             {{- end }}
+            {{- if .Values.production_database_access }}
+            production_database_access: {{ .Values.production_database_access | toYaml | nindent 14 }}
+            {{- end }}
             databases:
             {{- range $val := .Values.ibm_db2u_databases }}
             {{- if and (contains "sdb" $val.db2_instance_name) ($val.replica_db) }}
             - mas_application_id: {{ $val.mas_application_id }}
               replica_db: {{ $val.replica_db }}
             {{- end }}
-            {{- end }}
-            {{- if .Values.production_database_access }}
-            production_database_access: {{ .Values.production_database_access | toYaml | nindent 14 }}
             {{- end }}
             {{- if .Values.custom_labels }}
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}


### PR DESCRIPTION
**Issue:** https://jsw.ibm.com/browse/MASCORE-14514

**Description** : The production-database-access GenericAddon was previously tied to the ibm_db2u_databases configuration — it was only activated by looping over db2u database entries and finding one with mas_application_id: manage that carried a production_database_access block. This change decouples it to follow the same pattern as all other generic addons (additional_vpn, extensions, enhanced_dr, etc.), where it is configured as a standalone top-level value.
Moves accessType from spec.config.instances[].accessType up to spec.settings.accessType in the GenericAddon CR 

**Test Results:**
<img width="3456" height="1658" alt="image" src="https://github.com/user-attachments/assets/4e1f4d05-5191-4665-a8ab-c2a2543cc291" />

