### PR TITLE
[patch] Lowercase ICN in SLS namespace.

### DIFF
--- a/root-applications/ibm-mas-cluster-root/README.md
+++ b/root-applications/ibm-mas-cluster-root/README.md
@@ -278,7 +278,7 @@ The SLS ApplicationSet ([`065-sls-appset.yaml`](templates/065-sls-appset.yaml)) 
 **Generator:** Single git generator (no merge)
 - Path: `{account.id}/icn/{cluster.id}/*/ibm-sls.yaml`
 
-**Generated Application Naming:** `sls.root.{ibm_customer_number}.{subscription_id}`
+**Generated Application Naming:** `sls.root.{ibm_customer_number | lower}.{subscription_id}`
 
 ### AI Service Instance ApplicationSet
 

--- a/root-applications/ibm-mas-cluster-root/templates/065-sls-appset.yaml
+++ b/root-applications/ibm-mas-cluster-root/templates/065-sls-appset.yaml
@@ -27,7 +27,7 @@ spec:
     applicationsSync: "{{- if .Values.auto_delete }}sync{{- else }}create-update{{- end }}"
   template:
     metadata:
-      name: "sls.root.{{ `{{.ibm_sls_standalone.ibm_customer_number}}` }}.{{ `{{.ibm_sls_standalone.subscription_id}}` }}"
+      name: "sls.root.{{ `{{.ibm_sls_standalone.ibm_customer_number | lower}}` }}.{{ `{{.ibm_sls_standalone.subscription_id}}` }}"
       labels:
         environment: '{{ .Values.account.id }}'
         region: '{{ .Values.region.id }}'

--- a/root-applications/ibm-mas-sls-root/README.md
+++ b/root-applications/ibm-mas-sls-root/README.md
@@ -181,7 +181,7 @@ The following table lists the ArgoCD application defined in the templates folder
 
 | Template File | Application Name | Cluster Admin Role | Application Admin Role | Both Roles |
 |--------------|------------------|-------------------|----------------------|------------|
-| [`100-ibm-sls-app.yaml`](templates/100-ibm-sls-app.yaml) | sls.{ibm_customer_number}.{subscription_id} | | | ✓ |
+| [`100-ibm-sls-app.yaml`](templates/100-ibm-sls-app.yaml) | sls.{ibm_customer_number \| lower}.{subscription_id} | | | ✓ |
 
 ### Role Conditions
 
@@ -195,7 +195,7 @@ The following table lists the ArgoCD application defined in the templates folder
 
 The SLS Application ([`100-ibm-sls-app.yaml`](templates/100-ibm-sls-app.yaml)) deploys a standalone Suite License Service instance:
 
-**Target Namespace:** `mas-{ibm_customer_number}-{subscription_id}-sls`
+**Target Namespace:** `mas-{ibm_customer_number | lower}-{subscription_id}-sls`
 
 **Source Path:** `sls-applications/100-ibm-sls`
 
@@ -212,7 +212,7 @@ The SLS Application ([`100-ibm-sls-app.yaml`](templates/100-ibm-sls-app.yaml)) d
 **Ignore Differences:**
 - ServiceAccount `imagePullSecrets` (automatically managed by OpenShift)
 
-**Application Naming:** `sls.{ibm_customer_number}.{subscription_id}`
+**Application Naming:** `sls.{ibm_customer_number | lower}.{subscription_id}`
 
 ## Example Configuration
 

--- a/root-applications/ibm-mas-sls-root/templates/100-ibm-sls-app.yaml
+++ b/root-applications/ibm-mas-sls-root/templates/100-ibm-sls-app.yaml
@@ -4,7 +4,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: sls.{{ .Values.ibm_sls_standalone.ibm_customer_number }}.{{ .Values.ibm_sls_standalone.subscription_id }}
+  name: sls.{{ .Values.ibm_sls_standalone.ibm_customer_number | lower }}.{{ .Values.ibm_sls_standalone.subscription_id }}
   namespace: {{ .Values.argo.namespace }}
   labels:
     environment: '{{ .Values.account.id }}'
@@ -29,7 +29,7 @@ spec:
   project: "{{ .Values.argo.projects.apps }}"
   destination:
     server: {{ .Values.cluster.url }}
