### PR TITLE
[patch] add kmodels toleration to instana agent pod

### DIFF
--- a/cluster-applications/055-instana-agent-operator/templates/03-InstanaAgent.yaml
+++ b/cluster-applications/055-instana-agent-operator/templates/03-InstanaAgent.yaml
@@ -55,4 +55,3 @@ spec:
           - io.strimzi.operator.user.Main
         processes:
           - stunnel
-      

--- a/cluster-applications/055-instana-agent-operator/templates/03-InstanaAgent.yaml
+++ b/cluster-applications/055-instana-agent-operator/templates/03-InstanaAgent.yaml
@@ -55,3 +55,4 @@ spec:
           - io.strimzi.operator.user.Main
         processes:
           - stunnel
+      

--- a/cluster-applications/055-instana-agent-operator/templates/03-InstanaAgent.yaml
+++ b/cluster-applications/055-instana-agent-operator/templates/03-InstanaAgent.yaml
@@ -31,6 +31,9 @@ spec:
         - effect: NoSchedule
           key: icp4data
           operator: Exists
+        - effect: NoSchedule
+          key: kmodels
+          operator: Exists  
       volumeMounts:
         - name: tmp-volume
           mountPath: /tmp


### PR DESCRIPTION
This PR introduces a toleration on the Instana agent that will allow the agent to be deployed on nodes that have a taint with key kmodels frequently used within our saas environments for nodes with exclusively AI workload.

Resolves MASCORE-16079

---
Worker 1 added with kmodels taint
<img width="1090" height="171" alt="Screenshot 2026-08-11 at 5 23 27 PM" src="https://github.com/user-attachments/assets/3a815776-cd69-465c-9091-71d5aea53963" />

Instana agent pod not installed in worker 1 before the change
<img width="1332" height="99" alt="Screenshot 2026-08-11 at 5 29 33 PM" src="https://github.com/user-attachments/assets/d221e445-448b-46b8-9911-53c15b01bd15" />

Instana agent pod installed in worker 1 after the change
<img width="1385" height="138" alt="Screenshot 2026-08-11 at 5 35 06 PM" src="https://github.com/user-attachments/assets/7d341010-8004-4da4-ac05-10dec593ad7c" />
