### PR TITLE
MASCORE-15507: Fix ibm-redis-cp Helm chart version to 1.3.1

### DIFF
--- a/instance-applications/120-ibm-wml/templates/02-ibm-wml-cr.yaml
+++ b/instance-applications/120-ibm-wml/templates/02-ibm-wml-cr.yaml
@@ -52,7 +52,7 @@ spec:
 
               echo "Installing ibm-redis-cp cluster-scoped chart (CRDs + ClusterRoles)..."
               helm template ibm-redis-cp-cluster ibm-charts/ibm-redis-cp-cluster-scoped \
-                --version 1.6.11 \
+                --version 1.3.1 \
                 --namespace {{ .Values.cpd_operators_namespace }} \
                 --set global.licenseAccept=true \
                 --set global.operatorNamespace={{ .Values.cpd_operators_namespace }} \
@@ -61,7 +61,7 @@ spec:
 
               echo "Installing ibm-redis-cp namespace-scoped chart (operator)..."
               helm upgrade --install ibm-redis-cp ibm-charts/ibm-redis-cp \
-                --version 1.6.11 \
+                --version 1.3.1 \
                 --namespace {{ .Values.cpd_operators_namespace }} \
                 --set global.licenseAccept=true \
                 --set global.operatorNamespace={{ .Values.cpd_operators_namespace }} \


### PR DESCRIPTION
Version 1.6.11 does not exist in ibm-charts repo.
Available versions are 1.3.1 and 1.4.0.
Using 1.3.1 to match the sub_channel v1.3 defined in olm-utils-cm for CPD 5.3.1.