-    namespace: mas-{{ .Values.ibm_sls_standalone.ibm_customer_number }}-{{ .Values.ibm_sls_standalone.subscription_id }}-sls
+    namespace: mas-{{ .Values.ibm_sls_standalone.ibm_customer_number | lower }}-{{ .Values.ibm_sls_standalone.subscription_id }}-sls
   source:
     repoURL: "{{ .Values.source.repo_url }}"
     path: sls-applications/100-ibm-sls
@@ -71,7 +71,7 @@ spec:
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}
             {{- end }}
             junitreporter:
-              reporter_name: "ibm-sls-{{ .Values.ibm_sls_standalone.ibm_customer_number }}-{{ .Values.ibm_sls_standalone.subscription_id}}"
+              reporter_name: "ibm-sls-{{ .Values.ibm_sls_standalone.ibm_customer_number | lower }}-{{ .Values.ibm_sls_standalone.subscription_id}}"
               cluster_id: "{{ .Values.cluster.id }}"
               customer_id: "{{ .Values.ibm_sls_standalone.ibm_customer_number }}"
               subscription_id: "{{ .Values.ibm_sls_standalone.subscription_id }}"

--- a/sls-applications/100-ibm-sls/templates/01-ibm-sls_OperatorGroup.yaml
+++ b/sls-applications/100-ibm-sls/templates/01-ibm-sls_OperatorGroup.yaml
@@ -4,7 +4,7 @@ apiVersion: operators.coreos.com/v1alpha2
 kind: OperatorGroup
 metadata:
   name: operatorgroup
-  namespace: mas-{{ .Values.ibm_customer_number }}-{{ .Values.subscription_id }}-sls
+  namespace: mas-{{ .Values.ibm_customer_number | lower }}-{{ .Values.subscription_id }}-sls
   annotations:
     argocd.argoproj.io/sync-wave: "101"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
@@ -14,5 +14,5 @@ metadata:
 {{- end }}
 spec:
   targetNamespaces:
-    - mas-{{ .Values.ibm_customer_number }}-{{ .Values.subscription_id }}-sls
+    - mas-{{ .Values.ibm_customer_number | lower }}-{{ .Values.subscription_id }}-sls
 {{- end }}

--- a/sls-applications/100-ibm-sls/templates/02-ibm-sls_Subscription.yaml
+++ b/sls-applications/100-ibm-sls/templates/02-ibm-sls_Subscription.yaml
@@ -4,7 +4,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: ibm-sls
-  namespace: mas-{{ .Values.ibm_customer_number }}-{{ .Values.subscription_id }}-sls
+  namespace: mas-{{ .Values.ibm_customer_number | lower }}-{{ .Values.subscription_id }}-sls
   annotations:
     argocd.argoproj.io/sync-wave: "102"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/sls-applications/100-ibm-sls/templates/03-ibm-entitlement_Secret.yaml
+++ b/sls-applications/100-ibm-sls/templates/03-ibm-entitlement_Secret.yaml
@@ -4,7 +4,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: ibm-entitlement
-  namespace: mas-{{ .Values.ibm_customer_number }}-{{ .Values.subscription_id }}-sls
+  namespace: mas-{{ .Values.ibm_customer_number | lower }}-{{ .Values.subscription_id }}-sls
   annotations:
     argocd.argoproj.io/sync-wave: "102"
 {{- if .Values.custom_labels }}

--- a/sls-applications/100-ibm-sls/templates/04-mongo-credentials_Secret.yaml
+++ b/sls-applications/100-ibm-sls/templates/04-mongo-credentials_Secret.yaml
@@ -4,7 +4,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: "{{ .Values.sls_mongo_secret_name }}"
-  namespace: mas-{{ .Values.ibm_customer_number }}-{{ .Values.subscription_id }}-sls
+  namespace: mas-{{ .Values.ibm_customer_number | lower }}-{{ .Values.subscription_id }}-sls
   annotations:
     argocd.argoproj.io/sync-wave: "103"
 {{- if .Values.custom_labels }}

--- a/sls-applications/100-ibm-sls/templates/05-ibm-sls-sls-entitlement_Secret.yaml
+++ b/sls-applications/100-ibm-sls/templates/05-ibm-sls-sls-entitlement_Secret.yaml
@@ -4,7 +4,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: ibm-sls-sls-entitlement
-  namespace: mas-{{ .Values.ibm_customer_number }}-{{ .Values.subscription_id }}-sls
+  namespace: mas-{{ .Values.ibm_customer_number | lower }}-{{ .Values.subscription_id }}-sls
   annotations:
     argocd.argoproj.io/sync-wave: "104"
 {{- if .Values.custom_labels }}

