### PR TITLE
MASCORE-15507: Add ibm-redis-cp operator Subscription for CPD 5.3.1+ WML

### DIFF
--- a/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
@@ -146,6 +146,29 @@ spec:
   backoffLimit: 4
 
 
+
+{{- if and .Values.wml_channel (not (lt (semver "5.3.1" | (semver (.Values.cpd_product_version | toString)).Compare) 0)) }}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: ibm-redis-cp-operator
+  namespace: "{{ .Values.cpd_operators_namespace }}"
+  annotations:
+    argocd.argoproj.io/sync-wave: "090"
+{{- if .Values.custom_labels }}
+  labels:
+{{ .Values.custom_labels | toYaml | indent 4 }}
+{{- end }}
+spec:
+  channel: "{{ .Values.ibm_redis_cp_channel }}"
+  installPlanApproval: {{ .Values.ibm_redis_cp_install_plan | default "Automatic" | quote }}
+  name: ibm-redis-cp
+  source: ibm-operator-catalog
+  sourceNamespace: openshift-marketplace
+{{- end }}
+
+
 {{- if lt (semver "5.3.1" | (semver (.Values.cpd_product_version | toString)).Compare) 0 }}
 {{- if or .Values.wml_channel .Values.wsl_channel .Values.spss_channel }}
 ---

--- a/instance-applications/110-ibm-cp4d/values.yaml
+++ b/instance-applications/110-ibm-cp4d/values.yaml
@@ -10,3 +10,5 @@ cpd_product_version: ""
 cpd_iam_integration: false
 cpd_primary_storage_class: ""
 cpd_metadata_storage_class: ""
+ibm_redis_cp_channel: ""
+ibm_redis_cp_install_plan: ""

--- a/instance-applications/600-application-admin-rbac/templates/per-namespace-rbac.yaml
+++ b/instance-applications/600-application-admin-rbac/templates/per-namespace-rbac.yaml
@@ -122,6 +122,7 @@ rules:
 - apiGroups:
   - config.mas.ibm.com
   resources:
+  - aicfgs
   - appcfgs
   - bascfgs
   - idpcfgs

--- a/rbac/kustomize/base/application-admin-role.yaml
+++ b/rbac/kustomize/base/application-admin-role.yaml
@@ -95,6 +95,7 @@ rules:
 - apiGroups:
   - config.mas.ibm.com
   resources:
+  - aicfgs
   - appcfgs
   - bascfgs
   - idpcfgs

--- a/root-applications/ibm-mas-instance-root/templates/110-ibm-cp4d-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/110-ibm-cp4d-app.yaml
@@ -94,6 +94,8 @@ spec:
             opencontent_opensearch_channel: "{{ .Values.ibm_cp4d_services_base.opencontent_opensearch_channel }}"
             elasticsearch_install_plan: "{{ .Values.ibm_cp4d_services_base.elasticsearch_install_plan }}"
             opensearch_install_plan: "{{ .Values.ibm_cp4d_services_base.opensearch_install_plan }}"
+            ibm_redis_cp_channel: "{{ .Values.ibm_cp4d_services_base.ibm_redis_cp_channel }}"
+            ibm_redis_cp_install_plan: "{{ .Values.ibm_cp4d_services_base.ibm_redis_cp_install_plan }}"
             {{- end }}
             {{- if .Values.custom_labels }}
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}


### PR DESCRIPTION
The WmlBase CR was failing with:
  'Failed to find exact match for redis.ibm.com/v1.Rediscp'

The WML operator Ansible playbook requires the IBM Redis CP operator (ibm-redis-cp) to be installed. For CPD < 5.3.1 this was handled via OLM, but the Helm-based path for CPD >= 5.3.1 had no Subscription for ibm-redis-cp, leaving the Rediscp CRD uninstalled.

Changes:
- Add ibm-redis-cp Subscription to 09-ibm-cp4d_services_base.yaml, gated on wml_channel being set and CPD version >= 5.3.1
- Add ibm_redis_cp_channel and ibm_redis_cp_install_plan to 110-ibm-cp4d/values.yaml
- Pass ibm_redis_cp_channel and ibm_redis_cp_install_plan through 110-ibm-cp4d-app.yaml from ibm_cp4d_services_base config block
- Regenerate RBAC rules