### PR TITLE
[patch] temporarily hardcode AI Service tenant operator resources

### DIFF
--- a/instance-applications/115-ibm-aiservice-tenant/templates/06-aiservice-tenant-operator-subscription.yaml
+++ b/instance-applications/115-ibm-aiservice-tenant/templates/06-aiservice-tenant-operator-subscription.yaml
@@ -33,6 +33,6 @@ spec:
         cpu: "0.1"
         memory: 200Mi
       limits:
-        cpu: "0.5"
+        cpu: "0.1"
         memory: 1024Mi
 {{- end }}

--- a/instance-applications/115-ibm-aiservice-tenant/templates/06-aiservice-tenant-operator-subscription.yaml
+++ b/instance-applications/115-ibm-aiservice-tenant/templates/06-aiservice-tenant-operator-subscription.yaml
@@ -27,4 +27,12 @@ spec:
   name: ibm-aiservice-tenant
   source: "{{ .Values.catalog_source }}"
   sourceNamespace: openshift-marketplace
+  config:
+    resources:
+      requests:
+        cpu: "0.1"
+        memory: 200Mi
+      limits:
+        cpu: "0.5"
+        memory: 1024Mi
 {{- end }}

--- a/instance-applications/115-ibm-aiservice-tenant/templates/06-aiservice-tenant-operator-subscription.yaml
+++ b/instance-applications/115-ibm-aiservice-tenant/templates/06-aiservice-tenant-operator-subscription.yaml
@@ -33,6 +33,6 @@ spec:
         cpu: "0.1"
         memory: 200Mi
       limits:
-        cpu: "0.1"
+        cpu: "0.25"
         memory: 1024Mi
 {{- end }}


### PR DESCRIPTION
## Issue
MASAIB-2712

## Description
Temporarily hardcode the AI Service tenant operator resource requests and limits until the GitOps pipeline fully supports configuring these values. The operator's current requests are too high and this may potentially block a successful upgrade from AI Service 9.1 to 9.2. Work to make these values configurable is underway in https://github.com/ibm-mas/gitops/pull/518 

## Test Results
Pointed ArgoCD to this branch in a test cluster and confirmed that the operator pod was redeployed with the resource changes