### PR TITLE
[patch] check for aiservice secret before patching

### DIFF
--- a/instance-applications/115-ibm-aiservice-tenant/templates/08-postsync-migration-job.yaml
+++ b/instance-applications/115-ibm-aiservice-tenant/templates/08-postsync-migration-job.yaml
@@ -1,7 +1,7 @@
 {{- $_job_name_prefix := "postsync-tenant-migration" }}
 {{- $_cli_image_digest := "sha256:64dbab13b7f1ca3d823abee851a94208cf51967849f72102a7e34a909c226df7" }}
 {{- $_job_config_values := omit .Values "junitreporter" }}
-{{- $_job_version := "v2" }}
+{{- $_job_version := "v3" }}
 {{- $_job_hash := print ($_job_config_values | toYaml) $_cli_image_digest $_job_version | adler32sum }}
 {{- $_job_name := join "-" (list $_job_name_prefix $_job_hash ) }}
 {{- $_job_cleanup_group := cat $_job_name_prefix | sha1sum }}

--- a/instance-applications/115-ibm-aiservice-tenant/templates/08-postsync-migration-job.yaml
+++ b/instance-applications/115-ibm-aiservice-tenant/templates/08-postsync-migration-job.yaml
@@ -152,18 +152,21 @@ spec:
                 local clean_up_namespace=${1}
                 local cr_namespace=${2}
                 readonly API_KEY_SECRET="${TENANT_NAMESPACE}----apikey-secret"
-                echo "[INFO] Updating owner reference in secret ${API_KEY_SECRET} in namespace ${cr_namespace}"
                 readonly CR_UID=$(oc get aiservicetenant "${TENANT_NAMESPACE}" -n "${cr_namespace}" -o jsonpath='{.metadata.uid}')
-                oc get secret "${API_KEY_SECRET}" -n "${cr_namespace}" -o json > /tmp/apikey-secret.json
-                jq --arg name "${TENANT_NAMESPACE}" --arg cr_uid "${CR_UID}" \
-                  '.metadata.ownerReferences = [{"apiVersion": "aiservice.ibm.com/v1", "kind": "AIServiceTenant", "name": $name, "uid": $cr_uid}]' \
-                  /tmp/apikey-secret.json > /tmp/apikey-secret_patched.json
-                oc apply -f /tmp/apikey-secret_patched.json
+                if oc get secret "${API_KEY_SECRET}" -n "${cr_namespace}" > /dev/null 2>&1; then
+                  echo "[INFO] Updating owner reference in secret ${API_KEY_SECRET} in namespace ${cr_namespace}"
+                  oc get secret "${API_KEY_SECRET}" -n "${cr_namespace}" -o json > /tmp/apikey-secret.json
+                  jq --arg name "${TENANT_NAMESPACE}" --arg cr_uid "${CR_UID}" \
+                    '.metadata.ownerReferences = [{"apiVersion": "aiservice.ibm.com/v1", "kind": "AIServiceTenant", "name": $name, "uid": $cr_uid}]' \
+                    /tmp/apikey-secret.json > /tmp/apikey-secret_patched.json
+                  oc apply -f /tmp/apikey-secret_patched.json
+                else
+                  echo "[WARN] Secret ${API_KEY_SECRET} not found in namespace ${cr_namespace} => cannot update owner reference"
+                fi
 
                 echo "[INFO] Deleting secret ${API_KEY_SECRET} in namespace ${clean_up_namespace} (if it exists)"
                 oc delete secret "${API_KEY_SECRET}" -n "${clean_up_namespace}" --ignore-not-found
 
-                oc get aiservicetenant "${TENANT_NAMESPACE}" -n "${clean_up_namespace}" --ignore-not-found
                 if oc get aiservicetenant "${TENANT_NAMESPACE}" -n "${clean_up_namespace}" > /dev/null 2>&1; then
                   echo "[INFO] Deleting AIServiceTenant CR ${TENANT_NAMESPACE} in namespace ${clean_up_namespace}"
                   # Must patch CR to remove finalizer otherwise we cannot delete it
@@ -171,6 +174,8 @@ spec:
                     oc patch aiservicetenant "${TENANT_NAMESPACE}" --type json --patch='[ { "op": "remove", "path": "/metadata/finalizers" } ]' -n "${clean_up_namespace}"
                   fi
                   oc delete aiservicetenant "${TENANT_NAMESPACE}" -n "${clean_up_namespace}"
+                else
+                  echo "[WARN] AIServiceTenant ${TENANT_NAMESPACE} not found in namespace ${clean_up_namespace} => cannot delete"
                 fi
               }
 


### PR DESCRIPTION
## Issue
MASAIB-2553

## Description
The post-sync job for AI Service migration fails for newly provisioned tenants as the job looks for the API key secret in the tenant namespace, however, for a new tenant that is still being reconciled this secret may not yet exist. In this case we should check if the secret exists before trying to update it:

* For new tenants we do not need to perform migration so skipping the secret update is fine.
* For existing tenants that are being migrated the secret will already exist at this point (unless something else unrelated to this migration step has gone wrong).

Wrap the step that patches the secret in an if-statement: `if oc get secret ...`. Add additional logging.

## Test Results
Tested and confirmed that the job does not fail if the secret does not exist. Logs are shown below:

```
[INFO] Running post-sync tenant migration at Wed Jul 8 02:06:19 PM UTC 2026
[WARN] Secret aiservice-apmdevops-t03----apikey-secret not found in namespace aiservice-apmdevops-t03 => cannot update owner reference
[INFO] Deleting secret aiservice-apmdevops-t03----apikey-secret in namespace aiservice-apmdevops (if it exists)
[WARN] AIServiceTenant aiservice-apmdevops-t03 not found in namespace aiservice-apmdevops => cannot delete
```