### PR TITLE
MASCORE-15507: Keep failed install-wml-helm pod for log inspection

### DIFF
--- a/instance-applications/120-ibm-wml/templates/02-ibm-wml-cr.yaml
+++ b/instance-applications/120-ibm-wml/templates/02-ibm-wml-cr.yaml
@@ -34,8 +34,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "092"
     argocd.argoproj.io/hook: Sync
-
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded,HookFailed
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
 
 spec:
   template:


### PR DESCRIPTION
Temporarily remove HookFailed from delete policy so failed pods stay alive long enough to read their logs and diagnose the ibm-redis-cp Helm chart name issue.