### PR TITLE
[patch] skip edge certificate order if already exists

### DIFF
--- a/cluster-applications/030-ibm-dro/templates/12-2-dro-dns_job.yaml
+++ b/cluster-applications/030-ibm-dro/templates/12-2-dro-dns_job.yaml
@@ -17,12 +17,12 @@ data:
   aws_secret_access_key: {{ .Values.sm_aws_secret_access_key | default "" | b64enc }}
 type: Opaque
 ---
-{{- if and (eq .Values.dns_provider "cis") (not (empty .Values.cis_crn)) (not (empty .Values.dro_public_domain)) }}
+{{- if and (not (empty .Values.cis_crn)) (not (empty .Values.dro_public_domain)) }}
 {{- $_cli_image_digest := "sha256:64dbab13b7f1ca3d823abee851a94208cf51967849f72102a7e34a909c226df7" }}
 {{- $_job_name_prefix := "ibm-dro-dns" }}
 {{- $_job_cleanup_group := cat $_job_name_prefix | sha1sum }}
 {{- $_job_config_values := omit .Values "junitreporter" }}
-{{- $_job_version := "v3" }}
+{{- $_job_version := "v4" }}
 {{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_digest $_job_version | adler32sum }}
 ---
 # NetworkPolicy to allow egress traffic for AWS Secrets Manager and IBM Cloud API
@@ -245,20 +245,31 @@ spec:
               fi
 
               echo ""
-              echo "Ordering edge certificate for ${FULL_RECORD_NAME}..."
-              
-              CERT_ORDER_OUTPUT=$(ibmcloud cis certificate-order "${DOMAIN_ID}" \
-                --hostnames "${FULL_RECORD_NAME}" 2>&1)
-              
-              CERT_ORDER_RC=$?
-              
-              echo "Certificate order output:"
-              echo "${CERT_ORDER_OUTPUT}"
-              
-              if [[ ${CERT_ORDER_RC} -eq 0 ]]; then
-                echo "Edge certificate ordered successfully!"
+              echo "Checking if edge certificate already exists for ${FULL_RECORD_NAME}..."
+
+              EXISTING_CERTS=$(ibmcloud cis certificates "${DOMAIN_ID}" --output json 2>/dev/null)
+              CERT_EXISTS=$(echo "${EXISTING_CERTS}" | jq -r --arg hostname "${FULL_RECORD_NAME}" \
+                '[.[] | select(.hosts != null and (.hosts | map(select(. == $hostname)) | length > 0))] | length')
+
+              if [[ "${CERT_EXISTS}" -gt 0 ]]; then
+                echo "Edge certificate already exists for ${FULL_RECORD_NAME}. Skipping certificate order."
               else
-                echo "WARNING: Edge certificate order failed or certificate may already exist"
+                echo "No existing edge certificate found. Ordering edge certificate for ${FULL_RECORD_NAME}..."
+
+                CERT_ORDER_OUTPUT=$(ibmcloud cis certificate-order "${DOMAIN_ID}" \
+                  --hostnames "${FULL_RECORD_NAME}" 2>&1)
+
+                CERT_ORDER_RC=$?
+
+                echo "Certificate order output:"
+                echo "${CERT_ORDER_OUTPUT}"
+
+                if [[ ${CERT_ORDER_RC} -eq 0 ]]; then
+                  echo "Edge certificate ordered successfully!"
+                else
+                  echo "ERROR: Edge certificate order failed"
+                  exit 1
+                fi
               fi
 
       volumes:

--- a/cluster-applications/030-ibm-dro/templates/12-2-dro-dns_job.yaml
+++ b/cluster-applications/030-ibm-dro/templates/12-2-dro-dns_job.yaml
@@ -17,7 +17,7 @@ data:
   aws_secret_access_key: {{ .Values.sm_aws_secret_access_key | default "" | b64enc }}
 type: Opaque
 ---
-{{- if and (not (empty .Values.cis_crn)) (not (empty .Values.dro_public_domain)) }}
+{{- if and (eq .Values.dns_provider "cis") (not (empty .Values.cis_crn)) (not (empty .Values.dro_public_domain)) }}
 {{- $_cli_image_digest := "sha256:64dbab13b7f1ca3d823abee851a94208cf51967849f72102a7e34a909c226df7" }}
 {{- $_job_name_prefix := "ibm-dro-dns" }}
 {{- $_job_cleanup_group := cat $_job_name_prefix | sha1sum }}


### PR DESCRIPTION
**Issue:**   https://jsw.ibm.com/browse/MASCORE-15221

**## Summary**
Skip CIS edge certificate creation in the DRO DNS job if a certificate already exists for the hostname, preventing duplicate certificates from being ordered on every job run.

**Test Results**  : 
<img width="2220" height="1848" alt="000" src="https://github.com/user-attachments/assets/b40c8c7e-9b72-45d2-8c06-0e70f348d566" />
<img width="2220" height="1848" alt="00e" src="https://github.com/user-attachments/assets/ef96b369-1af1-4f83-9379-3616696cf68c" />