--- a/sls-applications/100-ibm-sls/templates/06-ibm-sls_LicenseService.yaml
+++ b/sls-applications/100-ibm-sls/templates/06-ibm-sls_LicenseService.yaml
@@ -4,7 +4,7 @@ apiVersion: sls.ibm.com/v1
 kind: LicenseService
 metadata:
   name: sls
-  namespace: mas-{{ .Values.ibm_customer_number }}-{{ .Values.subscription_id }}-sls
+  namespace: mas-{{ .Values.ibm_customer_number | lower }}-{{ .Values.subscription_id }}-sls
   annotations:
     argocd.argoproj.io/sync-wave: "105"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/sls-applications/100-ibm-sls/templates/07-ibm-sls-dns_job.yaml
+++ b/sls-applications/100-ibm-sls/templates/07-ibm-sls-dns_job.yaml
@@ -14,7 +14,7 @@ kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: ibm-sls-dns-netpol
-  namespace: mas-{{ .Values.ibm_customer_number }}-{{ .Values.subscription_id }}-sls
+  namespace: mas-{{ .Values.ibm_customer_number | lower }}-{{ .Values.subscription_id }}-sls
   annotations:
     argocd.argoproj.io/sync-wave: "112"
 spec:
@@ -32,7 +32,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ $_job_name  }}
-  namespace: mas-{{ .Values.ibm_customer_number }}-{{ .Values.subscription_id }}-sls
+  namespace: mas-{{ .Values.ibm_customer_number | lower }}-{{ .Values.subscription_id }}-sls
   annotations:
     argocd.argoproj.io/sync-wave: "113"
   labels:

--- a/sls-applications/100-ibm-sls/templates/07-ibm-sls-dns_job.yaml
+++ b/sls-applications/100-ibm-sls/templates/07-ibm-sls-dns_job.yaml
@@ -26,7 +26,7 @@ spec:
   policyTypes:
     - Egress
 
