### PR TITLE
MASCORE-15507: fix wrong OpenSearch CRD name in WSL Helm Job wait loop

### DIFF
--- a/instance-applications/120-ibm-wsl/templates/01-ibm-wsl-cr.yaml
+++ b/instance-applications/120-ibm-wsl/templates/01-ibm-wsl-cr.yaml
@@ -148,7 +148,7 @@ spec:
                 "opencontent-opensearch-cluster-scoped" \
                 "1.2.0"
 
-              echo "Waiting for opensearchclusters.opensearch.cloudpackopen.ibm.com CRD to be established..."
+              echo "Waiting for clusters.opensearch.cloudpackopen.ibm.com CRD to be established..."
               wait_period=0
               while true; do
                 wait_period=$((wait_period+10))
@@ -156,7 +156,7 @@ spec:
                   echo "CRD not established after 5 minutes. Exiting."
                   exit 1
                 fi
-                STATUS=$(oc get crd opensearchclusters.opensearch.cloudpackopen.ibm.com -o jsonpath='{.status.conditions[?(@.type=="Established")].status}' --ignore-not-found 2>/dev/null)
+                STATUS=$(oc get crd clusters.opensearch.cloudpackopen.ibm.com -o jsonpath='{.status.conditions[?(@.type=="Established")].status}' --ignore-not-found 2>/dev/null)
                 if [ "$STATUS" = "True" ]; then
                   echo "CRD established."
                   break


### PR DESCRIPTION
The wait loop was polling for:
  opensearchclusters.opensearch.cloudpackopen.ibm.com  (does not exist)

The actual CRD name registered by the IBM OpenSearch Helm chart is:
  clusters.opensearch.cloudpackopen.ibm.com

This caused the WSL Helm Job to always timeout after 5 minutes at the OpenSearch step, blocking CCS, DataRefinery, WS-Runtimes and WSL from ever installing.