### PR TITLE
[patch] Fix duplicate resources in sls app

### DIFF
--- a/sls-applications/100-ibm-sls/templates/08-postsync-update-sm_Job.yaml
+++ b/sls-applications/100-ibm-sls/templates/08-postsync-update-sm_Job.yaml
@@ -59,15 +59,15 @@ are required here.
 
 
 
-{{ $ns := printf "mas-%s-%s-sls" .Values.ibm_customer_number .Values.subscription_id }}
-{{ $instance := printf "%s-%s" .Values.ibm_customer_number .Values.subscription_id }}
+{{- $ns := printf "mas-%s-%s-sls" .Values.ibm_customer_number .Values.subscription_id }}
+{{- $instance := printf "%s-%s" .Values.ibm_customer_number .Values.subscription_id }}
 
-{{ $aws_secret := "aws"}}
-{{ $np_name :=    "postsync-ibm-sls-update-sm-np" }}
-{{ $role_name :=  "postsync-ibm-sls-update-sm-r" }}
-{{ $sa_name :=    "postsync-ibm-sls-update-sm-sa" }}
-{{ $rb_name :=    "postsync-ibm-sls-update-sm-rb" }}
-{{ $job_label :=  "postsync-ibm-sls-update-sm-job" }}
+{{- $aws_secret := "aws"}}
+{{- $np_name :=    "postsync-ibm-sls-update-sm-np" }}
+{{- $role_name :=  "postsync-ibm-sls-update-sm-r" }}
+{{- $sa_name :=    "postsync-ibm-sls-update-sm-sa" }}
+{{- $rb_name :=    "postsync-ibm-sls-update-sm-rb" }}
+{{- $job_label :=  "postsync-ibm-sls-update-sm-job" }}
 
 
 


### PR DESCRIPTION
Local variable assignments used {{ ... }} instead of {{- ... }}, causing blank lines to be rendered before the first --- document separator.

ArgoCD interpreted this as a second YAML stream, resulting in all 6 resources being rendered twice during sync.

<img width="3366" height="510" alt="image" src="https://github.com/user-attachments/assets/cab2b4cf-e17b-4469-bab4-656831231847" />

<img width="1211" height="846" alt="image" src="https://github.com/user-attachments/assets/8219788f-9b2b-4655-a700-861cbfc1c8fc" />
