### PR TITLE
[DO NOT MERGE][minor] AI Service tenant operator customization

### DIFF
--- a/instance-applications/115-ibm-aiservice-tenant/README.md
+++ b/instance-applications/115-ibm-aiservice-tenant/README.md
@@ -208,7 +208,7 @@ ibm_aiservice_tenant:
 
 ### Tenant with Custom Operator Resource Limits (9.2.x+)
 
-Use `tenant_operator_config` to set resource requests and limits on the tenant operator pod. This maps directly to the [`spec.config`](https://olm.operatorframework.io/docs/concepts/crds/subscription/) field of the OLM `Subscription` resource.
+Use `tenant_operator_config` to set resource requests and limits on the tenant operator pod. This maps directly to the [`spec.config`](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/subscription-config.md) field of the OLM `Subscription` resource.
 
 ```yaml
 ibm_aiservice_tenant:

--- a/instance-applications/115-ibm-aiservice-tenant/README.md
+++ b/instance-applications/115-ibm-aiservice-tenant/README.md
@@ -81,6 +81,18 @@ ibm_aiservice_tenant:
   tenant_entitlement_end_date: string
   
   aiservice_operator_log_level: string
+
+  # Operator Resource Configuration (optional, requires catalog_channel 9.2.x+)
+  # Sets resource requests/limits on the tenant operator container via the
+  # Subscription spec.config field. Accepts any valid SubscriptionConfig object.
+  tenant_operator_config:
+    resources:
+      requests:
+        cpu: string
+        memory: string
+      limits:
+        cpu: string
+        memory: string
 ```
 
 **Note**: Values marked with "(secret reference)" should use the format `<path:secrets/path:key>` to reference secrets stored in the Secrets Vault.
@@ -193,6 +205,27 @@ ibm_aiservice_tenant:
           operator: Equal
           value: inference
 ```
+
+### Tenant with Custom Operator Resource Limits (9.2.x+)
+
+Use `tenant_operator_config` to set resource requests and limits on the tenant operator pod. This maps directly to the [`spec.config`](https://olm.operatorframework.io/docs/concepts/crds/subscription/) field of the OLM `Subscription` resource.
+
+```yaml
+ibm_aiservice_tenant:
+  # Specify all parameters as per above example
+
+  # Operator Resource Configuration
+  tenant_operator_config:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+```
+
+Any valid [`SubscriptionConfig`](https://pkg.go.dev/github.com/operator-framework/api/pkg/operators/v1alpha1#SubscriptionConfig) field is accepted (e.g. `env`, `volumes`, `tolerations`, `nodeSelector`).
 
 
 ## Prerequisites

--- a/instance-applications/115-ibm-aiservice-tenant/templates/06-aiservice-tenant-operator-subscription.yaml
+++ b/instance-applications/115-ibm-aiservice-tenant/templates/06-aiservice-tenant-operator-subscription.yaml
@@ -28,7 +28,6 @@ spec:
   source: "{{ .Values.catalog_source }}"
   sourceNamespace: openshift-marketplace
   {{- if .Values.tenant_operator_config }}
-  config: 
-  {{ .Values.tenant_operator_config | toYaml | indent 4 }}
+  config: {{ .Values.tenant_operator_config | toYaml | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/instance-applications/115-ibm-aiservice-tenant/templates/06-aiservice-tenant-operator-subscription.yaml
+++ b/instance-applications/115-ibm-aiservice-tenant/templates/06-aiservice-tenant-operator-subscription.yaml
@@ -29,6 +29,6 @@ spec:
   sourceNamespace: openshift-marketplace
   {{- if .Values.tenant_operator_config }}
   config: 
-  {{ .Values.tenant_operator_config | indent 4 }}
+  {{ .Values.tenant_operator_config | toYaml | indent 4 }}
   {{- end }}
 {{- end }}

--- a/instance-applications/115-ibm-aiservice-tenant/templates/06-aiservice-tenant-operator-subscription.yaml
+++ b/instance-applications/115-ibm-aiservice-tenant/templates/06-aiservice-tenant-operator-subscription.yaml
@@ -27,4 +27,8 @@ spec:
   name: ibm-aiservice-tenant
   source: "{{ .Values.catalog_source }}"
   sourceNamespace: openshift-marketplace
+  {{- if .Values.tenant_operator_config }}
+  config: 
+  {{ .Values.tenant_operator_config | indent 4 }}
+  {{- end }}
 {{- end }}

--- a/instance-applications/115-ibm-aiservice-tenant/values.yaml
+++ b/instance-applications/115-ibm-aiservice-tenant/values.yaml
@@ -1,5 +1,6 @@
 catalog_channel: "9.2.x-dev"
 catalog_source: ibm-operator-catalog
+tenant_operator_config: {}
 
 # FVT Environment Configuration
 ibm_aiservice_tenant:

--- a/root-applications/ibm-aiservice-tenant-root/README.md
+++ b/root-applications/ibm-aiservice-tenant-root/README.md
@@ -168,6 +168,7 @@ The following parameters are passed from the parent AI Service Instance Root App
 | `avp.values_varname` | Vault values variable name | `HELM_VALUES` |
 | `auto_delete` | Enable auto-pruning | `false` |
 | `cluster.url` | Kubernetes API URL | `https://kubernetes.default.svc` |
+| `ibm_aiservice_tenant.tenant_operator_config` | OLM `SubscriptionConfig` object applied to the tenant operator `Subscription` `spec.config` field. Use to set resource requests/limits, env vars, tolerations, etc. on the operator pod. Optional; omit to use operator defaults. | `{}` |
 
 ## ArgoCD Applications
 
@@ -200,7 +201,7 @@ config-repo/
 │                   └── aiservice-tenant-params.yaml  # Required
 ```
 
-See the [AI Service Tenant Chart](../../instance-applications/115-ibm-aiservice-tenant/README.md) for detailed tenant configuration examples.
+See the [AI Service Tenant Chart](../../instance-applications/115-ibm-aiservice-tenant/README.md) for detailed tenant configuration examples, including `tenant_operator_config` usage.
 
 ## Prerequisites
 

--- a/root-applications/ibm-aiservice-tenant-root/templates/100-ibm-aiservice-tenant-app.yaml
+++ b/root-applications/ibm-aiservice-tenant-root/templates/100-ibm-aiservice-tenant-app.yaml
@@ -45,7 +45,7 @@ spec:
             catalog_source: "{{ .Values.ibm_aiservice_tenant.catalog_source }}"
             catalog_channel: "{{ .Values.ibm_aiservice_tenant.catalog_channel }}"
             aiservice_tenant_install_plan_approval: "{{ .Values.ibm_aiservice_tenant.aiservice_tenant_install_plan_approval }}"
-            tenant_operator_config: "{{ .Values.ibm_aiservice_tenant.tenant_operator_config }}"
+            tenant_operator_config: {{ .Values.ibm_aiservice_tenant.tenant_operator_config }}
             
             tenant_id: "{{ .Values.ibm_aiservice_tenant.tenant_id }}"
             aiservice_instance_id: "{{ .Values.ibm_aiservice_tenant.aiservice_instance_id }}"

--- a/root-applications/ibm-aiservice-tenant-root/templates/100-ibm-aiservice-tenant-app.yaml
+++ b/root-applications/ibm-aiservice-tenant-root/templates/100-ibm-aiservice-tenant-app.yaml
@@ -45,7 +45,9 @@ spec:
             catalog_source: "{{ .Values.ibm_aiservice_tenant.catalog_source }}"
             catalog_channel: "{{ .Values.ibm_aiservice_tenant.catalog_channel }}"
             aiservice_tenant_install_plan_approval: "{{ .Values.ibm_aiservice_tenant.aiservice_tenant_install_plan_approval }}"
-            tenant_operator_config: {{ .Values.ibm_aiservice_tenant.tenant_operator_config }}
+            {{- if .Values.ibm_aiservice_tenant.tenant_operator_config }}
+            tenant_operator_config: {{ .Values.ibm_aiservice_tenant.tenant_operator_config | toYaml | nindent 14 }}
+            {{- end }}
             
             tenant_id: "{{ .Values.ibm_aiservice_tenant.tenant_id }}"
             aiservice_instance_id: "{{ .Values.ibm_aiservice_tenant.aiservice_instance_id }}"

--- a/root-applications/ibm-aiservice-tenant-root/templates/100-ibm-aiservice-tenant-app.yaml
+++ b/root-applications/ibm-aiservice-tenant-root/templates/100-ibm-aiservice-tenant-app.yaml
@@ -44,7 +44,8 @@ spec:
           value: |
             catalog_source: "{{ .Values.ibm_aiservice_tenant.catalog_source }}"
             catalog_channel: "{{ .Values.ibm_aiservice_tenant.catalog_channel }}"
-            aiservice_tenant_install_plan_approval: "{{ .Values.ibm_aiservice_tenant.aiservice_tenant_install_plan_approval }}" 
+            aiservice_tenant_install_plan_approval: "{{ .Values.ibm_aiservice_tenant.aiservice_tenant_install_plan_approval }}"
+            tenant_operator_config: "{{ .Values.ibm_aiservice_tenant.tenant_operator_config }}"
             
             tenant_id: "{{ .Values.ibm_aiservice_tenant.tenant_id }}"
             aiservice_instance_id: "{{ .Values.ibm_aiservice_tenant.aiservice_instance_id }}"

--- a/root-applications/ibm-aiservice-tenant-root/values.yaml
+++ b/root-applications/ibm-aiservice-tenant-root/values.yaml
@@ -251,6 +251,7 @@ ibm_aiservice:
 ibm_aiservice_tenant:
   catalog_channel: ""
   catalog_source: "ibm-operator-catalog"
+  tenant_operator_config: {}
   
   mas_instance_id: "MAS_INSTANCE_ID"
   aiservice_namespace: 'mas-{{ mas_instance_id }}-aiservice'


### PR DESCRIPTION
## Issue
MASAIB-2648

## Description
Allow the AI Service tenant operator to be customized via its Subscription. For example, the operator's resource requests and limits can be controlled by adding fields to the Subscription's "config" field.

## Test Results
Successfully modified the CPU request for the tenant operator using the Subscription:

<img width="357" height="185" alt="Screenshot 2026-08-04 at 09 26 02" src="https://github.com/user-attachments/assets/47cfd5d2-af9f-4953-8999-a798dde8636b" />

<img width="246" height="86" alt="Screenshot 2026-08-04 at 09 25 46" src="https://github.com/user-attachments/assets/6254ef66-1a55-4bc1-8694-f04b3efd6e77" />
