### PR TITLE
MASCORE-15507: Fix ibm-redis-cp install - use Helm not OLM Subscription

### DIFF
--- a/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
+++ b/instance-applications/110-ibm-cp4d/templates/09-ibm-cp4d_services_base.yaml
@@ -147,28 +147,6 @@ spec:
 
 
 
-{{- if and .Values.wml_channel (not (lt (semver "5.3.1" | (semver (.Values.cpd_product_version | toString)).Compare) 0)) }}
----
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
-  name: ibm-redis-cp-operator
-  namespace: "{{ .Values.cpd_operators_namespace }}"
-  annotations:
-    argocd.argoproj.io/sync-wave: "090"
-{{- if .Values.custom_labels }}
-  labels:
-{{ .Values.custom_labels | toYaml | indent 4 }}
-{{- end }}
-spec:
-  channel: "{{ .Values.ibm_redis_cp_channel }}"
-  installPlanApproval: {{ .Values.ibm_redis_cp_install_plan | default "Automatic" | quote }}
-  name: ibm-redis-cp
-  source: ibm-operator-catalog
-  sourceNamespace: openshift-marketplace
-{{- end }}
-
-
 {{- if lt (semver "5.3.1" | (semver (.Values.cpd_product_version | toString)).Compare) 0 }}
 {{- if or .Values.wml_channel .Values.wsl_channel .Values.spss_channel }}
 ---

--- a/instance-applications/110-ibm-cp4d/values.yaml
+++ b/instance-applications/110-ibm-cp4d/values.yaml
@@ -10,5 +10,3 @@ cpd_product_version: ""
 cpd_iam_integration: false
 cpd_primary_storage_class: ""
 cpd_metadata_storage_class: ""
-ibm_redis_cp_channel: ""
-ibm_redis_cp_install_plan: ""

--- a/instance-applications/120-ibm-wml/templates/02-ibm-wml-cr.yaml
+++ b/instance-applications/120-ibm-wml/templates/02-ibm-wml-cr.yaml
@@ -51,6 +51,40 @@ spec:
               helm repo add ibm-charts https://raw.githubusercontent.com/IBM/charts/master/repo/ibm-helm
               helm repo update
 
+              echo "Installing ibm-redis-cp cluster-scoped chart (CRDs + ClusterRoles)..."
+              helm template ibm-redis-cp-cluster ibm-charts/ibm-redis-cp-cluster-scoped \
+                --version 1.6.11 \
+                --namespace {{ .Values.cpd_operators_namespace }} \
+                --set global.licenseAccept=true \
+                --set global.operatorNamespace={{ .Values.cpd_operators_namespace }} \
+                --set global.instanceNamespace={{ .Values.cpd_instance_namespace }} \
+                --set global.imagePullSecret=ibm-entitlement-key | oc apply -f -
+
+              echo "Installing ibm-redis-cp namespace-scoped chart (operator)..."
+              helm upgrade --install ibm-redis-cp ibm-charts/ibm-redis-cp \
+                --version 1.6.11 \
+                --namespace {{ .Values.cpd_operators_namespace }} \
+                --set global.licenseAccept=true \
+                --set global.operatorNamespace={{ .Values.cpd_operators_namespace }} \
+                --set global.instanceNamespace={{ .Values.cpd_instance_namespace }} \
+                --set global.imagePullSecret=ibm-entitlement-key
+
+              echo "Waiting for redicps.redis.ibm.com CRD to be established..."
+              wait_period=0
+              while true; do
+                wait_period=$((wait_period+10))
+                if [ $wait_period -gt 300 ]; then
+                  echo "Rediscp CRD not established after 5 minutes. Exiting."
+                  exit 1
+                fi
+                STATUS=$(oc get crd redicps.redis.ibm.com -o jsonpath='{.status.conditions[?(@.type=="Established")].status}' --ignore-not-found 2>/dev/null)
+                if [ "$STATUS" = "True" ]; then
+                  echo "Rediscp CRD established."
+                  break
+                fi
+                sleep 10
+              done
+
               echo "Installing wml cluster-scoped chart (CRDs + ClusterRoles)..."
               helm template wml-cluster ibm-charts/wml-cluster-scoped \
                 --version 12.1.0 \

--- a/root-applications/ibm-mas-instance-root/templates/110-ibm-cp4d-app.yaml
+++ b/root-applications/ibm-mas-instance-root/templates/110-ibm-cp4d-app.yaml
@@ -94,8 +94,6 @@ spec:
             opencontent_opensearch_channel: "{{ .Values.ibm_cp4d_services_base.opencontent_opensearch_channel }}"
             elasticsearch_install_plan: "{{ .Values.ibm_cp4d_services_base.elasticsearch_install_plan }}"
             opensearch_install_plan: "{{ .Values.ibm_cp4d_services_base.opensearch_install_plan }}"
-            ibm_redis_cp_channel: "{{ .Values.ibm_cp4d_services_base.ibm_redis_cp_channel }}"
-            ibm_redis_cp_install_plan: "{{ .Values.ibm_cp4d_services_base.ibm_redis_cp_install_plan }}"
             {{- end }}
             {{- if .Values.custom_labels }}
             custom_labels: {{ .Values.custom_labels | toYaml | nindent 14 }}


### PR DESCRIPTION
The IBM Maximo catalog does not contain an ibm-redis-cp OLM package. The previous fix (OLM Subscription) was wrong for this environment.

ibm-redis-cp for CPD 5.3.1 must be installed via Helm, the same way WML itself is installed.

Changes:
- Remove the ibm-redis-cp OLM Subscription added in previous commit (no such package exists in ibm-operator-catalog on this cluster)
- Revert ibm_redis_cp_channel/install_plan values and root app changes
- Add ibm-redis-cp Helm install steps to the existing install-wml-helm job in 02-ibm-wml-cr.yaml, running before WML itself so the Rediscp CRD is established before the WmlBase CR reconcile begins
- Regenerate RBAC rules