-{{- if and (not (empty .Values.dns_provider)) (not (empty .Values.cis_domain)) (not (empty .Values.cis_crn)) }}
+{{- if and (not (empty .Values.cis_domain)) (not (empty .Values.cis_crn)) }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -82,6 +82,9 @@ spec:
               echo "Reading AWS credentials..."
               SM_AWS_ACCESS_KEY_ID=$(cat /etc/mas/creds/aws/aws_access_key_id)
               SM_AWS_SECRET_ACCESS_KEY=$(cat /etc/mas/creds/aws/aws_secret_access_key)
+
+              # Namespace and DNS record names must be lowercase; ICN in the license file may be mixed-case
+              ICN_LOWER="${ICN,,}"
 
               export SM_AWS_REGION=${REGION_ID}
 
@@ -161,7 +164,7 @@ spec:
               exit 1
               fi
 
-              Name="sls.mas-${ICN}-${SUBSCRIPTION_ID}-sls"
+              Name="sls.mas-${ICN_LOWER}-${SUBSCRIPTION_ID}-sls"
 
               echo "Name: ${Name}"
               echo "CIS_DOMAIN: ${CIS_DOMAIN}"
@@ -241,4 +244,4 @@ spec:
             secret:
               secretName: aws       # make sure this Secret exists in the same namespace
               defaultMode: 420
-{{- end }}         
+{{- end }}

--- a/sls-applications/100-ibm-sls/templates/08-postsync-update-sm_Job.yaml
+++ b/sls-applications/100-ibm-sls/templates/08-postsync-update-sm_Job.yaml
@@ -241,14 +241,17 @@ spec:
               SM_AWS_ACCESS_KEY_ID=$(cat /etc/mas/creds/aws/aws_access_key_id)
               SM_AWS_SECRET_ACCESS_KEY=$(cat /etc/mas/creds/aws/aws_secret_access_key)
 
-              echo "Fetching registrationKey from sls-suite-registration ConfigMap in mas-${ICN}-${SUBSCRIPTION_ID}-sls"
+              # Namespace names must be lowercase; ICN in the license file may be mixed-case
+              ICN_LOWER="${ICN,,}"
+
+              echo "Fetching registrationKey from sls-suite-registration ConfigMap in mas-${ICN_LOWER}-${SUBSCRIPTION_ID}-sls"
               SLS_REGISTRATION_KEY=$(cat /etc/mas/creds/sls-suite-registration/registrationKey)
               if [[ -z "${SLS_REGISTRATION_KEY}" ]]; then
                 echo "Failed to fetch registrationKey"
                 exit 1
               fi
 
-              echo "Fetching ca from sls-suite-registration ConfigMap in mas-${ICN}-${SUBSCRIPTION_ID}-sls"
+              echo "Fetching ca from sls-suite-registration ConfigMap in mas-${ICN_LOWER}-${SUBSCRIPTION_ID}-sls"
               SLS_CA=$(cat /etc/mas/creds/sls-suite-registration/ca | base64 -w0)
               if [[ -z "${SLS_CA}" ]]; then
                 echo "Failed to fetch ca"
@@ -256,7 +259,7 @@ spec:
               fi
 
               echo "Setting SLS URL"
-              SLS_URL="https://sls.mas-${ICN}-${SUBSCRIPTION_ID}-sls.${DOMAIN}"
+              SLS_URL="https://sls.mas-${ICN_LOWER}-${SUBSCRIPTION_ID}-sls.${DOMAIN}"
 
               # might as well take advantage of gitops_utils for sm_ functions as we're using the cli image
               source /mascli/functions/gitops_utils
@@ -275,7 +278,7 @@ spec:
               sm_update_secret $SECRET_NAME_SLS "{\"registration_key\": \"$SLS_REGISTRATION_KEY\", \"ca_b64\": \"$SLS_CA\", \"sls_url\":\"$SLS_URL\" }" "${TAGS}"
     
               # 1. Define the namespace using the environment variables passed to the container
-              namespace="mas-${ICN}-${SUBSCRIPTION_ID}-sls"
+              namespace="mas-${ICN_LOWER}-${SUBSCRIPTION_ID}-sls"
 
               echo "Fetching routes from ${namespace}"
 

--- a/sls-applications/100-ibm-sls/templates/08-postsync-update-sm_Job.yaml
+++ b/sls-applications/100-ibm-sls/templates/08-postsync-update-sm_Job.yaml
@@ -59,8 +59,8 @@ are required here.
 
 
 
-{{ $ns := printf "mas-%s-%s-sls" .Values.ibm_customer_number .Values.subscription_id }}
-{{ $instance := printf "%s-%s" .Values.ibm_customer_number .Values.subscription_id }}
+{{ $ns := printf "mas-%s-%s-sls" (.Values.ibm_customer_number | lower) .Values.subscription_id }}
+{{ $instance := printf "%s-%s" (.Values.ibm_customer_number | lower) .Values.subscription_id }}
 
 {{ $aws_secret := "aws"}}
 {{ $np_name :=    "postsync-ibm-sls-update-sm-np" }}


### PR DESCRIPTION
**Description :** ICNs in SLS license files can contain uppercase characters (e.g. `US_0X1`),
which caused RFC 1123 violations in OpenShift namespace names and ArgoCD
Application names.

## Changes
- Applied `| lower` to ICN in all namespace and Application name constructions
  across `sls-applications/100-ibm-sls/templates/` and
  `root-applications/ibm-mas-sls-root/` and `ibm-mas-cluster-root/`
- Added `ICN_LOWER="${ICN,,}"` in job shell scripts for runtime namespace construction
- Original ICN value preserved in AWS Secrets Manager paths, `ICN` env vars,
  and license/customer data fields

## Related
MASCORE-15295
MASCORE-15736

## Test  Results :
<img width="3456" height="1874" alt="Pasted Graphic 16" src="https://github.com/user-attachments/assets/ebc3273d-9661-44a5-b47a-ed18330aad7f" />

**icn in namespace  is lowercase but icn present in capital formate under license file.**
<img width="3456" height="1874" alt="Pasted Graphic 17" src="https://github.com/user-attachments/assets/f9aa8c06-35fb-4b20-b537-6d8cb6dd1d6c" />

<img width="3456" height="1088" alt="Pasted Graphic 18" src="https://github.com/user-attachments/assets/851fce27-cc9d-46c9-b891-71041b3b418b" />
<img width="3456" height="1822" alt="Pasted Graphic 19" src="https://github.com/user-attachments/assets/9436d826-c9ac-4412-9998-490f483c236a" />

